### PR TITLE
[Internal] Injection plugin

### DIFF
--- a/packages/core/src/plugins/build-report/helpers.ts
+++ b/packages/core/src/plugins/build-report/helpers.ts
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { INJECTED_FILE } from '@dd/core/plugins/injection/constants';
 import type {
     BuildReport,
     SerializedEntry,
@@ -188,6 +189,9 @@ export const unserializeBuildReport = (report: SerializedBuildReport): BuildRepo
     };
 };
 
+// Is the file coming from the injection plugin?
+export const isInjection = (filename: string) => filename.includes(INJECTED_FILE);
+
 const BUNDLER_SPECIFICS = ['unknown', 'commonjsHelpers.js', 'vite/preload-helper.js'];
 // Make list of paths unique, remove the current file and particularities.
 export const cleanReport = <T = string>(
@@ -199,6 +203,8 @@ export const cleanReport = <T = string>(
     for (const reportFilepath of report) {
         const cleanedPath = cleanPath(reportFilepath);
         if (
+            // Don't add injections.
+            isInjection(reportFilepath) ||
             // Don't add itself into it.
             cleanedPath === filepath ||
             // Remove common specific files injected by bundlers.
@@ -237,6 +243,10 @@ export const cleanPath = (filepath: string) => {
 
 // Will only prepend the cwd if not already there.
 export const getAbsolutePath = (cwd: string, filepath: string) => {
+    if (isInjection(filepath)) {
+        return INJECTED_FILE;
+    }
+
     if (filepath.startsWith(cwd)) {
         return filepath;
     }
@@ -245,6 +255,10 @@ export const getAbsolutePath = (cwd: string, filepath: string) => {
 
 // Extract a name from a path based on the context (out dir and cwd).
 export const cleanName = (context: GlobalContext, filepath: string) => {
+    if (isInjection(filepath)) {
+        return INJECTED_FILE;
+    }
+
     if (filepath === 'unknown') {
         return filepath;
     }

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -2,11 +2,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { GlobalContext, Meta, Options, PluginOptions } from '@dd/core/types';
+import type { GlobalContext, Meta, Options, PluginOptions, ToInjectItem } from '@dd/core/types';
 
 import { getBuildReportPlugin } from './build-report';
 import { getBundlerReportPlugin } from './bundler-report';
 import { getGitPlugin } from './git';
+import { getInjectionPlugins } from './injection';
 
 export const getInternalPlugins = (
     options: Options,
@@ -16,6 +17,7 @@ export const getInternalPlugins = (
     const variant =
         meta.framework === 'webpack' ? (meta.webpack.compiler['webpack'] ? '5' : '4') : '';
 
+    const toInject: ToInjectItem[] = [];
     const globalContext: GlobalContext = {
         auth: options.auth,
         bundler: {
@@ -29,6 +31,9 @@ export const getInternalPlugins = (
             warnings: [],
         },
         cwd,
+        inject: (item: ToInjectItem) => {
+            toInject.push(item);
+        },
         start: Date.now(),
         version: meta.version,
     };
@@ -36,9 +41,10 @@ export const getInternalPlugins = (
     const bundlerReportPlugin = getBundlerReportPlugin(options, globalContext);
     const buildReportPlugin = getBuildReportPlugin(options, globalContext);
     const gitPlugin = getGitPlugin(options, globalContext);
+    const injectionPlugins = getInjectionPlugins(options, globalContext, toInject);
 
     return {
         globalContext,
-        internalPlugins: [bundlerReportPlugin, buildReportPlugin, gitPlugin],
+        internalPlugins: [bundlerReportPlugin, buildReportPlugin, gitPlugin, ...injectionPlugins],
     };
 };

--- a/packages/core/src/plugins/injection/constants.ts
+++ b/packages/core/src/plugins/injection/constants.ts
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+export const PREPARATION_PLUGIN_NAME = 'datadog-injection-preparation-plugin';
+export const PLUGIN_NAME = 'datadog-injection-plugin';
+export const RESOLUTION_PLUGIN_NAME = 'datadog-injection-resolution-plugin';
+export const INJECTED_FILE = '__DATADOG_INJECTION_STUB';
+export const DISTANT_FILE_RX = /^https?:\/\//;

--- a/packages/core/src/plugins/injection/helpers.ts
+++ b/packages/core/src/plugins/injection/helpers.ts
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { doRequest, truncateString } from '@dd/core/helpers';
+import type { Logger } from '@dd/core/log';
+import { getAbsolutePath } from '@dd/core/plugins/build-report/helpers';
+import type { ToInjectItem } from '@dd/core/types';
+import { readFile } from 'fs/promises';
+
+import { DISTANT_FILE_RX } from './constants';
+
+const MAX_TIMEOUT_IN_MS = 5000;
+
+export const processDistantFile = async (
+    item: ToInjectItem,
+    timeout: number = MAX_TIMEOUT_IN_MS,
+): Promise<string> => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    return Promise.race([
+        doRequest<string>({ url: item.value }).finally(() => {
+            if (timeout) {
+                clearTimeout(timeoutId);
+            }
+        }),
+        new Promise<string>((_, reject) => {
+            timeoutId = setTimeout(() => {
+                reject(new Error('Timeout'));
+            }, timeout);
+        }),
+    ]);
+};
+
+export const processLocalFile = async (item: ToInjectItem): Promise<string> => {
+    const absolutePath = getAbsolutePath(process.cwd(), item.value);
+    return readFile(absolutePath, { encoding: 'utf-8' });
+};
+
+export const processRawCode = async (item: ToInjectItem): Promise<string> => {
+    // TODO: Confirm the code actually executes without errors.
+    return item.value;
+};
+
+export const processItem = async (item: ToInjectItem, log: Logger): Promise<string> => {
+    let result: string;
+    try {
+        if (item.type === 'file') {
+            if (item.value.match(DISTANT_FILE_RX)) {
+                result = await processDistantFile(item);
+            } else {
+                result = await processLocalFile(item);
+            }
+        } else if (item.type === 'code') {
+            result = await processRawCode(item);
+        } else {
+            throw new Error(`Invalid item type "${item.type}", only accepts "code" or "file".`);
+        }
+    } catch (error: any) {
+        const itemId = `${item.type} - ${truncateString(item.value)}`;
+        if (item.fallback) {
+            // In case of any error, we'll fallback to next item in queue.
+            log(`Fallback for "${itemId}": ${error.toString()}`, 'warn');
+            result = await processItem(item.fallback, log);
+        } else {
+            // Or return an empty string.
+            log(`Failed "${itemId}": ${error.toString()}`, 'warn');
+            result = '';
+        }
+    }
+
+    return result;
+};
+
+export const processInjections = async (
+    toInject: ToInjectItem[],
+    log: Logger,
+): Promise<string[]> => {
+    const proms: (Promise<string> | string)[] = [];
+
+    for (const item of toInject) {
+        proms.push(processItem(item, log));
+    }
+
+    const results = await Promise.all(proms);
+    return results.filter(Boolean);
+};

--- a/packages/core/src/plugins/injection/index.ts
+++ b/packages/core/src/plugins/injection/index.ts
@@ -103,6 +103,7 @@ export const getInjectionPlugins = (
                                 context.bundler.variant === '5'
                                     ? { import: [INJECTED_FILE] }
                                     : INJECTED_FILE;
+                            return newEntry;
                         }
 
                         for (const entryName in originalEntry) {

--- a/packages/core/src/plugins/injection/index.ts
+++ b/packages/core/src/plugins/injection/index.ts
@@ -1,0 +1,153 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { getLogger } from '@dd/core/log';
+import type { GlobalContext, Options, PluginOptions, ToInjectItem } from '@dd/core/types';
+
+import {
+    INJECTED_FILE,
+    PLUGIN_NAME,
+    PREPARATION_PLUGIN_NAME,
+    RESOLUTION_PLUGIN_NAME,
+} from './constants';
+import { processInjections } from './helpers';
+
+export const getInjectionPlugins = (
+    opts: Options,
+    context: GlobalContext,
+    toInject: ToInjectItem[],
+): PluginOptions[] => {
+    const log = getLogger(opts.logLevel, PLUGIN_NAME);
+    const contentToInject: string[] = [];
+
+    const getContentToInject = () => {
+        contentToInject.unshift(
+            // Needs at least one element otherwise ESBuild will throw 'Do not know how to load path'.
+            // Most likely because it tries to generate an empty file.
+            `
+/********************************************/
+/* BEGIN INJECTION BY DATADOG BUILD PLUGINS */`,
+        );
+        contentToInject.push(`
+/*  END INJECTION BY DATADOG BUILD PLUGINS  */
+/********************************************/`);
+
+        return contentToInject.join('\n\n');
+    };
+
+    // Rollup uses its own banner hook
+    // and doesn't need to create a virtual INJECTED_FILE.
+    // We use its native functionality.
+    const rollupInjectionPlugin: PluginOptions['rollup'] = {
+        banner(chunk) {
+            if (chunk.isEntry) {
+                return getContentToInject();
+            }
+            return '';
+        },
+    };
+
+    // This plugin happens in 3 steps in order to cover all bundlers:
+    //   1. Prepare the content to inject, fetching distant/local files and anything necessary.
+    //   2. Inject a virtual file into the bundling, this file will be home of all injected content.
+    //   3. Resolve the virtual file, returning the prepared injected content.
+    return [
+        // Prepare and fetch the content to inject.
+        {
+            name: PREPARATION_PLUGIN_NAME,
+            enforce: 'pre',
+            // We use buildStart as it is the first async hook.
+            async buildStart() {
+                const results = await processInjections(toInject, log);
+                contentToInject.push(...results);
+            },
+        },
+        // Inject the virtual file that will be home of all injected content.
+        {
+            name: PLUGIN_NAME,
+            esbuild: {
+                setup(build) {
+                    const { initialOptions } = build;
+                    initialOptions.inject = initialOptions.inject || [];
+                    initialOptions.inject.push(INJECTED_FILE);
+                },
+            },
+            webpack: (compiler) => {
+                const injectEntry = (originalEntry: any) => {
+                    if (!originalEntry) {
+                        return [INJECTED_FILE];
+                    }
+
+                    if (Array.isArray(originalEntry)) {
+                        return [INJECTED_FILE, ...originalEntry];
+                    }
+
+                    if (typeof originalEntry === 'function') {
+                        return async () => {
+                            const originEntry = await originalEntry();
+                            return [INJECTED_FILE, originEntry];
+                        };
+                    }
+
+                    if (typeof originalEntry === 'string') {
+                        return [INJECTED_FILE, originalEntry];
+                    }
+
+                    // We need to adjust the existing entries to import our injected file.
+                    if (typeof originalEntry === 'object') {
+                        const newEntry: typeof originalEntry = {};
+                        if (Object.keys(originalEntry).length === 0) {
+                            newEntry[INJECTED_FILE] =
+                                // Webpack 4 and 5 have different entry formats.
+                                context.bundler.variant === '5'
+                                    ? { import: [INJECTED_FILE] }
+                                    : INJECTED_FILE;
+                        }
+
+                        for (const entryName in originalEntry) {
+                            if (!Object.hasOwn(originalEntry, entryName)) {
+                                continue;
+                            }
+                            const entry = originalEntry[entryName];
+                            newEntry[entryName] =
+                                // Webpack 4 and 5 have different entry formats.
+                                typeof entry === 'string'
+                                    ? [INJECTED_FILE, entry]
+                                    : {
+                                          ...entry,
+                                          import: [INJECTED_FILE, ...entry.import],
+                                      };
+                        }
+
+                        return newEntry;
+                    }
+
+                    return [INJECTED_FILE, originalEntry];
+                };
+
+                compiler.options.entry = injectEntry(compiler.options.entry);
+            },
+            rollup: rollupInjectionPlugin,
+            vite: rollupInjectionPlugin,
+        },
+        // Resolve the injected file.
+        {
+            name: RESOLUTION_PLUGIN_NAME,
+            enforce: 'post',
+            resolveId(id) {
+                if (id === INJECTED_FILE) {
+                    return { id, moduleSideEffects: true };
+                }
+            },
+            loadInclude(id) {
+                return id === INJECTED_FILE;
+            },
+            load(id) {
+                if (id === INJECTED_FILE) {
+                    return getContentToInject();
+                }
+            },
+        },
+    ];
+};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,8 +65,11 @@ export type BundlerReport = {
     variant?: string; // e.g. Major version of the bundler (webpack 4, webpack 5)
 };
 
+export type ToInjectItem = { type: 'file' | 'code'; value: string; fallback?: ToInjectItem };
+
 export type GlobalContext = {
     auth?: AuthOptions;
+    inject: (item: ToInjectItem) => void;
     bundler: BundlerReport;
     build: BuildReport;
     cwd: string;

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -31,6 +31,7 @@
         "@dd/core": "workspace:*",
         "@dd/telemetry-plugins": "workspace:*",
         "@rollup/plugin-commonjs": "25.0.7",
+        "glob": "11.0.0",
         "jest": "29.7.0",
         "ts-jest": "29.1.2"
     },

--- a/packages/tests/src/core/plugins/injection/helpers.test.ts
+++ b/packages/tests/src/core/plugins/injection/helpers.test.ts
@@ -1,0 +1,166 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { Logger } from '@dd/core/log';
+import {
+    processInjections,
+    processItem,
+    processLocalFile,
+    processDistantFile,
+} from '@dd/core/plugins/injection/helpers';
+import type { ToInjectItem } from '@dd/core/types';
+import { vol } from 'memfs';
+import nock from 'nock';
+import path from 'path';
+
+jest.mock('fs', () => require('memfs').fs);
+jest.mock('fs/promises', () => require('memfs').fs.promises);
+
+const localFileContent = 'local file content';
+const distantFileContent = 'distant file content';
+const codeContent = 'code content';
+
+const code: ToInjectItem = { type: 'code', value: codeContent };
+const existingFile: ToInjectItem = { type: 'file', value: 'fixtures/local-file.js' };
+const nonExistingFile: ToInjectItem = {
+    type: 'file',
+    value: 'fixtures/non-existing-file.js',
+};
+const existingDistantFile: ToInjectItem = {
+    type: 'file',
+    value: 'https://example.com/distant-file.js',
+};
+const nonExistingDistantFile: ToInjectItem = {
+    type: 'file',
+    value: 'https://example.com/non-existing-distant-file.js',
+};
+
+describe('Injection Plugin Helpers', () => {
+    const mockLogger: Logger = jest.fn();
+    let nockScope: nock.Scope;
+
+    beforeEach(() => {
+        nockScope = nock('https://example.com')
+            .get('/distant-file.js')
+            .reply(200, distantFileContent);
+        // Emulate some fixtures.
+        vol.fromJSON({
+            [existingFile.value]: localFileContent,
+        });
+    });
+
+    afterEach(() => {
+        vol.reset();
+    });
+
+    describe('processInjections', () => {
+        test('Should process injections without throwing.', async () => {
+            const items: ToInjectItem[] = [
+                code,
+                existingFile,
+                nonExistingFile,
+                existingDistantFile,
+                nonExistingDistantFile,
+            ];
+
+            const expectResult = expect(processInjections(items, mockLogger)).resolves;
+
+            await expectResult.not.toThrow();
+            await expectResult.toEqual([codeContent, localFileContent, distantFileContent]);
+
+            expect(nockScope.isDone()).toBe(true);
+        });
+    });
+
+    describe('processItem', () => {
+        test.each<{ description: string; item: ToInjectItem; expectation: string }>([
+            {
+                description: 'basic code',
+                expectation: codeContent,
+                item: code,
+            },
+            {
+                description: 'an existing file',
+                expectation: localFileContent,
+                item: existingFile,
+            },
+            {
+                description: 'a non existing file',
+                expectation: '',
+                item: nonExistingFile,
+            },
+            {
+                description: 'an existing distant file',
+                expectation: distantFileContent,
+                item: existingDistantFile,
+            },
+            {
+                description: 'a non existing distant file',
+                expectation: '',
+                item: nonExistingDistantFile,
+            },
+            {
+                description: 'failing fallbacks',
+                expectation: '',
+                item: {
+                    ...nonExistingDistantFile,
+                    fallback: nonExistingFile,
+                },
+            },
+            {
+                description: 'successful fallbacks',
+                expectation: codeContent,
+                item: {
+                    ...nonExistingDistantFile,
+                    fallback: {
+                        ...nonExistingFile,
+                        fallback: code,
+                    },
+                },
+            },
+        ])('Should process $description without throwing.', async ({ item, expectation }) => {
+            const expectResult = expect(processItem(item, mockLogger)).resolves;
+
+            await expectResult.not.toThrow();
+            await expectResult.toEqual(expectation);
+        });
+    });
+
+    describe('processLocalFile', () => {
+        test.each([
+            {
+                description: 'with a relative path',
+                value: './fixtures/local-file.js',
+                expectation: localFileContent,
+            },
+            {
+                description: 'with an absolute path',
+                value: path.join(process.cwd(), './fixtures/local-file.js'),
+                expectation: localFileContent,
+            },
+        ])('Should process local file $description.', async ({ value, expectation }) => {
+            const item: ToInjectItem = { type: 'file', value };
+            const expectResult = expect(processLocalFile(item)).resolves;
+
+            await expectResult.not.toThrow();
+            await expectResult.toEqual(expectation);
+        });
+    });
+
+    describe('processDistantFile', () => {
+        test('Should timeout after a given delay.', async () => {
+            nock('https://example.com')
+                .get('/delayed-distant-file.js')
+                .delay(10)
+                .reply(200, 'delayed distant file content');
+
+            const item: ToInjectItem = {
+                type: 'file',
+                value: 'https://example.com/delayed-distant-file.js',
+            };
+
+            await expect(processDistantFile(item, 1)).rejects.toThrow('Timeout');
+        });
+    });
+});

--- a/packages/tests/src/core/plugins/injection/index.test.ts
+++ b/packages/tests/src/core/plugins/injection/index.test.ts
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { Options } from '@dd/core/types';
+import { getComplexBuildOverrides } from '@dd/tests/helpers/mocks';
+import type { CleanupFn } from '@dd/tests/helpers/runBundlers';
+import { BUNDLERS, runBundlers } from '@dd/tests/helpers/runBundlers';
+import { readFileSync } from 'fs';
+import { glob } from 'glob';
+import nock from 'nock';
+import path from 'path';
+
+describe('Injection Plugin', () => {
+    const distantFileContent = 'console.log("Hello injection from distant file.");';
+    const localFileContent = 'console.log("Hello injection from local file.");';
+    const codeContent = 'console.log("Hello injection from code.");';
+    let outdirs: Record<string, string> = {};
+
+    const customPlugins: Options['customPlugins'] = (opts, context) => {
+        context.inject({
+            type: 'file',
+            value: 'https://example.com/distant-file.js',
+        });
+        context.inject({
+            type: 'file',
+            value: './src/fixtures/file-to-inject.js',
+        });
+        context.inject({
+            type: 'code',
+            value: codeContent,
+        });
+
+        return [
+            {
+                name: 'get-outdirs',
+                writeBundle() {
+                    // Store the seeded outdir to inspect the produced files.
+                    outdirs[context.bundler.fullName] = context.bundler.outDir;
+                },
+            },
+        ];
+    };
+
+    describe('Basic build', () => {
+        let nockScope: nock.Scope;
+        let cleanup: CleanupFn;
+
+        beforeAll(async () => {
+            nockScope = nock('https://example.com')
+                .get('/distant-file.js')
+                .times(BUNDLERS.length)
+                .reply(200, distantFileContent);
+
+            cleanup = await runBundlers({
+                customPlugins,
+            });
+        });
+
+        afterAll(async () => {
+            outdirs = {};
+            nock.cleanAll();
+            await cleanup();
+        });
+
+        test('Should have requested the distant file for each bundler.', () => {
+            expect(nockScope.isDone()).toBe(true);
+        });
+
+        describe.each(BUNDLERS)('$name | $version', ({ name }) => {
+            test.each([
+                { type: 'some string', content: codeContent },
+                { type: 'a local file', content: localFileContent },
+                { type: 'a distant file', content: distantFileContent },
+            ])('Should inject $type once.', ({ content }) => {
+                const files = glob.sync(path.resolve(outdirs[name], '*.js'));
+                const fullContent = files.map((file) => readFileSync(file, 'utf8')).join('\n');
+
+                // We have a single entry, so the content should be repeated only once.
+                expect(fullContent).toRepeatStringTimes(content, 1);
+            });
+        });
+    });
+
+    describe('Complex build', () => {
+        let nockScope: nock.Scope;
+        let cleanup: CleanupFn;
+
+        beforeAll(async () => {
+            nockScope = nock('https://example.com')
+                .get('/distant-file.js')
+                .times(BUNDLERS.length)
+                .reply(200, distantFileContent);
+
+            cleanup = await runBundlers(
+                {
+                    customPlugins,
+                },
+                getComplexBuildOverrides(),
+            );
+        });
+
+        afterAll(async () => {
+            outdirs = {};
+            nock.cleanAll();
+            await cleanup();
+        });
+
+        test('Should have requested the distant file for each bundler.', () => {
+            expect(nockScope.isDone()).toBe(true);
+        });
+
+        describe.each(BUNDLERS)('$name | $version', ({ name }) => {
+            test.each([
+                { type: 'some string', content: codeContent },
+                { type: 'a local file', content: localFileContent },
+                { type: 'a distant file', content: distantFileContent },
+            ])('Should inject $type.', ({ content }) => {
+                const files = glob.sync(path.resolve(outdirs[name], '*.js'));
+                const fullContent = files.map((file) => readFileSync(file, 'utf8')).join('\n');
+
+                // We don't know exactly how each bundler will concattenate the files.
+                // Since we have two entries here, we can expect the content
+                // to be repeated at least once and at most twice.
+                expect(fullContent).toRepeatStringRange(content, [1, 2]);
+            });
+        });
+    });
+});

--- a/packages/tests/src/fixtures/file-to-inject.js
+++ b/packages/tests/src/fixtures/file-to-inject.js
@@ -1,0 +1,5 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+console.log("Hello injection from local file.");

--- a/packages/tests/src/helpers/mocks.ts
+++ b/packages/tests/src/helpers/mocks.ts
@@ -39,6 +39,7 @@ export const getContextMock = (options: Partial<GlobalContext> = {}): GlobalCont
             errors: [],
         },
         cwd: '/cwd/path',
+        inject: jest.fn(),
         start: Date.now(),
         version: 'FAKE_VERSION',
         ...options,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,6 +1863,7 @@ __metadata:
     esbuild: "npm:0.21.5"
     faker: "npm:5.5.3"
     fs-extra: "npm:7.0.1"
+    glob: "npm:11.0.0"
     jest: "npm:29.7.0"
     memfs: "npm:4.9.2"
     nock: "npm:14.0.0-beta.7"


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Having a way to reliably prepend some code to the output bundle would be great.

It needs to:
 - support all the currently supported bundlers (webpack4-5, esbuild, rollup and vite).
 - be usable from anywhere within the ecosystem.
 - support local files, distant files and raw code.
 - not conflict with the existing plugins (build report in particular).

### How?

<!-- A brief description of implementation details of this PR. -->

Create a pretty simple injection plugin.

It's composed of 4 different elements:

- A `context.inject()` function you'd call to add a new item to inject.
- A preparation plugin, that resolves all the injections.
- A file injection plugin, that injects, within the bundle, a stub file where all the injections live (rollup is different, more on this later)
- A resolution plugin, that resolve the stub file.

> [!NOTE]
> Rollup and Vite are different because they offer the `banner` hook that works as expected OOTB.
> We couldn't use the Webpack's BannerPlugin because it doesn't gives you the information about the chunk being entry or not, which is critical if you want to inject something only once.

I have a follow-up PR with the documentation.