### PR TITLE
[rum] Change how we handle errors in sourcemaps upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ datadogWebpackPlugin({
     rum?: {
         disabled?: boolean,
         sourcemaps?: {
+            bailOnError?: boolean,
             dryRun?: boolean,
             intakeUrl?: string,
             maxConcurrency?: number,
@@ -257,6 +258,7 @@ datadogWebpackPlugin({
     rum?: {
         disabled?: boolean;
         sourcemaps?: {
+            bailOnError?: boolean;
             dryRun?: boolean;
             intakeUrl?: string;
             maxConcurrency?: number;

--- a/packages/core/src/plugins/git/trackedFilesMatcher.ts
+++ b/packages/core/src/plugins/git/trackedFilesMatcher.ts
@@ -26,6 +26,13 @@ export class TrackedFilesMatcher {
         }
     }
 
+    private displaySource(src: string) {
+        if (src.length <= 40) {
+            return src;
+        }
+        return `[...]${src.slice(-35)}`;
+    }
+
     // Looks up the sources declared in the sourcemap and return a list of related tracked files.
     public matchSourcemap(
         srcmapPath: string,
@@ -44,7 +51,9 @@ export class TrackedFilesMatcher {
         }
         const filtered = this.matchSources(sources);
         if (filtered.length === 0) {
-            onSourcesNotFound(`Sources not in the tracked files.`);
+            onSourcesNotFound(
+                `${sources.map(this.displaySource).join(', ')} not in the tracked files.`,
+            );
             return undefined;
         }
 

--- a/packages/plugins/rum/README.md
+++ b/packages/plugins/rum/README.md
@@ -11,6 +11,7 @@ Interact with our Real User Monitoring product (RUM) in Datadog directly from yo
 <!-- #toc -->
 -   [Configuration](#configuration)
 -   [Sourcemaps Upload](#sourcemaps-upload)
+    -   [`rum.sourcemaps.bailOnError`](#rumsourcemapsbailonerror)
     -   [`rum.sourcemaps.dryRun`](#rumsourcemapsdryrun)
     -   [`rum.sourcemaps.intakeUrl`](#rumsourcemapsintakeurl)
     -   [`rum.sourcemaps.maxConcurrency`](#rumsourcemapsmaxconcurrency)

--- a/packages/plugins/rum/README.md
+++ b/packages/plugins/rum/README.md
@@ -25,6 +25,7 @@ Interact with our Real User Monitoring product (RUM) in Datadog directly from yo
 rum?: {
     disabled?: boolean;
     sourcemaps?: {
+        bailOnError?: boolean;
         dryRun?: boolean;
         intakeUrl?: string;
         maxConcurrency?: number;

--- a/packages/plugins/rum/README.md
+++ b/packages/plugins/rum/README.md
@@ -44,6 +44,12 @@ Upload JavaScript sourcemaps to Datadog to un-minify your errors.
 > You can override the intake URL by setting the `DATADOG_SOURCEMAP_INTAKE_URL` environment variable (eg. `https://sourcemap-intake.datadoghq.com/v1/input`).
 > Or only the domain with the `DATADOG_SITE` environment variable (eg. `datadoghq.com`).
 
+### `rum.sourcemaps.bailOnError`
+
+> default: `false`
+
+Should the upload of sourcemaps fail the build on first error?
+
 ### `rum.sourcemaps.dryRun`
 
 > default: `false`

--- a/packages/plugins/rum/src/sourcemaps/payload.ts
+++ b/packages/plugins/rum/src/sourcemaps/payload.ts
@@ -4,6 +4,7 @@
 
 import type { RepositoryData } from '@dd/core/types';
 import { promises as fs } from 'fs';
+import path from 'path';
 
 import type { Sourcemap } from '../types';
 
@@ -57,8 +58,8 @@ const SLASH_RX = /[/]+|[\\]+/g;
 const SLASH_TRIM_RX = /^[/]+|^[\\]+|[/]+$|[\\]+$/g;
 
 // Verify any repeated pattern between the path and prefix.
-export const prefixRepeat = (path: string, prefix: string): string => {
-    const pathParts = path.replace(SLASH_TRIM_RX, '').split(SLASH_RX);
+export const prefixRepeat = (filePath: string, prefix: string): string => {
+    const pathParts = filePath.replace(SLASH_TRIM_RX, '').split(SLASH_RX);
     const prefixParts = prefix.replace(SLASH_TRIM_RX, '').split(SLASH_RX);
     const normalizedPath = pathParts.join('/');
 
@@ -75,14 +76,14 @@ export const prefixRepeat = (path: string, prefix: string): string => {
 };
 
 // Verify that every files are available.
-export const checkFile = async (path: string): Promise<FileValidity> => {
+export const checkFile = async (filePath: string): Promise<FileValidity> => {
     const validity: FileValidity = {
         empty: false,
         exists: true,
     };
 
     try {
-        const stats = await fs.stat(path);
+        const stats = await fs.stat(filePath);
         if (stats.size === 0) {
             validity.empty = true;
         }
@@ -172,7 +173,7 @@ export const getPayload = async (
                                 sourcemap.sourcemapFilePath,
                                 (reason) => {
                                     warnings.push(
-                                        `No tracked files found for sources contained in ${sourcemap.sourcemapFilePath}: "${reason}"`,
+                                        `${path.basename(sourcemap.sourcemapFilePath)}: "${reason}"`,
                                     );
                                 },
                             ),

--- a/packages/plugins/rum/src/sourcemaps/sender.ts
+++ b/packages/plugins/rum/src/sourcemaps/sender.ts
@@ -230,11 +230,11 @@ export const sendSourcemaps = async (
     const warnings = payloads.map((payload) => payload.warnings).flat();
 
     if (warnings.length > 0) {
-        log(`Warnings while uploading sourcemaps:\n    - ${warnings.join('\n    - ')}`, 'warn');
+        log(`Warnings while preparing payloads:\n    - ${warnings.join('\n    - ')}`, 'warn');
     }
 
     if (errors.length > 0) {
-        const errorMsg = `Failed to upload sourcemaps:\n    - ${errors.join('\n    - ')}`;
+        const errorMsg = `Failed to prepare payloads, aborting upload :\n    - ${errors.join('\n    - ')}`;
         log(errorMsg, 'error');
         // Depending on the configuration we throw or not.
         if (options.bailOnError === true) {

--- a/packages/plugins/rum/src/types.ts
+++ b/packages/plugins/rum/src/types.ts
@@ -9,6 +9,7 @@ import type { CONFIG_KEY } from './constants';
 export type MinifiedPathPrefix = `http://${string}` | `https://${string}` | `/${string}`;
 
 export type RumSourcemapsOptions = {
+    bailOnError?: boolean;
     dryRun?: boolean;
     intakeUrl?: string;
     maxConcurrency?: number;

--- a/packages/plugins/rum/src/validate.ts
+++ b/packages/plugins/rum/src/validate.ts
@@ -99,6 +99,7 @@ export const validateSourcemapsOptions = (
 
         // Add the defaults.
         const sourcemapsWithDefaults: RumSourcemapsOptionsWithDefaults = {
+            bailOnError: false,
             dryRun: false,
             maxConcurrency: 20,
             intakeUrl:

--- a/packages/tests/src/plugins/rum/sourcemaps/sender.test.ts
+++ b/packages/tests/src/plugins/rum/sourcemaps/sender.test.ts
@@ -131,7 +131,7 @@ describe('RUM Plugin Sourcemaps', () => {
 
             expect(logMock).toHaveBeenCalledTimes(1);
             expect(logMock).toHaveBeenCalledWith(
-                expect.stringMatching('Failed to upload sourcemaps'),
+                expect.stringMatching('Failed to prepare payloads, aborting upload'),
                 'error',
             );
             expect(scope.isDone()).toBe(false);
@@ -155,7 +155,7 @@ describe('RUM Plugin Sourcemaps', () => {
                     getContextMock(),
                     () => {},
                 );
-            }).rejects.toThrow('Failed to upload sourcemaps:');
+            }).rejects.toThrow('Failed to prepare payloads, aborting upload');
 
             expect(scope.isDone()).toBe(false);
         });

--- a/packages/tests/src/plugins/rum/sourcemaps/sender.test.ts
+++ b/packages/tests/src/plugins/rum/sourcemaps/sender.test.ts
@@ -2,9 +2,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { MultipartValue } from '@dd/rum-plugins/sourcemaps/payload';
-import { doRequest, getData, sendSourcemaps } from '@dd/rum-plugins/sourcemaps/sender';
+import { doRequest, getData, sendSourcemaps, upload } from '@dd/rum-plugins/sourcemaps/sender';
 import { getContextMock } from '@dd/tests/helpers/mocks';
+import retry from 'async-retry';
 import { vol } from 'memfs';
 import nock from 'nock';
 import { Readable, type Stream } from 'stream';
@@ -14,6 +14,7 @@ import {
     API_PATH,
     FAKE_URL,
     INTAKE_URL,
+    getPayloadMock,
     getSourcemapMock,
     getSourcemapsConfiguration,
 } from '../testHelpers';
@@ -31,6 +32,8 @@ jest.mock('async-retry', () => {
         });
     });
 });
+
+const retryMock = jest.mocked(retry);
 
 function readFully(stream: Stream): Promise<Buffer> {
     const chunks: any[] = [];
@@ -61,31 +64,7 @@ describe('RUM Plugin Sourcemaps', () => {
                 __dirname,
             );
 
-            const payload = {
-                content: new Map<string, MultipartValue>([
-                    [
-                        'source_map',
-                        {
-                            type: 'file',
-                            path: '/path/to/sourcemap.js.map',
-                            options: { filename: 'source_map', contentType: 'application/json' },
-                        },
-                    ],
-                    [
-                        'minified_file',
-                        {
-                            type: 'file',
-                            path: '/path/to/minified.min.js',
-                            options: {
-                                filename: 'minified_file',
-                                contentType: 'application/javascript',
-                            },
-                        },
-                    ],
-                ]),
-                errors: [],
-                warnings: [],
-            };
+            const payload = getPayloadMock();
 
             const { data, headers } = await getData(payload)();
             const zippedData = await readFully(data);
@@ -105,14 +84,7 @@ describe('RUM Plugin Sourcemaps', () => {
     describe('sendSourcemaps', () => {
         afterEach(async () => {
             nock.cleanAll();
-
-            // Using a setTimeout because it creates an error on the ReadStreams created for the payloads.
-            await new Promise((resolve) => {
-                setTimeout(() => {
-                    vol.reset();
-                    resolve(true);
-                }, 100);
-            });
+            vol.reset();
         });
 
         test('It should upload sourcemaps.', async () => {
@@ -137,7 +109,35 @@ describe('RUM Plugin Sourcemaps', () => {
             expect(scope.isDone()).toBe(true);
         });
 
-        test('It should throw in case of payload issues', async () => {
+        test('It should alert in case of payload issues', async () => {
+            const scope = nock(FAKE_URL).post(API_PATH).reply(200);
+            // Emulate some fixtures.
+            vol.fromJSON(
+                {
+                    // Empty file.
+                    '/path/to/minified.min.js': '',
+                },
+                __dirname,
+            );
+
+            const logMock = jest.fn();
+
+            await sendSourcemaps(
+                [getSourcemapMock()],
+                getSourcemapsConfiguration(),
+                getContextMock(),
+                logMock,
+            );
+
+            expect(logMock).toHaveBeenCalledTimes(1);
+            expect(logMock).toHaveBeenCalledWith(
+                expect.stringMatching('Failed to upload sourcemaps'),
+                'error',
+            );
+            expect(scope.isDone()).toBe(false);
+        });
+
+        test('It should throw in case of payload issues and bailOnError', async () => {
             const scope = nock(FAKE_URL).post(API_PATH).reply(200);
             // Emulate some fixtures.
             vol.fromJSON(
@@ -151,7 +151,7 @@ describe('RUM Plugin Sourcemaps', () => {
             await expect(async () => {
                 await sendSourcemaps(
                     [getSourcemapMock()],
-                    getSourcemapsConfiguration(),
+                    getSourcemapsConfiguration({ bailOnError: true }),
                     getContextMock(),
                     () => {},
                 );
@@ -196,12 +196,12 @@ describe('RUM Plugin Sourcemaps', () => {
                 .times(2)
                 .reply(404)
                 .post(API_PATH)
-                .reply(200, {});
+                .reply(200, { data: 'ok' });
 
             const response = await doRequest(INTAKE_URL, getDataMock);
 
             expect(scope.isDone()).toBe(true);
-            expect(response).toEqual({});
+            expect(response).toEqual({ data: 'ok' });
         });
 
         test('It should throw on too many retries', async () => {
@@ -233,8 +233,62 @@ describe('RUM Plugin Sourcemaps', () => {
 
             await expect(async () => {
                 await doRequest(INTAKE_URL, () => ({ data, headers: {} }));
-            }).rejects.toThrow('TypeError: Response body object should not be disturbed or locked');
+            }).rejects.toThrow('Response body object should not be disturbed or locked');
             expect(scope.isDone()).toBe(true);
+        });
+    });
+
+    describe('upload', () => {
+        test('It should not throw', async () => {
+            retryMock.mockImplementation(jest.fn());
+
+            const payloads = [getPayloadMock()];
+
+            const { warnings, errors } = await upload(
+                payloads,
+                getSourcemapsConfiguration(),
+                getContextMock(),
+                () => {},
+            );
+
+            expect(warnings).toHaveLength(0);
+            expect(errors).toHaveLength(0);
+        });
+
+        test('It should alert in case of errors', async () => {
+            retryMock.mockRejectedValue(new Error('Fake Error'));
+
+            const payloads = [getPayloadMock()];
+            const { warnings, errors } = await upload(
+                payloads,
+                getSourcemapsConfiguration(),
+                getContextMock(),
+                jest.fn(),
+            );
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatchObject({
+                metadata: {
+                    sourcemap: expect.any(String),
+                    file: expect.any(String),
+                },
+                error: new Error('Fake Error'),
+            });
+            expect(warnings).toHaveLength(0);
+        });
+
+        test('It should throw in case of errors with bailOnError', async () => {
+            retryMock.mockRejectedValue(new Error('Fake Error'));
+
+            const payloads = [getPayloadMock()];
+            expect(async () => {
+                await upload(
+                    payloads,
+                    getSourcemapsConfiguration({ bailOnError: true }),
+                    getContextMock(),
+                    () => {},
+                );
+            }).rejects.toThrow('Fake Error');
         });
     });
 });

--- a/packages/tests/src/plugins/rum/testHelpers.ts
+++ b/packages/tests/src/plugins/rum/testHelpers.ts
@@ -30,6 +30,7 @@ export const getSourcemapsConfiguration = (
     options: Partial<RumSourcemapsOptions> = {},
 ): RumSourcemapsOptionsWithDefaults => {
     return {
+        bailOnError: false,
         dryRun: false,
         maxConcurrency: 10,
         intakeUrl: INTAKE_URL,

--- a/packages/tests/src/plugins/rum/testHelpers.ts
+++ b/packages/tests/src/plugins/rum/testHelpers.ts
@@ -4,7 +4,7 @@
 
 import { TrackedFilesMatcher } from '@dd/core/plugins/git/trackedFilesMatcher';
 import type { RepositoryData } from '@dd/core/types';
-import type { Metadata } from '@dd/rum-plugins/sourcemaps/payload';
+import type { Metadata, MultipartValue, Payload } from '@dd/rum-plugins/sourcemaps/payload';
 import type {
     RumSourcemapsOptions,
     RumSourcemapsOptionsWithDefaults,
@@ -68,6 +68,39 @@ export const getRepositoryDataMock = (options: Partial<RepositoryData> = {}): Re
         hash: 'hash',
         remote: 'remote',
         trackedFilesMatcher: new TrackedFilesMatcher(['/path/to/minified.min.js']),
+        ...options,
+    };
+};
+
+export const getPayloadMock = (
+    options: Partial<Payload> = {},
+    content: [string, MultipartValue][] = [],
+): Payload => {
+    return {
+        content: new Map<string, MultipartValue>([
+            [
+                'source_map',
+                {
+                    type: 'file',
+                    path: '/path/to/sourcemap.js.map',
+                    options: { filename: 'source_map', contentType: 'application/json' },
+                },
+            ],
+            [
+                'minified_file',
+                {
+                    type: 'file',
+                    path: '/path/to/minified.min.js',
+                    options: {
+                        filename: 'minified_file',
+                        contentType: 'application/javascript',
+                    },
+                },
+            ],
+            ...content,
+        ]),
+        errors: [],
+        warnings: [],
         ...options,
     };
 };

--- a/packages/tests/src/plugins/rum/validate.test.ts
+++ b/packages/tests/src/plugins/rum/validate.test.ts
@@ -77,6 +77,7 @@ describe('RUM Plugins validate', () => {
 
             expect(errors.length).toBe(0);
             expect(config).toEqual({
+                bailOnError: false,
                 dryRun: false,
                 maxConcurrency: 20,
                 intakeUrl: 'https://sourcemap-intake.datadoghq.com/api/v2/srcmap',


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

We sometimes have hiccups in the sourcemaps upload, but the error gets semi-swallowed and isn't caught.

### How?

<!-- A brief description of implementation details of this PR. -->

There was a bug using `p-queue`, `queue.add` is actually async and wasn't awaited, which made the throw not catchable.

Also, we don't always want to fail the full build because we failed to upload one sourcemap.
So we added a `bailOnError` option that is `false` by default.

This refines how we handle errors and add more testing around it as well.

> [!WARNING]
> Since it's changing the default behaviour this will need a minor bump.