### PR TITLE
Custom Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ datadogWebpackPlugin({
     auth?: {
         apiKey?: string;
     };
+    customPlugins?: (options: Options, context: GlobalContext) => UnpluginPlugin[];
     logLevel?: 'debug' | 'info' | 'warn' | 'error' | 'none';
     rum?: {
         disabled?: boolean;
@@ -296,18 +297,86 @@ In order to interact with Datadog, you have to use [your own API Key](https://ap
 
 Which level of log do you want to show.
 
----
+### `customPlugins`
+
+> default: `[]`
+
+This is a way for you to inject any [Unplugin Plugin](https://unplugin.unjs.io/guide/) you want.
+
+It's particularly useful  to use our global, shared context of the main plugin.
+
+```typescript
+{
+    customPlugins: [
+        (options, context) => {
+            return {
+                name: 'my-custom-plugin',
+                buildStart() {
+                    console.log('Hello world');
+                },
+            };
+        }
+    ];
+}
+```
+
+Your function will receive two arguments:
+
+- `options`: The options you passed to the main plugin (including your custom plugins).
+- `context`: The global context shared accross our plugin.
+
+
+```typescript
+type GlobalContext = {
+    // Available from the initialization.
+    auth?: {
+        apiKey?: string;
+    };
+    // Available from the initialization.
+    // More details on the currently running bundler.
+    bundler: {
+        name: string;
+        fullName: string; // Including its variant.
+        outDir: string;
+        rawConfig?: any;
+        variant?: string; // Major version of the bundler (webpack 4, webpack 5)
+    };
+    // Available from `writeBundle`.
+    build: {
+        errors: string[];
+        warnings: string[];
+        entries?: { filepath: string; name: string; size: number; type: string, inputs: Input[], outputs: Output[] }[];
+        inputs?: { filepath: string; name: string; size: number; type: string, dependencies: Input[]; dependents: Input[] }[];
+        outputs?: { filepath: string; name: string; size: number; type: string, inputs: (Input | Output)[] }[];
+        start?: number;
+        end?: number;
+        duration?: number;
+        writeDuration?: number;
+    };
+    // Available from the initialization.
+    cwd: string;
+    // Available from `buildStart`.
+    git?: {
+        hash: string;
+        remote: string;
+        trackedFilesMatcher: [TrackedFilesMatcher](packages/core/src/plugins/git/trackedFilesMatcher.ts);
+    };
+    // Available from the initialization.
+    start: number;
+    // Available from the initialization.
+    version: string;
+}
+```
+
+> [!NOTE]
+> Some parts of the context are only available after certain hooks.
 
 ## Contributing
 
 Check out the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information.
 
----
-
 ## License
 
 [MIT](LICENSE)
-
----
 
 <kbd>[Back to top :arrow_up:](#top)</kbd>

--- a/packages/core/src/plugins/build-report/esbuild.ts
+++ b/packages/core/src/plugins/build-report/esbuild.ts
@@ -3,10 +3,9 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import path from 'path';
-import type { UnpluginOptions } from 'unplugin';
 
 import type { Logger } from '../../log';
-import type { Entry, GlobalContext, Input, Output } from '../../types';
+import type { Entry, GlobalContext, Input, Output, PluginOptions } from '../../types';
 
 import { cleanName, getType } from './helpers';
 
@@ -19,10 +18,7 @@ const reIndexMeta = <T>(obj: Record<string, T>, cwd: string) =>
         }),
     );
 
-export const getEsbuildPlugin = (
-    context: GlobalContext,
-    log: Logger,
-): UnpluginOptions['esbuild'] => {
+export const getEsbuildPlugin = (context: GlobalContext, log: Logger): PluginOptions['esbuild'] => {
     return {
         setup(build) {
             const cwd = context.cwd;

--- a/packages/core/src/plugins/build-report/index.ts
+++ b/packages/core/src/plugins/build-report/index.ts
@@ -2,18 +2,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { UnpluginOptions } from 'unplugin';
-
 import { getLogger } from '../../log';
-import type { GlobalContext, Options } from '../../types';
+import type { GlobalContext, Options, PluginOptions } from '../../types';
 
 import { getEsbuildPlugin } from './esbuild';
 import { getRollupPlugin } from './rollup';
 import { getWebpackPlugin } from './webpack';
 
-const PLUGIN_NAME = 'build-report';
+const PLUGIN_NAME = 'datadog-build-report-plugin';
 
-export const getBuildReportPlugin = (opts: Options, context: GlobalContext): UnpluginOptions => {
+export const getBuildReportPlugin = (opts: Options, context: GlobalContext): PluginOptions => {
     const log = getLogger(opts.logLevel, PLUGIN_NAME);
     return {
         name: PLUGIN_NAME,

--- a/packages/core/src/plugins/build-report/rollup.ts
+++ b/packages/core/src/plugins/build-report/rollup.ts
@@ -3,14 +3,13 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import path from 'path';
-import type { UnpluginOptions } from 'unplugin';
 
 import type { Logger } from '../../log';
-import type { Entry, GlobalContext, Input, Output } from '../../types';
+import type { Entry, GlobalContext, Input, Output, PluginOptions } from '../../types';
 
 import { cleanName, cleanPath, cleanReport, getType } from './helpers';
 
-export const getRollupPlugin = (context: GlobalContext, log: Logger): UnpluginOptions['rollup'] => {
+export const getRollupPlugin = (context: GlobalContext, log: Logger): PluginOptions['rollup'] => {
     const importsReport: Record<
         string,
         {

--- a/packages/core/src/plugins/build-report/webpack.ts
+++ b/packages/core/src/plugins/build-report/webpack.ts
@@ -3,15 +3,14 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import path from 'path';
-import type { UnpluginOptions } from 'unplugin';
 
 import type { Logger } from '../../log';
-import type { Entry, GlobalContext, Input, Output } from '../../types';
+import type { Entry, GlobalContext, Input, Output, PluginOptions } from '../../types';
 
 import { cleanName, cleanReport, getType } from './helpers';
 
 export const getWebpackPlugin =
-    (context: GlobalContext, PLUGIN_NAME: string, log: Logger): UnpluginOptions['webpack'] =>
+    (context: GlobalContext, PLUGIN_NAME: string, log: Logger): PluginOptions['webpack'] =>
     (compiler) => {
         compiler.hooks.afterEmit.tap(PLUGIN_NAME, (compilation) => {
             const inputs: Input[] = [];

--- a/packages/core/src/plugins/git/index.ts
+++ b/packages/core/src/plugins/git/index.ts
@@ -2,15 +2,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { UnpluginOptions } from 'unplugin';
-
-import type { GlobalContext, Options } from '../../types';
+import type { GlobalContext, Options, PluginOptions } from '../../types';
 
 import { getRepositoryData, newSimpleGit } from './helpers';
 
-export const getGitPlugin = (options: Options, context: GlobalContext): UnpluginOptions => {
+export const getGitPlugin = (options: Options, context: GlobalContext): PluginOptions => {
     return {
-        name: 'git-plugin',
+        name: 'datadog-git-plugin',
         enforce: 'pre',
         async buildStart() {
             // Verify that we should get the git information based on the options.

--- a/packages/core/src/plugins/global-context/index.ts
+++ b/packages/core/src/plugins/global-context/index.ts
@@ -2,15 +2,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { GlobalContext, Meta, Options } from '@dd/core/types';
+import type { GlobalContext, Meta, Options, PluginOptions } from '@dd/core/types';
 import path from 'path';
-import type { UnpluginOptions } from 'unplugin';
 
 // TODO: Add universal config report with list of plugins (names), loaders.
 
-const PLUGIN_NAME = 'context-plugin';
+const PLUGIN_NAME = 'datadog-context-plugin';
 
-const rollupPlugin: (context: GlobalContext) => UnpluginOptions['rollup'] = (context) => ({
+const rollupPlugin: (context: GlobalContext) => PluginOptions['rollup'] = (context) => ({
     options(options) {
         context.bundler.rawConfig = options;
         const outputOptions = (options as any).output;
@@ -32,9 +31,6 @@ export const getGlobalContextPlugin = (opts: Options, meta: Meta) => {
 
     const globalContext: GlobalContext = {
         auth: opts.auth,
-        start: Date.now(),
-        cwd,
-        version: meta.version,
         bundler: {
             name: meta.framework,
             fullName: `${meta.framework}${variant}`,
@@ -45,9 +41,12 @@ export const getGlobalContextPlugin = (opts: Options, meta: Meta) => {
             errors: [],
             warnings: [],
         },
+        cwd,
+        start: Date.now(),
+        version: meta.version,
     };
 
-    const globalContextPlugin: UnpluginOptions = {
+    const globalContextPlugin: PluginOptions = {
         name: PLUGIN_NAME,
         enforce: 'pre',
         esbuild: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,6 +83,7 @@ export type PluginOptions = UnpluginOptions & {
 };
 
 export type GetPlugins<T> = (options: T, context: GlobalContext) => PluginOptions[];
+export type GetCustomPlugins<T> = (options: T, context: GlobalContext) => UnpluginOptions[];
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'none';
 
@@ -102,6 +103,7 @@ export interface Options extends GetPluginsOptions {
     [rum.CONFIG_KEY]?: RumOptions;
     [telemetry.CONFIG_KEY]?: TelemetryOptions;
     // #types-injection-marker
+    customPlugins?: GetCustomPlugins<Options>[];
 }
 
 export type PluginName = `datadog-${Lowercase<string>}-plugin`;

--- a/packages/factory/src/index.ts
+++ b/packages/factory/src/index.ts
@@ -17,7 +17,7 @@ import type { OptionsWithTelemetry } from '@dd/telemetry-plugins/types';
 import * as telemetry from '@dd/telemetry-plugins';
 // #imports-injection-marker
 
-import type { UnpluginContextMeta, UnpluginInstance } from 'unplugin';
+import type { UnpluginContextMeta, UnpluginInstance, UnpluginOptions } from 'unplugin';
 import { createUnplugin } from 'unplugin';
 
 // #types-export-injection-marker
@@ -35,6 +35,7 @@ export const helpers = {
 const validateOptions = (options: Options = {}): Options => {
     return {
         auth: {},
+        customPlugins: [],
         disableGit: false,
         logLevel: 'warn',
         ...options,
@@ -65,7 +66,15 @@ export const buildPluginFactory = ({
         });
 
         // List of plugins to be returned.
-        const plugins: PluginOptions[] = [...internalPlugins];
+        const plugins: (PluginOptions | UnpluginOptions)[] = [...internalPlugins];
+
+        // Add custom, on the fly plugins.
+        if (options.customPlugins) {
+            for (const customPlugin of options.customPlugins) {
+                const customPlugins = customPlugin(options, globalContext);
+                plugins.push(...customPlugins);
+            }
+        }
 
         // Based on configuration add corresponding plugin.
         // #configs-injection-marker

--- a/packages/factory/src/index.ts
+++ b/packages/factory/src/index.ts
@@ -8,7 +8,7 @@
 
 import { getInternalPlugins } from '@dd/core/plugins/index';
 // eslint-disable-next-line arca/newline-after-import-section
-import type { Options } from '@dd/core/types';
+import type { Options, PluginOptions } from '@dd/core/types';
 
 // #imports-injection-marker
 import type { OptionsWithRum } from '@dd/rum-plugins/types';
@@ -17,7 +17,7 @@ import type { OptionsWithTelemetry } from '@dd/telemetry-plugins/types';
 import * as telemetry from '@dd/telemetry-plugins';
 // #imports-injection-marker
 
-import type { UnpluginContextMeta, UnpluginInstance, UnpluginOptions } from 'unplugin';
+import type { UnpluginContextMeta, UnpluginInstance } from 'unplugin';
 import { createUnplugin } from 'unplugin';
 
 // #types-export-injection-marker
@@ -65,7 +65,7 @@ export const buildPluginFactory = ({
         });
 
         // List of plugins to be returned.
-        const plugins: UnpluginOptions[] = [...internalPlugins];
+        const plugins: PluginOptions[] = [...internalPlugins];
 
         // Based on configuration add corresponding plugin.
         // #configs-injection-marker

--- a/packages/plugins/telemetry/src/esbuild-plugin/index.ts
+++ b/packages/plugins/telemetry/src/esbuild-plugin/index.ts
@@ -3,9 +3,8 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import type { Logger } from '@dd/core/log';
-import type { GlobalContext } from '@dd/core/types';
+import type { GlobalContext, PluginOptions } from '@dd/core/types';
 import type { BuildResult } from 'esbuild';
-import type { UnpluginOptions } from 'unplugin';
 
 import type { BundlerContext } from '../types';
 
@@ -15,7 +14,7 @@ export const getEsbuildPlugin = (
     bundlerContext: BundlerContext,
     globalContext: GlobalContext,
     logger: Logger,
-): UnpluginOptions['esbuild'] => {
+): PluginOptions['esbuild'] => {
     return {
         setup: (build) => {
             globalContext.build.start = Date.now();

--- a/packages/plugins/telemetry/src/webpack-plugin/index.ts
+++ b/packages/plugins/telemetry/src/webpack-plugin/index.ts
@@ -2,8 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { GlobalContext } from '@dd/core/types';
-import type { UnpluginOptions } from 'unplugin';
+import type { GlobalContext, PluginOptions } from '@dd/core/types';
 
 import { PLUGIN_NAME } from '../constants';
 import type { Compilation, BundlerContext } from '../types';
@@ -14,7 +13,7 @@ import { Tapables } from './tapables';
 export const getWebpackPlugin = (
     bundlerContext: BundlerContext,
     globalContext: GlobalContext,
-): UnpluginOptions['webpack'] => {
+): PluginOptions['webpack'] => {
     return async (compiler) => {
         globalContext.build.start = Date.now();
 

--- a/packages/tests/src/core/plugins/global-context/index.test.ts
+++ b/packages/tests/src/core/plugins/global-context/index.test.ts
@@ -3,58 +3,32 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import type { GlobalContext, Options } from '@dd/core/types';
-import { uploadSourcemaps } from '@dd/rum-plugins/sourcemaps/index';
-import { getPlugins } from '@dd/telemetry-plugins';
 import { defaultDestination, defaultPluginOptions } from '@dd/tests/helpers/mocks';
 import { BUNDLERS, runBundlers } from '@dd/tests/helpers/runBundlers';
-import { getSourcemapsConfiguration } from '@dd/tests/plugins/rum/testHelpers';
 import path from 'path';
-
-jest.mock('@dd/telemetry-plugins', () => {
-    const originalModule = jest.requireActual('@dd/telemetry-plugins');
-    return {
-        ...originalModule,
-        getPlugins: jest.fn(() => []),
-    };
-});
-
-jest.mock('@dd/rum-plugins/sourcemaps/index', () => {
-    const originalModule = jest.requireActual('@dd/rum-plugins/sourcemaps/index');
-    return {
-        ...originalModule,
-        uploadSourcemaps: jest.fn(),
-    };
-});
-
-const getTelemetryPluginsMocked = jest.mocked(getPlugins);
-const uploadSourcemapsMocked = jest.mocked(uploadSourcemaps);
 
 describe('Global Context Plugin', () => {
     // Intercept contexts to verify it at the moment they're used.
     const initialContexts: Record<string, GlobalContext> = {};
     const lateContexts: Record<string, GlobalContext> = {};
     beforeAll(async () => {
-        // This one is called at initialization, with the initial context.
-        getTelemetryPluginsMocked.mockImplementation((options, context) => {
-            const bundlerName = `${context.bundler.name}${context.bundler.variant || ''}`;
-            initialContexts[bundlerName] = JSON.parse(JSON.stringify(context));
-            return [];
-        });
-
-        // This one is called late in the build, with the final context.
-        uploadSourcemapsMocked.mockImplementation((options, context, log) => {
-            const bundlerName = `${context.bundler.name}${context.bundler.variant || ''}`;
-            lateContexts[bundlerName] = JSON.parse(JSON.stringify(context));
-            return Promise.resolve();
-        });
-
         const pluginConfig: Options = {
             ...defaultPluginOptions,
-            // TODO: Replace these with an injected custom plugins, once we implemented the feature.
-            telemetry: {},
-            rum: {
-                sourcemaps: getSourcemapsConfiguration(),
-            },
+            customPlugins: [
+                // Use a custom plugin to intercept contexts to verify it at the moment they're used.
+                (opts, context) => {
+                    const bundlerName = context.bundler.fullName;
+                    initialContexts[bundlerName] = JSON.parse(JSON.stringify(context));
+                    return [
+                        {
+                            name: 'custom-plugin',
+                            writeBundle() {
+                                lateContexts[bundlerName] = JSON.parse(JSON.stringify(context));
+                            },
+                        },
+                    ];
+                },
+            ],
         };
 
         await runBundlers(pluginConfig);


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Allowing the user to inject their own plugins in their configuration in order to leverage the shared context of our plugin.

### How?

<!-- A brief description of implementation details of this PR. -->

Add a new `customConfig` configuration.
More details in the [README](https://github.com/DataDog/build-plugins/blob/a95eea3a641bc751a934a26d680da5d55663a549/README.md#customplugins).
