### PR TITLE
[fix] Remove webpack-sources from externals

### DIFF
--- a/packages/tools/src/rollupConfig.mjs
+++ b/packages/tools/src/rollupConfig.mjs
@@ -26,8 +26,6 @@ export const bundle = (config) => ({
         'esbuild',
         'vite',
         'rollup',
-        // These are external dependencies
-        'webpack-sources',
         // These should be internal only and never be anywhere published.
         '@dd/core',
         '@dd/tools',


### PR DESCRIPTION
This made our bundle require webpack-sources ALL THE TIME.

### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Adding `webpack-sources` as an external in rollup's config, makes it require the lib from the top.

<img width="1293" alt="image" src="https://github.com/user-attachments/assets/fd7889fa-5efa-4219-b2a8-c8cc88ac8cee">


### How?

<!-- A brief description of implementation details of this PR. -->

Remove the dependency from there, `webpack-sources` is an exception, because it's only loaded dynamically from unplugin's custom webpack/rspack loaders.
