### PR TITLE
[plugin] Add error tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A set of plugins to interact with Datadog directly from your builds.
 
 <!-- #toc -->
 -   [Plugins](#plugins)
+    -   [`errorTracking` Error Tracking Plugin](#errortracking-error-tracking-plugin)
     -   [`telemetry` Telemetry Plugin](#telemetry-telemetry-plugin)
 -   [Configuration](#configuration)
     -   [`auth.apiKey`](#authapikey)
@@ -32,6 +33,12 @@ A set of plugins to interact with Datadog directly from your builds.
 ## Plugins
 
 <!-- #list-of-packages -->
+### `errorTracking` Error Tracking Plugin
+
+> This plugin is distributed with Datadog's Build Plugins. (please edit this line)
+
+<kbd>[📝 Full documentation ➡️](./packages/plugins/error-tracking#readme)</kbd>
+
 ### `telemetry` Telemetry Plugin
 
 > Display and send telemetry data as metrics to Datadog.

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -16,6 +16,7 @@ export { helpers } from '@dd/factory';
 export type {
     Options as EsbuildPluginOptions,
     // #types-export-injection-marker
+    ErrorTrackingTypes,
     TelemetryTypes,
     // #types-export-injection-marker
 } from '@dd/factory';

--- a/packages/factory/package.json
+++ b/packages/factory/package.json
@@ -16,6 +16,7 @@
         "./*": "./src/*"
     },
     "dependencies": {
+        "@dd/error-tracking-plugins": "workspace:*",
         "@dd/telemetry-plugins": "workspace:*",
         "unplugin": "1.10.1"
     }

--- a/packages/factory/src/index.ts
+++ b/packages/factory/src/index.ts
@@ -9,6 +9,15 @@ It's mostly filled automatically with new plugins.
 
 import type { GetPluginsOptions, GetPluginsOptionsWithCWD } from '@dd/core/types';
 // #imports-injection-marker
+import type {
+    OptionsWithErrorTrackingEnabled,
+    ErrorTrackingOptions,
+} from '@dd/error-tracking-plugins/types';
+import {
+    helpers as errorTrackingHelpers,
+    getPlugins as getErrorTrackingPlugins,
+    CONFIG_KEY as ERROR_TRACKING_CONFIG_KEY,
+} from '@dd/error-tracking-plugins';
 import type { OptionsWithTelemetryEnabled, TelemetryOptions } from '@dd/telemetry-plugins/types';
 import {
     helpers as telemetryHelpers,
@@ -21,12 +30,14 @@ import type { UnpluginContextMeta, UnpluginInstance, UnpluginOptions } from 'unp
 import { createUnplugin } from 'unplugin';
 
 // #types-export-injection-marker
+export type { types as ErrorTrackingTypes } from '@dd/error-tracking-plugins';
 export type { types as TelemetryTypes } from '@dd/telemetry-plugins';
 // #types-export-injection-marker
 
 export interface Options extends GetPluginsOptions {
     // Each product should have a unique entry.
     // #types-injection-marker
+    [ERROR_TRACKING_CONFIG_KEY]?: ErrorTrackingOptions;
     [TELEMETRY_CONFIG_KEY]?: TelemetryOptions;
     // #types-injection-marker
 }
@@ -37,6 +48,7 @@ interface OptionsWithCWD extends Options, GetPluginsOptionsWithCWD {}
 export const helpers = {
     // Each product should have a unique entry.
     // #helpers-injection-marker
+    [ERROR_TRACKING_CONFIG_KEY]: errorTrackingHelpers,
     [TELEMETRY_CONFIG_KEY]: telemetryHelpers,
     // #helpers-injection-marker
 };
@@ -53,6 +65,12 @@ export const buildPluginFactory = (): UnpluginInstance<Options, true> => {
 
         // Based on configuration add corresponding plugin.
         // #configs-injection-marker
+        if (
+            options[ERROR_TRACKING_CONFIG_KEY] &&
+            options[ERROR_TRACKING_CONFIG_KEY].disabled !== true
+        ) {
+            plugins.push(...getErrorTrackingPlugins(options as OptionsWithErrorTrackingEnabled));
+        }
         if (options[TELEMETRY_CONFIG_KEY] && options[TELEMETRY_CONFIG_KEY].disabled !== true) {
             plugins.push(...getTelemetryPlugins(options as OptionsWithTelemetryEnabled));
         }

--- a/packages/plugins/error-tracking/README.md
+++ b/packages/plugins/error-tracking/README.md
@@ -1,0 +1,21 @@
+# Error Tracking Plugin <!-- #omit in toc -->
+
+This plugin is distributed with Datadog's Build Plugins. (please edit this line)
+
+<!-- The title and the following line will both be added to the root README.md  -->
+
+## Table of content <!-- #omit in toc -->
+
+<!-- This is auto generated with yarn cli integrity -->
+
+<!-- #toc -->
+-   [Configuration](#configuration)
+<!-- #toc -->
+
+## Configuration
+
+```ts
+errorTracking: {
+    disabled?: boolean;
+}
+```

--- a/packages/plugins/error-tracking/package.json
+++ b/packages/plugins/error-tracking/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@dd/error-tracking-plugins",
+    "packageManager": "yarn@4.0.2",
+    "license": "MIT",
+    "private": true,
+    "author": "Datadog",
+    "description": "Error Tracking plugin distributed with Datadog's Build Plugins.",
+    "homepage": "https://github.com/DataDog/build-plugin/tree/main/packages/plugins/error-tracking#readme",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DataDog/build-plugin",
+        "directory": "packages/plugins/error-tracking"
+    },
+    "exports": {
+        ".": "./src/index.ts",
+        "./*": "./src/*.ts"
+    },
+    "scripts": {
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@dd/core": "workspace:*",
+        "unplugin": "1.10.1"
+    }
+}

--- a/packages/plugins/error-tracking/src/constants.ts
+++ b/packages/plugins/error-tracking/src/constants.ts
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+export const CONFIG_KEY = 'errorTracking' as const;
+export const PLUGIN_NAME = 'datadog-error-tracking-plugin' as const;

--- a/packages/plugins/error-tracking/src/index.ts
+++ b/packages/plugins/error-tracking/src/index.ts
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { GetPlugins } from '@dd/core/types';
+
+import { PLUGIN_NAME } from './constants';
+import type { OptionsWithErrorTrackingEnabled, ErrorTrackingOptions } from './types';
+
+export { CONFIG_KEY, PLUGIN_NAME } from './constants';
+
+export const helpers = {
+    // Add the helpers you'd like to expose here.
+};
+
+export type types = {
+    // Add the types you'd like to expose here.
+    ErrorTrackingOptions: ErrorTrackingOptions;
+    OptionsWithErrorTrackingEnabled: OptionsWithErrorTrackingEnabled;
+};
+
+export const getPlugins: GetPlugins<OptionsWithErrorTrackingEnabled> = (
+    opt: OptionsWithErrorTrackingEnabled,
+) => {
+    return [
+        {
+            name: PLUGIN_NAME,
+        },
+    ];
+};

--- a/packages/plugins/error-tracking/src/types.ts
+++ b/packages/plugins/error-tracking/src/types.ts
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { GetPluginsOptionsWithCWD } from '@dd/core/types';
+
+import type { CONFIG_KEY } from './constants';
+
+export type ErrorTrackingOptions = {
+    disabled?: boolean;
+};
+
+export interface ErrorTrackingOptionsEnabled extends ErrorTrackingOptions {
+    disabled?: false;
+}
+
+export interface OptionsWithErrorTrackingEnabled extends GetPluginsOptionsWithCWD {
+    [CONFIG_KEY]: ErrorTrackingOptionsEnabled;
+}

--- a/packages/plugins/error-tracking/tsconfig.json
+++ b/packages/plugins/error-tracking/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": "./",
+        "rootDir": "./",
+        "outDir": "./dist"
+    },
+    "include": ["**/*"],
+    "exclude": ["dist", "node_modules"]
+}

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -16,6 +16,7 @@ export { helpers } from '@dd/factory';
 export type {
     Options as WebpackPluginOptions,
     // #types-export-injection-marker
+    ErrorTrackingTypes,
     TelemetryTypes,
     // #types-export-injection-marker
 } from '@dd/factory';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1748,10 +1748,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@dd/error-tracking-plugins@workspace:*, @dd/error-tracking-plugins@workspace:packages/plugins/error-tracking":
+  version: 0.0.0-use.local
+  resolution: "@dd/error-tracking-plugins@workspace:packages/plugins/error-tracking"
+  dependencies:
+    "@dd/core": "workspace:*"
+    unplugin: "npm:1.10.1"
+  languageName: unknown
+  linkType: soft
+
 "@dd/factory@workspace:*, @dd/factory@workspace:packages/factory":
   version: 0.0.0-use.local
   resolution: "@dd/factory@workspace:packages/factory"
   dependencies:
+    "@dd/error-tracking-plugins": "workspace:*"
     "@dd/telemetry-plugins": "workspace:*"
     unplugin: "npm:1.10.1"
   languageName: unknown


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Adding the new `error-tracking` plugin.

### How?

<!-- A brief description of implementation details of this PR. -->

Run `yarn cli create-plugin` and implement first feature, sourcemaps upload.
