### PR TITLE
[rum] Use context for sourcemaps instead of `basePath`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ A set of plugins to interact with Datadog directly from your builds.
     rum?: {
         disabled?: boolean;
         sourcemaps?: {
-            basePath: string;
             dryRun?: boolean;
             intakeUrl?: string;
             maxConcurrency?: number;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "oss": "yarn cli oss -d packages -l mit",
         "publish:all": "yarn loop --no-private npm publish",
         "test": "yarn workspace @dd/tests test",
+        "test:noisy": "yarn workspace @dd/tests test:noisy",
         "typecheck:all": "yarn workspaces foreach -Apti run typecheck",
         "version:all": "yarn loop version --deferred ${0} && yarn version apply --all",
         "watch:all": "yarn loop run watch"

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
         "cli": "yarn workspace @dd/tools cli",
         "format": "yarn lint --fix",
         "lint": "eslint ./packages/**/*.{ts,js} --quiet",
+        "loop": "yarn workspaces foreach -Apti --include \"@datadog/*\" --exclude \"@datadog/build-plugins\"",
         "oss": "yarn cli oss -d packages -l mit",
-        "publish:all": "yarn workspaces foreach -A --include \"@datadog/*\" --exclude \"@datadog/build-plugins\" --no-private npm publish",
+        "publish:all": "yarn loop --no-private npm publish",
         "test": "yarn workspace @dd/tests test",
         "typecheck:all": "yarn workspaces foreach -Apti run typecheck",
-        "version:all": "yarn workspaces foreach -Apti --include \"@datadog/*\" --exclude \"@datadog/build-plugins\" version --deferred ${0} && yarn version apply --all",
-        "watch:all": "yarn workspaces foreach -Apti run watch"
+        "version:all": "yarn loop version --deferred ${0} && yarn version apply --all",
+        "watch:all": "yarn loop run watch"
     },
     "husky": {
         "hooks": {

--- a/packages/plugins/rum/README.md
+++ b/packages/plugins/rum/README.md
@@ -18,7 +18,6 @@ Interact with our Real User Monitoring product (RUM) in Datadog directly from yo
 rum?: {
     disabled?: boolean;
     sourcemaps?: {
-        basePath: string;
         dryRun?: boolean;
         intakeUrl?: string;
         maxConcurrency?: number;

--- a/packages/plugins/rum/package.json
+++ b/packages/plugins/rum/package.json
@@ -23,7 +23,6 @@
         "@dd/core": "workspace:*",
         "async-retry": "1.3.3",
         "chalk": "2.3.1",
-        "glob": "7.1.6",
         "outdent": "0.8.0",
         "p-queue": "6.6.2",
         "unplugin": "patch:unplugin@npm%3A1.10.1#~/.yarn/patches/unplugin-npm-1.10.1-b23391b255.patch"

--- a/packages/plugins/rum/src/sourcemaps/index.ts
+++ b/packages/plugins/rum/src/sourcemaps/index.ts
@@ -24,7 +24,8 @@ export const uploadSourcemaps = async (
         .join('\n');
 
     // Gather the sourcemaps files.
-    const sourcemaps = getSourcemapsFiles(options.sourcemaps);
+    // console.log(context.outputFiles?.filter((file) => file.filepath.endsWith('.map')));
+    const sourcemaps = getSourcemapsFiles(options.sourcemaps, context);
 
     const summary = outdent`
     Uploading ${green(sourcemaps.length.toString())} sourcemaps with configuration:

--- a/packages/plugins/rum/src/sourcemaps/index.ts
+++ b/packages/plugins/rum/src/sourcemaps/index.ts
@@ -24,7 +24,6 @@ export const uploadSourcemaps = async (
         .join('\n');
 
     // Gather the sourcemaps files.
-    // console.log(context.outputFiles?.filter((file) => file.filepath.endsWith('.map')));
     const sourcemaps = getSourcemapsFiles(options.sourcemaps, context);
 
     const summary = outdent`

--- a/packages/plugins/rum/src/sourcemaps/sender.ts
+++ b/packages/plugins/rum/src/sourcemaps/sender.ts
@@ -151,8 +151,14 @@ export const upload = async (
 
     for (const payload of payloads) {
         const metadata = {
-            sourcemap: (payload.content.get('source_map') as MultipartFileValue)?.path,
-            file: (payload.content.get('minified_file') as MultipartFileValue)?.path,
+            sourcemap: (payload.content.get('source_map') as MultipartFileValue)?.path.replace(
+                context.outputDir,
+                '.',
+            ),
+            file: (payload.content.get('minified_file') as MultipartFileValue)?.path.replace(
+                context.outputDir,
+                '.',
+            ),
         };
 
         log(`Queuing ${green(metadata.sourcemap)} | ${green(metadata.file)}`);

--- a/packages/plugins/rum/src/sourcemaps/sender.ts
+++ b/packages/plugins/rum/src/sourcemaps/sender.ts
@@ -188,7 +188,7 @@ export const sendSourcemaps = async (
         git_repository_url: context.git?.remote,
         git_commit_sha: context.git?.hash,
         plugin_version: context.version,
-        project_path: options.basePath,
+        project_path: context.outputDir,
         service: options.service,
         type: 'js_sourcemap',
         version: options.releaseVersion,

--- a/packages/plugins/rum/src/types.ts
+++ b/packages/plugins/rum/src/types.ts
@@ -9,8 +9,6 @@ import type { CONFIG_KEY } from './constants';
 export type MinifiedPathPrefix = `http://${string}` | `https://${string}` | `/${string}`;
 
 export type RumSourcemapsOptions = {
-    // TODO: Compute this basePath directly from the bundler's configuration, using the CrossHelper Plugin.
-    basePath: string;
     dryRun?: boolean;
     intakeUrl?: string;
     maxConcurrency?: number;

--- a/packages/plugins/rum/src/validate.ts
+++ b/packages/plugins/rum/src/validate.ts
@@ -73,9 +73,6 @@ export const validateSourcemapsOptions = (
 
     if (validatedOptions.sourcemaps) {
         // Validate the configuration.
-        if (!validatedOptions.sourcemaps.basePath) {
-            toReturn.errors.push(`${red('sourcemaps.basePath')} is required.`);
-        }
         if (!validatedOptions.sourcemaps.releaseVersion) {
             toReturn.errors.push(`${red('sourcemaps.releaseVersion')} is required.`);
         }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -21,7 +21,8 @@
         "build": "yarn clean && tsc",
         "clean": "rm -rf dist",
         "typecheck": "tsc --noEmit",
-        "test": "NODE_OPTIONS=\"--openssl-legacy-provider ${NODE_OPTIONS:-}\" jest --verbose --silent"
+        "test": "yarn test:noisy --silent",
+        "test:noisy": "NODE_OPTIONS=\"--openssl-legacy-provider ${NODE_OPTIONS:-}\" jest --verbose"
     },
     "dependencies": {
         "@datadog/esbuild-plugin": "workspace:*",

--- a/packages/tests/src/core/plugins/git/index.test.ts
+++ b/packages/tests/src/core/plugins/git/index.test.ts
@@ -3,7 +3,8 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { getRepositoryData } from '@dd/core/plugins/git/helpers';
-import { getPlugins } from '@dd/telemetry-plugins';
+import { getPlugins as getRumPlugins } from '@dd/rum-plugins';
+import { getPlugins as getTelemetryPlugins } from '@dd/telemetry-plugins';
 import { defaultPluginOptions } from '@dd/tests/helpers/mocks';
 import { runBundlers } from '@dd/tests/helpers/runBundlers';
 import { API_PATH, FAKE_URL, getSourcemapsConfiguration } from '@dd/tests/plugins/rum/testHelpers';
@@ -17,10 +18,13 @@ jest.mock('@dd/telemetry-plugins', () => {
     };
 });
 
-const getPluginsMocked = jest.mocked(getPlugins);
-const mockGitData = {
-    data: 'data',
-};
+jest.mock('@dd/rum-plugins', () => {
+    const originalModule = jest.requireActual('@dd/rum-plugins');
+    return {
+        ...originalModule,
+        getPlugins: jest.fn(() => []),
+    };
+});
 
 jest.mock('@dd/core/plugins/git/helpers', () => {
     const originalModule = jest.requireActual('@dd/core/plugins/git/helpers');
@@ -30,6 +34,12 @@ jest.mock('@dd/core/plugins/git/helpers', () => {
     };
 });
 
+const getTelemetryPluginsMocked = jest.mocked(getTelemetryPlugins);
+const getRumPluginsMocked = jest.mocked(getRumPlugins);
+const mockGitData = {
+    data: 'data',
+};
+
 const getRepositoryDataMocked = jest.mocked(getRepositoryData);
 
 describe('Git Plugin', () => {
@@ -37,9 +47,11 @@ describe('Git Plugin', () => {
         // Mock requests.
         nock(FAKE_URL).post(API_PATH).reply(200, {}).persist();
     });
+
     afterAll(() => {
         nock.cleanAll();
     });
+
     describe('It should run', () => {
         test('by default with sourcemaps.', async () => {
             const pluginConfig = {
@@ -48,8 +60,12 @@ describe('Git Plugin', () => {
                     sourcemaps: getSourcemapsConfiguration(),
                 },
             };
-            const results = await runBundlers(pluginConfig);
-            expect(getRepositoryDataMocked).toHaveBeenCalledTimes(results.length);
+
+            await runBundlers(pluginConfig);
+
+            // This will fail when we add new bundlers to support.
+            // It is intended so we keep an eye on it whenever we add a new bundler.
+            expect(getRepositoryDataMocked).toHaveBeenCalledTimes(3);
         });
 
         test('and add the relevant data to the context.', async () => {
@@ -64,13 +80,16 @@ describe('Git Plugin', () => {
             await runBundlers(pluginConfig);
 
             // Confirm every call gets the git data in the context.
-            for (const call of getPluginsMocked.mock.calls) {
-                expect(call[1]).toMatchObject({
-                    git: mockGitData,
-                });
+            for (const mock of [getTelemetryPluginsMocked.mock, getRumPluginsMocked.mock]) {
+                for (const call of mock.calls) {
+                    expect(call[1]).toMatchObject({
+                        git: mockGitData,
+                    });
+                }
             }
         });
     });
+
     describe('It should not run', () => {
         test('by default without sourcemaps.', async () => {
             const pluginConfig = {

--- a/packages/tests/src/core/plugins/global-context/index.test.ts
+++ b/packages/tests/src/core/plugins/global-context/index.test.ts
@@ -80,7 +80,6 @@ describe('Global Context Plugin', () => {
             ...defaultPluginOptions,
             rum: {
                 sourcemaps: {
-                    basePath: 'base-path',
                     minifiedPathPrefix: 'http://path',
                     releaseVersion: '1.0.0',
                     service: 'service',

--- a/packages/tests/src/core/plugins/global-context/index.test.ts
+++ b/packages/tests/src/core/plugins/global-context/index.test.ts
@@ -7,7 +7,6 @@ import { uploadSourcemaps } from '@dd/rum-plugins/sourcemaps/index';
 import { getPlugins } from '@dd/telemetry-plugins';
 import { BUNDLERS, defaultDestination, defaultPluginOptions } from '@dd/tests/helpers/mocks';
 import { runBundlers } from '@dd/tests/helpers/runBundlers';
-import { rmSync } from 'fs';
 
 jest.mock('@dd/telemetry-plugins', () => {
     const originalModule = jest.requireActual('@dd/telemetry-plugins');
@@ -29,10 +28,6 @@ const getPluginsMocked = jest.mocked(getPlugins);
 const uploadSourcemapsMocked = jest.mocked(uploadSourcemaps);
 
 describe('Global Context Plugin', () => {
-    beforeEach(() => {
-        rmSync(defaultDestination, { recursive: true, force: true });
-    });
-
     test('It should inject context in the other plugins.', async () => {
         // Intercept context to verify it at the moment it's sent.
         const contextResults: GlobalContext[] = [];

--- a/packages/tests/src/factory/index.test.ts
+++ b/packages/tests/src/factory/index.test.ts
@@ -20,6 +20,7 @@ describe('Factory', () => {
         await runBundlers({ telemetry: { disabled: true } });
         expect(getPluginsMocked).not.toHaveBeenCalled();
     });
+
     test('It should call an enabled plugin', async () => {
         const results = await runBundlers({ telemetry: { disabled: false } });
         expect(getPluginsMocked).toHaveBeenCalledTimes(results.length);

--- a/packages/tests/src/helpers/runBundlers.ts
+++ b/packages/tests/src/helpers/runBundlers.ts
@@ -22,7 +22,7 @@ export const runWebpack = async (
     return new Promise((resolve) => {
         webpack(bundlerConfigs, (err, stats) => {
             if (err) {
-                console.log(err);
+                console.error(err);
             }
             resolve(stats);
         });

--- a/packages/tests/src/helpers/runBundlers.ts
+++ b/packages/tests/src/helpers/runBundlers.ts
@@ -5,12 +5,14 @@
 import type { Options } from '@dd/core/types';
 import type { BuildOptions } from 'esbuild';
 import esbuild from 'esbuild';
+import { rmSync } from 'fs';
 import type { Configuration as Configuration4 } from 'webpack4';
 import webpack4 from 'webpack4';
 import type { Configuration } from 'webpack';
 import webpack from 'webpack';
 
 import { getEsbuildOptions, getWebpack4Options, getWebpackOptions } from './configBundlers';
+import { defaultDestination } from './mocks';
 
 export const runWebpack = async (
     pluginOptions: Options = {},
@@ -52,6 +54,8 @@ export const runEsbuild = async (
 
 export const runBundlers = async (pluginOptions: Options = {}) => {
     const promises = [];
+
+    rmSync(defaultDestination, { recursive: true, force: true });
 
     promises.push(runWebpack(pluginOptions));
     promises.push(runWebpack4(pluginOptions));

--- a/packages/tests/src/helpers/runBundlers.ts
+++ b/packages/tests/src/helpers/runBundlers.ts
@@ -39,7 +39,13 @@ export const runWebpack4 = async (
             if (err) {
                 console.log(err);
             }
-            resolve(stats);
+
+            // Webpack is somehow not exiting gracefully.
+            setTimeout(() => {
+                process.nextTick(() => {
+                    resolve(stats);
+                });
+            }, 600);
         });
     });
 };

--- a/packages/tests/src/plugins/rum/index.test.ts
+++ b/packages/tests/src/plugins/rum/index.test.ts
@@ -25,6 +25,7 @@ describe('RUM Plugin', () => {
 
         expect(uploadSourcemapsMock).toHaveBeenCalled();
     });
+
     test('It should not process the sourcemaps with no options.', async () => {
         await runBundlers({
             rum: {},

--- a/packages/tests/src/plugins/rum/index.test.ts
+++ b/packages/tests/src/plugins/rum/index.test.ts
@@ -2,8 +2,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import type { GlobalContext } from '@dd/core/types';
 import { uploadSourcemaps } from '@dd/rum-plugins/sourcemaps/index';
-import { runBundlers } from '@dd/tests/helpers/runBundlers';
+import { runBundlers, runWebpack } from '@dd/tests/helpers/runBundlers';
 
 import { getSourcemapsConfiguration } from './testHelpers';
 
@@ -17,13 +18,34 @@ const uploadSourcemapsMock = jest.mocked(uploadSourcemaps);
 
 describe('RUM Plugin', () => {
     test('It should process the sourcemaps if enabled.', async () => {
+        await runWebpack({
+            rum: {
+                sourcemaps: getSourcemapsConfiguration(),
+            },
+        });
+        expect(uploadSourcemapsMock).toHaveBeenCalled();
+    });
+
+    test.only('It should process the sourcemaps with the right context.', async () => {
+        const contextResults: GlobalContext[] = [];
+        // Intercept context to verify it at the moment it's sent.
+        uploadSourcemapsMock.mockImplementation((options, context, log) => {
+            contextResults.push({ ...context });
+            return Promise.resolve();
+        });
+
         await runBundlers({
             rum: {
                 sourcemaps: getSourcemapsConfiguration(),
             },
         });
 
-        expect(uploadSourcemapsMock).toHaveBeenCalled();
+        // Verify that the mock's expects didn't fail.
+        expect(contextResults).toHaveLength(3);
+        for (const context of contextResults) {
+            expect(context.outputFiles).toBeDefined();
+            expect(context.outputFiles?.length).toBeGreaterThan(0);
+        }
     });
 
     test('It should not process the sourcemaps with no options.', async () => {

--- a/packages/tests/src/plugins/rum/index.test.ts
+++ b/packages/tests/src/plugins/rum/index.test.ts
@@ -26,7 +26,7 @@ describe('RUM Plugin', () => {
         expect(uploadSourcemapsMock).toHaveBeenCalled();
     });
 
-    test.only('It should process the sourcemaps with the right context.', async () => {
+    test('It should process the sourcemaps with the right context.', async () => {
         const contextResults: GlobalContext[] = [];
         // Intercept context to verify it at the moment it's sent.
         uploadSourcemapsMock.mockImplementation((options, context, log) => {

--- a/packages/tests/src/plugins/rum/sourcemaps/files.test.ts
+++ b/packages/tests/src/plugins/rum/sourcemaps/files.test.ts
@@ -1,33 +1,30 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
+
 import { getSourcemapsFiles } from '@dd/rum-plugins/sourcemaps/files';
 import { vol } from 'memfs';
+import path from 'path';
 
 import { getContextMock } from '../../../helpers/mocks';
 import { getSourcemapsConfiguration } from '../testHelpers';
 
 jest.mock('fs', () => require('memfs').fs);
 
+const FIXTURES = {
+    // Adding both .js and .mjs files.
+    'fixtures/common.js': '',
+    'fixtures/common.min.js.map': '',
+    'fixtures/common.min.js': '',
+    'fixtures/common.mjs': '',
+    'fixtures/common.min.mjs': '',
+    'fixtures/common.min.mjs.map': '',
+};
+
 describe('RUM Plugin Sourcemaps Files', () => {
     beforeEach(() => {
         // Emulate some fixtures.
-        vol.fromJSON(
-            {
-                // Adding three files outside the outputDir that should not be matched.
-                'common.js': '',
-                'common.min.js.map': '',
-                'common.min.js': '',
-                // Adding both .js and .mjs files.
-                'fixtures/common.js': '',
-                'fixtures/common.min.js.map': '',
-                'fixtures/common.min.js': '',
-                'fixtures/common.mjs': '',
-                'fixtures/common.min.mjs': '',
-                'fixtures/common.min.mjs.map': '',
-            },
-            __dirname,
-        );
+        vol.fromJSON(FIXTURES, __dirname);
     });
 
     afterEach(() => {
@@ -39,8 +36,14 @@ describe('RUM Plugin Sourcemaps Files', () => {
             getSourcemapsConfiguration({
                 minifiedPathPrefix: '/minified',
             }),
-            getContextMock(),
+            getContextMock({
+                outputDir: __dirname,
+                outputFiles: Object.keys(FIXTURES).map((filepath) => ({
+                    filepath: path.join(__dirname, filepath),
+                })),
+            }),
         );
+
         expect(sourcemaps.length).toBe(2);
 
         for (const sourcemap of sourcemaps) {
@@ -48,9 +51,9 @@ describe('RUM Plugin Sourcemaps Files', () => {
                 // Should end with ".min.js" or ".min.mjs".
                 minifiedFilePath: expect.stringMatching(/\.min\.(js|mjs)$/),
                 // Should start with "minified/" and end with ".min.js" or ".min.mjs".
-                minifiedUrl: expect.stringMatching(/^\/minified\/.*\.min\.(js|mjs)$/),
+                minifiedUrl: expect.stringMatching(/^\/minified\/fixtures\/common\.min\.(js|mjs)$/),
                 // Should start with "/" and end with ".min.js" or ".min.mjs".
-                relativePath: expect.stringMatching(/^\/.*\.min\.(js|mjs)$/),
+                relativePath: expect.stringMatching(/^\/fixtures\/common\.min\.(js|mjs)$/),
                 // Should end with ".map".
                 sourcemapFilePath: expect.stringMatching(/\.map$/),
                 minifiedPathPrefix: '/minified',

--- a/packages/tests/src/plugins/rum/sourcemaps/files.test.ts
+++ b/packages/tests/src/plugins/rum/sourcemaps/files.test.ts
@@ -1,11 +1,10 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
-
 import { getSourcemapsFiles } from '@dd/rum-plugins/sourcemaps/files';
 import { vol } from 'memfs';
-import path from 'path';
 
+import { getContextMock } from '../../../helpers/mocks';
 import { getSourcemapsConfiguration } from '../testHelpers';
 
 jest.mock('fs', () => require('memfs').fs);
@@ -15,7 +14,7 @@ describe('RUM Plugin Sourcemaps Files', () => {
         // Emulate some fixtures.
         vol.fromJSON(
             {
-                // Adding three files outside the basePath that should not be matched.
+                // Adding three files outside the outputDir that should not be matched.
                 'common.js': '',
                 'common.min.js.map': '',
                 'common.min.js': '',
@@ -38,9 +37,9 @@ describe('RUM Plugin Sourcemaps Files', () => {
     test('It should get sourcemap files.', async () => {
         const sourcemaps = getSourcemapsFiles(
             getSourcemapsConfiguration({
-                basePath: path.resolve(__dirname, 'fixtures'),
                 minifiedPathPrefix: '/minified',
             }),
+            getContextMock(),
         );
         expect(sourcemaps.length).toBe(2);
 

--- a/packages/tests/src/plugins/rum/sourcemaps/sender.test.ts
+++ b/packages/tests/src/plugins/rum/sourcemaps/sender.test.ts
@@ -129,9 +129,7 @@ describe('RUM Plugin Sourcemaps', () => {
 
             await sendSourcemaps(
                 [getSourcemapMock()],
-                getSourcemapsConfiguration({
-                    basePath: __dirname,
-                }),
+                getSourcemapsConfiguration(),
                 getContextMock(),
                 () => {},
             );
@@ -153,9 +151,7 @@ describe('RUM Plugin Sourcemaps', () => {
             await expect(async () => {
                 await sendSourcemaps(
                     [getSourcemapMock()],
-                    getSourcemapsConfiguration({
-                        basePath: __dirname,
-                    }),
+                    getSourcemapsConfiguration(),
                     getContextMock(),
                     () => {},
                 );

--- a/packages/tests/src/plugins/rum/testHelpers.ts
+++ b/packages/tests/src/plugins/rum/testHelpers.ts
@@ -10,7 +10,6 @@ import type {
     RumSourcemapsOptionsWithDefaults,
     Sourcemap,
 } from '@dd/rum-plugins/types';
-import { defaultDestination } from '@dd/tests/helpers/mocks';
 
 export const FAKE_URL = 'https://example.com';
 export const API_PATH = '/v2/srcmap';
@@ -20,7 +19,6 @@ export const getMinimalSourcemapsConfiguration = (
     options: Partial<RumSourcemapsOptions> = {},
 ): RumSourcemapsOptions => {
     return {
-        basePath: defaultDestination,
         minifiedPathPrefix: '/prefix',
         releaseVersion: '1.0.0',
         service: 'rum-build-plugin-sourcemaps',
@@ -32,7 +30,6 @@ export const getSourcemapsConfiguration = (
     options: Partial<RumSourcemapsOptions> = {},
 ): RumSourcemapsOptionsWithDefaults => {
     return {
-        basePath: defaultDestination,
         dryRun: false,
         maxConcurrency: 10,
         intakeUrl: INTAKE_URL,

--- a/packages/tests/src/plugins/rum/validate.test.ts
+++ b/packages/tests/src/plugins/rum/validate.test.ts
@@ -47,7 +47,7 @@ describe('RUM Plugins validate', () => {
                 },
             });
 
-            expect(errors.length).toBe(4);
+            expect(errors.length).toBe(3);
             const expectedErrors = [
                 'sourcemaps.releaseVersion is required.',
                 'sourcemaps.service is required.',

--- a/packages/tests/src/plugins/rum/validate.test.ts
+++ b/packages/tests/src/plugins/rum/validate.test.ts
@@ -49,7 +49,6 @@ describe('RUM Plugins validate', () => {
 
             expect(errors.length).toBe(4);
             const expectedErrors = [
-                'sourcemaps.basePath is required.',
                 'sourcemaps.releaseVersion is required.',
                 'sourcemaps.service is required.',
                 'sourcemaps.minifiedPathPrefix is required.',
@@ -59,7 +58,6 @@ describe('RUM Plugins validate', () => {
 
         test('It should return the validated configuration with defaults', () => {
             const configObject: RumSourcemapsOptions = {
-                basePath: 'src',
                 minifiedPathPrefix: '/path/to/minified',
                 releaseVersion: '1.0.0',
                 service: 'service',

--- a/packages/tests/src/plugins/telemetry/common/metrics/esbuild.test.ts
+++ b/packages/tests/src/plugins/telemetry/common/metrics/esbuild.test.ts
@@ -23,7 +23,7 @@ describe('Telemetry ESBuild Metrics', () => {
 
         afterAll(async () => {
             // Clean
-            fs.rmdirSync(OUTPUT, { recursive: true });
+            fs.rmSync(OUTPUT, { force: true, recursive: true });
         });
 
         beforeAll(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,7 +1764,6 @@ __metadata:
     "@types/async-retry": "npm:1.4.8"
     async-retry: "npm:1.3.3"
     chalk: "npm:2.3.1"
-    glob: "npm:7.1.6"
     outdent: "npm:0.8.0"
     p-queue: "npm:6.6.2"
     unplugin: "patch:unplugin@npm%3A1.10.1#~/.yarn/patches/unplugin-npm-1.10.1-b23391b255.patch"


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

It leads to some issues to glob into `basePath`, for instance, when your build has multiple entries, in webpack, each entry has its own process, and when globing for sourcemaps, each build will get sourcemaps from the previous build.

This isn't robust enough.

### How?

<!-- A brief description of implementation details of this PR. -->

By using the result of the builds, we can only target the files that were generated by the build.
And, we don't need `basePath`'s configuration anymore.
