### PR TITLE
[core] More global contexts

### DIFF
--- a/packages/core/src/plugins/global-context/index.ts
+++ b/packages/core/src/plugins/global-context/index.ts
@@ -53,41 +53,10 @@ export const getGlobalContextPlugin = (opts: Options, meta: Meta) => {
                 globalContext.outputDir = compiler.options.output.path;
             }
 
-            compiler.hooks.done.tap(PLUGIN_NAME, (stats) => {
-                const statsJson = stats.toJson();
-                const { outputPath = '', entrypoints } = statsJson;
+            compiler.hooks.emit.tap(PLUGIN_NAME, (compilation) => {
                 const files: File[] = [];
-
-                globalContext.outputDir = outputPath;
-
-                if (!entrypoints) {
-                    log('Missing entrypoints in stats.', 'warn');
-                    return;
-                }
-
-                const getFile = (asset: { name: string } | string) => {
-                    if (typeof asset === 'string') {
-                        return {
-                            filepath: path.join(outputPath, asset),
-                        };
-                    } else {
-                        return {
-                            filepath: path.join(outputPath, asset.name),
-                        };
-                    }
-                };
-
-                for (const [, entry] of Object.entries(entrypoints)) {
-                    if (!entry) {
-                        continue;
-                    }
-
-                    if (entry.assets) {
-                        files.push(...entry.assets.map(getFile));
-                    }
-                    if (entry.auxiliaryAssets) {
-                        files.push(...entry.auxiliaryAssets.map(getFile));
-                    }
+                for (const filename of Object.keys(compilation.assets)) {
+                    files.push({ filepath: path.join(globalContext.outputDir, filename) });
                 }
                 globalContext.outputFiles = files;
             });

--- a/packages/core/src/plugins/global-context/index.ts
+++ b/packages/core/src/plugins/global-context/index.ts
@@ -56,24 +56,28 @@ export const getGlobalContextPlugin = (opts: Options, meta: Meta) => {
                     return;
                 }
 
+                const getFile = (asset: { name: string } | string) => {
+                    if (typeof asset === 'string') {
+                        return {
+                            filepath: path.join(outputPath, asset),
+                        };
+                    } else {
+                        return {
+                            filepath: path.join(outputPath, asset.name),
+                        };
+                    }
+                };
+
                 for (const [, entry] of Object.entries(entrypoints)) {
                     if (!entry) {
                         continue;
                     }
 
                     if (entry.assets) {
-                        files.push(
-                            ...entry.assets.map((asset) => ({
-                                filepath: path.join(outputPath, asset.name),
-                            })),
-                        );
+                        files.push(...entry.assets.map(getFile));
                     }
                     if (entry.auxiliaryAssets) {
-                        files.push(
-                            ...entry.auxiliaryAssets.map((asset) => ({
-                                filepath: path.join(outputPath, asset.name),
-                            })),
-                        );
+                        files.push(...entry.auxiliaryAssets.map(getFile));
                     }
                 }
                 globalContext.outputFiles = files;

--- a/packages/core/src/plugins/global-context/index.ts
+++ b/packages/core/src/plugins/global-context/index.ts
@@ -2,11 +2,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { getLogger } from '@dd/core/log';
+import type { File, GlobalContext, Meta, Options } from '@dd/core/types';
+import path from 'path';
 import type { UnpluginOptions } from 'unplugin';
 
-import type { GlobalContext, Meta, Options } from '../../types';
+const PLUGIN_NAME = 'global-context-plugin';
 
 export const getGlobalContextPlugin = (opts: Options, meta: Meta) => {
+    const log = getLogger(opts.logLevel, 'internal-global-context');
     const globalContext: GlobalContext = {
         auth: opts.auth,
         cwd: process.cwd(),
@@ -17,15 +21,63 @@ export const getGlobalContextPlugin = (opts: Options, meta: Meta) => {
     };
 
     const globalContextPlugin: UnpluginOptions = {
-        name: 'global-context-plugin',
+        name: PLUGIN_NAME,
         enforce: 'pre',
         esbuild: {
             setup(build) {
                 globalContext.bundler.config = build.initialOptions;
+                // We force esbuild to produce its metafile.
+                build.initialOptions.metafile = true;
+                build.onEnd((result) => {
+                    if (!result.metafile) {
+                        log('Missing metafile from build result.', 'warn');
+                        return;
+                    }
+
+                    const files: File[] = [];
+                    for (const [output] of Object.entries(result.metafile.outputs)) {
+                        files.push({ filepath: path.join(globalContext.cwd, output) });
+                    }
+
+                    globalContext.outputFiles = files;
+                });
             },
         },
         webpack(compiler) {
             globalContext.bundler.config = compiler.options;
+            compiler.hooks.done.tap(PLUGIN_NAME, (stats) => {
+                const statsJson = stats.toJson();
+                // TODO: outputPath should fallback to what's been aggregated from the config.
+                const { outputPath = '', entrypoints } = statsJson;
+                const files: File[] = [];
+
+                if (!entrypoints) {
+                    log('Missing entrypoints in stats.', 'warn');
+                    return;
+                }
+
+                for (const [, entry] of Object.entries(entrypoints)) {
+                    if (!entry) {
+                        continue;
+                    }
+
+                    if (entry.assets) {
+                        files.push(
+                            ...entry.assets.map((asset) => ({
+                                filepath: path.join(outputPath, asset.name),
+                            })),
+                        );
+                    }
+                    if (entry.auxiliaryAssets) {
+                        files.push(
+                            ...entry.auxiliaryAssets.map((asset) => ({
+                                filepath: path.join(outputPath, asset.name),
+                            })),
+                        );
+                    }
+                }
+                globalContext.outputFiles = files;
+            });
         },
         vite: {
             options(options: any) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -23,11 +23,14 @@ export interface RepositoryData {
     trackedFilesMatcher: TrackedFilesMatcher;
 }
 
+export type File = { filepath: string };
+
 export type GlobalContext = {
     auth?: AuthOptions;
     cwd: string;
     version: string;
     git?: RepositoryData;
+    outputFiles?: File[];
     bundler: {
         name: string;
         config?: any;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,6 +31,7 @@ export type GlobalContext = {
     version: string;
     git?: RepositoryData;
     outputFiles?: File[];
+    outputDir: string;
     bundler: {
         name: string;
         config?: any;

--- a/packages/plugins/rum/src/types.ts
+++ b/packages/plugins/rum/src/types.ts
@@ -6,7 +6,7 @@ import type { GetPluginsOptions } from '@dd/core/types';
 
 import type { CONFIG_KEY } from './constants';
 
-export type MinifiedPathPrefix = `http://${string}` | `/${string}`;
+export type MinifiedPathPrefix = `http://${string}` | `https://${string}` | `/${string}`;
 
 export type RumSourcemapsOptions = {
     // TODO: Compute this basePath directly from the bundler's configuration, using the CrossHelper Plugin.

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -21,7 +21,7 @@
         "build": "yarn clean && tsc",
         "clean": "rm -rf dist",
         "typecheck": "tsc --noEmit",
-        "test": "NODE_OPTIONS=\"--openssl-legacy-provider ${NODE_OPTIONS:-}\" jest --verbose"
+        "test": "NODE_OPTIONS=\"--openssl-legacy-provider ${NODE_OPTIONS:-}\" jest --verbose --silent"
     },
     "dependencies": {
         "@datadog/esbuild-plugin": "workspace:*",

--- a/packages/tests/src/core/plugins/global-context/index.test.ts
+++ b/packages/tests/src/core/plugins/global-context/index.test.ts
@@ -6,7 +6,7 @@ import type { GlobalContext, Options } from '@dd/core/types';
 import { uploadSourcemaps } from '@dd/rum-plugins/sourcemaps/index';
 import { getPlugins } from '@dd/telemetry-plugins';
 import { BUNDLERS, defaultDestination, defaultPluginOptions } from '@dd/tests/helpers/mocks';
-import { runBundlers, runWebpack } from '@dd/tests/helpers/runBundlers';
+import { runBundlers } from '@dd/tests/helpers/runBundlers';
 import { rmSync } from 'fs';
 
 jest.mock('@dd/telemetry-plugins', () => {
@@ -88,11 +88,11 @@ describe('Global Context Plugin', () => {
             },
         };
 
-        await runWebpack(pluginConfig);
+        await runBundlers(pluginConfig);
 
         // This will fail when we add new bundlers to support.
         // It is intended so we keep an eye on it whenever we add a new bundler.
-        expect(contextResults).toHaveLength(1);
+        expect(contextResults).toHaveLength(3);
         for (const context of contextResults) {
             expect(context.outputFiles).toBeDefined();
             expect(context.outputFiles).toHaveLength(2);

--- a/packages/tests/src/core/plugins/global-context/index.test.ts
+++ b/packages/tests/src/core/plugins/global-context/index.test.ts
@@ -53,6 +53,7 @@ describe('Global Context Plugin', () => {
                     config: expect.any(Object),
                 },
                 cwd: expect.any(String),
+                outputDir: expect.any(String),
                 outputFiles: expect.any(Array),
                 version: expect.any(String),
             });

--- a/packages/tests/src/core/plugins/global-context/index.test.ts
+++ b/packages/tests/src/core/plugins/global-context/index.test.ts
@@ -5,7 +5,7 @@
 import type { Options } from '@dd/core/types';
 import { uploadSourcemaps } from '@dd/rum-plugins/sourcemaps/index';
 import { getPlugins } from '@dd/telemetry-plugins';
-import { defaultDestination, defaultPluginOptions } from '@dd/tests/helpers/mocks';
+import { BUNDLERS, defaultDestination, defaultPluginOptions } from '@dd/tests/helpers/mocks';
 import { runBundlers } from '@dd/tests/helpers/runBundlers';
 import { rmSync } from 'fs';
 
@@ -76,18 +76,20 @@ describe('Global Context Plugin', () => {
 
         // This will fail when we add new bundlers to support.
         // It is intended so we keep an eye on it whenever we add a new bundler.
-        expect(uploadSourcemapsMocked).toHaveBeenCalledTimes(2);
+        expect(uploadSourcemapsMocked).toHaveBeenCalledTimes(BUNDLERS.length);
         for (const call of uploadSourcemapsMocked.mock.calls) {
             expect(call[1]).toMatchObject({
                 outputFiles: expect.arrayContaining([
                     {
                         filepath: expect.stringMatching(
-                            new RegExp(`^${defaultDestination}/(esbuild|webpack)/main.js$`),
+                            new RegExp(`^${defaultDestination}/(${BUNDLERS.join('|')})/main.js$`),
                         ),
                     },
                     {
                         filepath: expect.stringMatching(
-                            new RegExp(`^${defaultDestination}/(esbuild|webpack)/main.js.map$`),
+                            new RegExp(
+                                `^${defaultDestination}/(${BUNDLERS.join('|')})/main.js.map$`,
+                            ),
                         ),
                     },
                 ]),

--- a/packages/tests/src/helpers/configBundlers.ts
+++ b/packages/tests/src/helpers/configBundlers.ts
@@ -23,6 +23,7 @@ export const getWebpackOptions = (
 
     return {
         entry: defaultEntry,
+        mode: 'production',
         output: {
             path: path.join(defaultDestination, 'webpack'),
             filename: `[name].js`,
@@ -71,7 +72,7 @@ export const getEsbuildOptions = (
         entryPoints: [defaultEntry],
         outfile: bundlerOptions.outdir
             ? undefined
-            : path.join(defaultDestination, 'esbuild', 'index.js'),
+            : path.join(defaultDestination, 'esbuild', 'main.js'),
         plugins: [datadogEsbuildPlugin(newPluginOptions)],
         ...bundlerOptions,
     };

--- a/packages/tests/src/helpers/configBundlers.ts
+++ b/packages/tests/src/helpers/configBundlers.ts
@@ -46,7 +46,8 @@ export const getWebpack4Options = (
     const plugin = datadogWebpackPlugin(newPluginOptions) as unknown;
 
     return {
-        entry: defaultEntry,
+        // Somehow webpack4 doesn't find @dd/tests/fixtures/index.js
+        entry: './src/fixtures/index.js',
         output: {
             path: path.join(defaultDestination, 'webpack'),
             filename: `[name].js`,

--- a/packages/tests/src/helpers/mocks.ts
+++ b/packages/tests/src/helpers/mocks.ts
@@ -7,6 +7,7 @@ import { ROOT } from '@dd/tools/constants';
 import path from 'path';
 
 export const PROJECT_ROOT = path.join(ROOT, 'packages/tests/src/fixtures/project');
+export const BUNDLERS = ['webpack', 'webpack4', 'esbuild'];
 
 export const defaultEntry = '@dd/tests/fixtures/index.js';
 export const defaultDestination = path.resolve(PROJECT_ROOT, '../dist');

--- a/packages/tests/src/helpers/mocks.ts
+++ b/packages/tests/src/helpers/mocks.ts
@@ -23,6 +23,7 @@ export const getContextMock = (options: Partial<GlobalContext> = {}): GlobalCont
     return {
         auth: { apiKey: '123' },
         cwd: '/cwd/path',
+        outputDir: '/cwd/path',
         version: '1.2.3',
         bundler: { name: 'esbuild' },
         ...options,

--- a/packages/tests/src/helpers/mocks.ts
+++ b/packages/tests/src/helpers/mocks.ts
@@ -3,10 +3,13 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import type { GlobalContext, Options } from '@dd/core/types';
+import { ROOT } from '@dd/tools/constants';
 import path from 'path';
 
+export const PROJECT_ROOT = path.join(ROOT, 'packages/tests/src/fixtures/project');
+
 export const defaultEntry = '@dd/tests/fixtures/index.js';
-export const defaultDestination = path.resolve(__dirname, '../fixtures/dist');
+export const defaultDestination = path.resolve(PROJECT_ROOT, '../dist');
 
 export const defaultPluginOptions: Options = {
     auth: {

--- a/packages/tests/src/helpers/runBundlers.ts
+++ b/packages/tests/src/helpers/runBundlers.ts
@@ -54,6 +54,7 @@ export const runBundlers = async (pluginOptions: Options = {}) => {
     const promises = [];
 
     promises.push(runWebpack(pluginOptions));
+    promises.push(runWebpack4(pluginOptions));
     promises.push(runEsbuild(pluginOptions));
 
     const results = await Promise.all(promises);

--- a/packages/tests/src/plugins/telemetry/common/metrics/esbuild.test.ts
+++ b/packages/tests/src/plugins/telemetry/common/metrics/esbuild.test.ts
@@ -10,8 +10,9 @@ import {
     getAssets,
 } from '@dd/telemetry-plugins/common/metrics/esbuild';
 import type { Metric, EsbuildStats } from '@dd/telemetry-plugins/types';
+import { PROJECT_ROOT } from '@dd/tests/helpers/mocks';
 import { runEsbuild } from '@dd/tests/helpers/runBundlers';
-import { PROJECT_ROOT, prefixPath } from '@dd/tests/plugins/telemetry/testHelpers';
+import { prefixPath } from '@dd/tests/plugins/telemetry/testHelpers';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/tests/src/plugins/telemetry/common/metrics/webpack.test.ts
+++ b/packages/tests/src/plugins/telemetry/common/metrics/webpack.test.ts
@@ -11,8 +11,8 @@ import {
     getAssets,
 } from '@dd/telemetry-plugins/common/metrics/webpack';
 import type { StatsJson, Metric } from '@dd/telemetry-plugins/types';
+import { PROJECT_ROOT } from '@dd/tests/helpers/mocks';
 import { runWebpack, runWebpack4 } from '@dd/tests/helpers/runBundlers';
-import { PROJECT_ROOT } from '@dd/tests/plugins/telemetry/testHelpers';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/tests/src/plugins/telemetry/common/metrics/webpack.test.ts
+++ b/packages/tests/src/plugins/telemetry/common/metrics/webpack.test.ts
@@ -24,7 +24,7 @@ describe('Telemetry Webpack Metrics', () => {
 
             afterAll(async () => {
                 // Clean
-                fs.rmdirSync(OUTPUT, { recursive: true });
+                fs.rmSync(OUTPUT, { force: true, recursive: true });
             });
 
             beforeAll(async () => {

--- a/packages/tests/src/plugins/telemetry/testHelpers.ts
+++ b/packages/tests/src/plugins/telemetry/testHelpers.ts
@@ -16,13 +16,9 @@ import type {
     TelemetryOptions,
     Module,
 } from '@dd/telemetry-plugins/types';
-import { ROOT } from '@dd/tools/constants.ts';
 import type { PluginBuild, Metafile } from 'esbuild';
 import esbuild from 'esbuild';
 import path from 'path';
-
-export const PROJECT_ROOT = path.join(ROOT, 'packages/tests/src/fixtures/project');
-export const exec = require('util').promisify(require('child_process').exec);
 
 // Have a path prefixed with the cwd.
 export const prefixPath = (modulePath: string) => {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -12,6 +12,7 @@
     },
     "packageManager": "yarn@4.0.2",
     "exports": {
+        "./rollupConfig.mjs": "./src/rollupConfig.mjs",
         "./*": "./src/*.ts"
     },
     "scripts": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -12,7 +12,7 @@
     },
     "packageManager": "yarn@4.0.2",
     "exports": {
-        "./*": "./src/*"
+        "./*": "./src/*.ts"
     },
     "scripts": {
         "cli": "ts-node -T --project ./tsconfig.json ./src/index.ts"


### PR DESCRIPTION
Stacked on https://github.com/DataDog/build-plugins/pull/85

### What and why?

<!-- A short description of what changes this PR introduces and why. -->

We need a way to communicate the list of files produced at the end of the build.

### How?

<!-- A brief description of implementation details of this PR. -->

We're using the global context plugin to gather the list from webpack and esbuild (since they are the only two bundles we support right now).
And add it to the global context.
