### PR TITLE
[Logger] Simplify how we instantiate the logger in plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ datadogWebpackPlugin({
     auth?: {
         apiKey?: string;
     };
-    customPlugins?: (options: Options, context: GlobalContext) => UnpluginPlugin[];
+    customPlugins?: (options: Options, context: GlobalContext, log: Logger) => UnpluginPlugin[];
     logLevel?: 'debug' | 'info' | 'warn' | 'error' | 'none';
     rum?: {
         disabled?: boolean;
@@ -305,10 +305,10 @@ Or to prototype some new plugins in the same environment.
 
 ```typescript
 {
-    customPlugins: (options, context) => [{
+    customPlugins: (options, context, log) => [{
         name: 'my-custom-plugin',
         buildStart() {
-            console.log('Hello world');
+            log.info('Hello world');
         },
     }];
 }
@@ -372,7 +372,6 @@ type GlobalContext = {
         writeDuration?: number;
     };
     cwd: string;
-    getLogger: (name: string) => [Logger](/packages/factory/src/helpers.ts);
     // Added in `buildStart`.
     git?: {
         hash: string;

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Your function will receive three arguments:
 - `context`: The global context shared accross our plugin.
 - `log`: A [logger](/packages/factory/README.md#logger) to display messages.
 
-The `context` object is a shared object that is mutated during the build process. It contains the following properties:
+The `context` is a shared object that is mutated during the build process. It contains the following properties:
 
 <!-- #global-context-type -->
 ```typescript

--- a/README.md
+++ b/README.md
@@ -314,10 +314,13 @@ Or to prototype some new plugins in the same environment.
 }
 ```
 
-Your function will receive two arguments:
+Your function will receive three arguments:
 
 - `options`: The options you passed to the main plugin (including your custom plugins).
 - `context`: The global context shared accross our plugin.
+- `log`: A [logger](/packages/factory/README.md#logger) to display messages.
+
+The `context` object is a shared object that is mutated during the build process. It contains the following properties:
 
 <!-- #global-context-type -->
 ```typescript

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -76,6 +76,7 @@ export type ToInjectItem = { type: 'file' | 'code'; value: string; fallback?: To
 
 export type GetLogger = (name: string) => Logger;
 export type Logger = {
+    getLogger: GetLogger;
     error: (text: any) => void;
     warn: (text: any) => void;
     info: (text: any) => void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,20 +74,19 @@ export type BundlerReport = {
 
 export type ToInjectItem = { type: 'file' | 'code'; value: string; fallback?: ToInjectItem };
 
+export type GetLogger = (name: string) => Logger;
 export type Logger = {
     error: (text: any) => void;
     warn: (text: any) => void;
     info: (text: any) => void;
     debug: (text: any) => void;
 };
-export type GetLogger = (name: string) => Logger;
 export type GlobalContext = {
     auth?: AuthOptions;
     inject: (item: ToInjectItem) => void;
     bundler: BundlerReport;
     build: BuildReport;
     cwd: string;
-    getLogger: GetLogger;
     git?: RepositoryData;
     pluginNames: string[];
     start: number;
@@ -103,8 +102,12 @@ export type PluginOptions = UnpluginOptions & {
     name: PluginName;
 };
 
-export type GetPlugins<T> = (options: T, context: GlobalContext) => PluginOptions[];
-export type GetCustomPlugins = (options: Options, context: GlobalContext) => UnpluginOptions[];
+export type GetPlugins<T> = (options: T, context: GlobalContext, log: Logger) => PluginOptions[];
+export type GetCustomPlugins = (
+    options: Options,
+    context: GlobalContext,
+    log: Logger,
+) => UnpluginOptions[];
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'none';
 

--- a/packages/factory/README.md
+++ b/packages/factory/README.md
@@ -53,14 +53,15 @@ Most of the time they will interact via the global context.
 ## Logger
 
 If you need to log anything into the console you'll have to use the global Logger.
-Simply instantiate your logger in your plugin's initialization.
+Simply add it to your `getMyPlugins` function and run `yarn cli integrity` to update the factory.
 
 ```typescript
 // ./packages/plugins/my-plugin/index.ts
 [...]
 
-export const getMyPlugins = (context: GlobalContext) => {
-    const logger = context.getLogger('my-plugin');
+export const getMyPlugins = (context: GlobalContext, log: Logger) => {
+    log.debug('Welcome to my plugin');
+    [...]
 };
 ```
 
@@ -130,7 +131,6 @@ type GlobalContext = {
         writeDuration?: number;
     };
     cwd: string;
-    getLogger: (name: string) => [Logger](/packages/factory/src/helpers.ts);
     // Added in `buildStart`.
     git?: {
         hash: string;

--- a/packages/factory/README.md
+++ b/packages/factory/README.md
@@ -74,7 +74,7 @@ logger.info('This is an info');
 logger.debug('This is a debug message');
 ```
 
-You can also create "sub-logger" when you want to individually identify logs from a specific part of your plugin.<br/>
+You can also create a "sub-logger" when you want to individually identify logs from a specific part of your plugin.<br/>
 Simply use `log.getLogger('my-plugin')` for this:
 
 ```typescript

--- a/packages/factory/README.md
+++ b/packages/factory/README.md
@@ -74,6 +74,24 @@ logger.info('This is an info');
 logger.debug('This is a debug message');
 ```
 
+You can also create "sub-logger" when you want to individually identify logs from a specific part of your plugin.<br/>
+Simply use `log.getLogger('my-plugin')` for this:
+
+```typescript
+export const getMyPlugins = (context: GlobalContext, log: Logger) => {
+    log.debug('Welcome to the root of my plugin');
+    return [
+        {
+            name: 'my-plugin',
+            setup: (context: PluginContext) => {
+                const subLog = log.getLogger('my-plugin');
+                subLog.info('This is a debug message from one of my plugins.');
+            },
+        },
+    ];
+};
+```
+
 ## Global Context
 
 A global, shared context within the build plugins ecosystem.<br/>

--- a/packages/factory/src/helpers.ts
+++ b/packages/factory/src/helpers.ts
@@ -105,7 +105,6 @@ export const getContext = ({
         inject: (item: ToInjectItem) => {
             injections.push(item);
         },
-        getLogger: getLoggerFactory(build, options.logLevel),
         start: Date.now(),
         version,
     };

--- a/packages/factory/src/helpers.ts
+++ b/packages/factory/src/helpers.ts
@@ -63,6 +63,10 @@ export const getLoggerFactory =
         };
 
         return {
+            getLogger: (subName: string) => {
+                const logger = getLoggerFactory(build, logLevel);
+                return logger(`${name}:${subName}`);
+            },
             error: (text: any) => log(text, 'error'),
             warn: (text: any) => log(text, 'warn'),
             info: (text: any) => log(text, 'info'),

--- a/packages/plugins/build-report/src/index.ts
+++ b/packages/plugins/build-report/src/index.ts
@@ -2,16 +2,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { GlobalContext, PluginOptions } from '@dd/core/types';
+import type { GlobalContext, Logger, PluginOptions } from '@dd/core/types';
 
 import { getEsbuildPlugin } from './esbuild';
 import { getRollupPlugin } from './rollup';
 import { getWebpackPlugin } from './webpack';
 
-const PLUGIN_NAME = 'datadog-build-report-plugin';
+export const PLUGIN_NAME = 'datadog-build-report-plugin';
 
-export const getBuildReportPlugins = (context: GlobalContext): PluginOptions[] => {
-    const log = context.getLogger(PLUGIN_NAME);
+export const getBuildReportPlugins = (context: GlobalContext, log: Logger): PluginOptions[] => {
     return [
         {
             name: PLUGIN_NAME,

--- a/packages/plugins/bundler-report/src/index.ts
+++ b/packages/plugins/bundler-report/src/index.ts
@@ -5,7 +5,7 @@
 import type { GlobalContext, PluginOptions } from '@dd/core/types';
 import path from 'path';
 
-const PLUGIN_NAME = 'datadog-bundler-report-plugin';
+export const PLUGIN_NAME = 'datadog-bundler-report-plugin';
 
 const rollupPlugin: (context: GlobalContext) => PluginOptions['rollup'] = (context) => ({
     options(options) {

--- a/packages/plugins/git/src/index.ts
+++ b/packages/plugins/git/src/index.ts
@@ -6,10 +6,12 @@ import type { GlobalContext, Options, PluginOptions } from '@dd/core/types';
 
 import { getRepositoryData, newSimpleGit } from './helpers';
 
+export const PLUGIN_NAME = 'datadog-git-plugin';
+
 export const getGitPlugins = (options: Options, context: GlobalContext): PluginOptions[] => {
     return [
         {
-            name: 'datadog-git-plugin',
+            name: PLUGIN_NAME,
             enforce: 'pre',
             async buildStart() {
                 // Verify that we should get the git information based on the options.

--- a/packages/plugins/injection/src/index.ts
+++ b/packages/plugins/injection/src/index.ts
@@ -4,19 +4,21 @@
 
 import { INJECTED_FILE } from '@dd/core/constants';
 import { outputFile, rm } from '@dd/core/helpers';
-import type { GlobalContext, PluginOptions, ToInjectItem } from '@dd/core/types';
+import type { GlobalContext, Logger, PluginOptions, ToInjectItem } from '@dd/core/types';
 import fs from 'fs';
 import path from 'path';
 
 import { PLUGIN_NAME, PREPARATION_PLUGIN_NAME } from './constants';
 import { processInjections } from './helpers';
 
+export { PLUGIN_NAME } from './constants';
+
 export const getInjectionPlugins = (
     bundler: any,
     context: GlobalContext,
     toInject: ToInjectItem[],
+    log: Logger,
 ): PluginOptions[] => {
-    const log = context.getLogger(PLUGIN_NAME);
     const contentToInject: string[] = [];
 
     const getContentToInject = () => {

--- a/packages/plugins/rum/src/index.ts
+++ b/packages/plugins/rum/src/index.ts
@@ -2,9 +2,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { GlobalContext, GetPlugins } from '@dd/core/types';
+import type { GlobalContext, GetPlugins, Logger } from '@dd/core/types';
 
-import { PLUGIN_NAME } from './constants';
 import { uploadSourcemaps } from './sourcemaps';
 import type { OptionsWithRum, RumOptions, RumOptionsWithSourcemaps } from './types';
 import { validateOptions } from './validate';
@@ -20,8 +19,8 @@ export type types = {
 export const getPlugins: GetPlugins<OptionsWithRum> = (
     opts: OptionsWithRum,
     context: GlobalContext,
+    log: Logger,
 ) => {
-    const log = context.getLogger(PLUGIN_NAME);
     // Verify configuration.
     const rumOptions = validateOptions(opts, log);
     return [

--- a/packages/plugins/telemetry/src/index.ts
+++ b/packages/plugins/telemetry/src/index.ts
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { GlobalContext, GetPlugins, PluginOptions } from '@dd/core/types';
+import type { GlobalContext, GetPlugins, PluginOptions, Logger } from '@dd/core/types';
 
 import { getMetrics } from './common/aggregator';
 import { defaultFilters } from './common/filters';
@@ -36,6 +36,7 @@ export type types = {
 export const getPlugins: GetPlugins<OptionsWithTelemetry> = (
     options: OptionsWithTelemetry,
     context: GlobalContext,
+    logger: Logger,
 ) => {
     let realBuildEnd: number = 0;
     const bundlerContext: BundlerContext = {
@@ -43,7 +44,6 @@ export const getPlugins: GetPlugins<OptionsWithTelemetry> = (
     };
 
     const telemetryOptions = validateOptions(options);
-    const logger = context.getLogger(PLUGIN_NAME);
     const plugins: PluginOptions[] = [];
 
     // Webpack and Esbuild specific plugins.

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -79,7 +79,6 @@ export const getContextMock = (options: Partial<GlobalContext> = {}): GlobalCont
         },
         cwd: '/cwd/path',
         inject: jest.fn(),
-        getLogger: jest.fn(() => mockLogger),
         pluginNames: [],
         start: Date.now(),
         version: 'FAKE_VERSION',

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -48,6 +48,7 @@ export const defaultPluginOptions: GetPluginsOptions = {
 
 export const mockLogFn = jest.fn((text: any, level: LogLevel) => {});
 const logFn: Logger = {
+    getLogger: jest.fn(),
     error: (text: any) => {
         mockLogFn(text, 'error');
     },

--- a/packages/tests/src/factory/helpers.test.ts
+++ b/packages/tests/src/factory/helpers.test.ts
@@ -37,7 +37,6 @@ describe('Factory Helpers', () => {
                 initialContexts[bundlerName] = JSON.parse(JSON.stringify(context));
 
                 // These are functions, so they can't be serialized with parse/stringify.
-                initialContexts[bundlerName].getLogger = context.getLogger;
                 initialContexts[bundlerName].inject = context.inject;
 
                 return [];
@@ -64,7 +63,6 @@ describe('Factory Helpers', () => {
                 expect(context.bundler.version).toBe(BUNDLER_VERSIONS[name]);
                 expect(context.cwd).toBe(process.cwd());
                 expect(context.version).toBe(version);
-                expect(context.getLogger).toEqual(expect.any(Function));
                 expect(context.inject).toEqual(expect.any(Function));
             });
         });
@@ -81,23 +79,6 @@ describe('Factory Helpers', () => {
             const injectedItem: ToInjectItem = { type: 'code', value: 'injected' };
             context.inject(injectedItem);
             expect(injections).toEqual([injectedItem]);
-        });
-
-        test('Should return a logger.', () => {
-            const context = getContext({
-                options: defaultPluginOptions,
-                bundlerName: 'webpack',
-                bundlerVersion: '1.0.0',
-                injections: [],
-                version: '1.0.0',
-            });
-
-            const logger = context.getLogger('testLogger');
-
-            expect(logger.error).toEqual(expect.any(Function));
-            expect(logger.warn).toEqual(expect.any(Function));
-            expect(logger.info).toEqual(expect.any(Function));
-            expect(logger.debug).toEqual(expect.any(Function));
         });
     });
 

--- a/packages/tools/src/commands/integrity/files.ts
+++ b/packages/tools/src/commands/integrity/files.ts
@@ -62,12 +62,13 @@ const updateCore = (plugins: Workspace[]) => {
 };
 
 // Deduct the right param that can be used when calling an internal plugin.
-const getParam = (param: string) => {
+const getParam = (param: string, pluginName?: string) => {
     const aliases: [string, string[]][] = [
         ['options', ['opts']],
         ['context', ['ctx', 'globalContext']],
         ['bundler', []],
         ['injections', ['toInject']],
+        [`getLogger('${pluginName || 'datadog-plugin'}')`, ['log', 'logger']],
     ];
 
     const foundAlias = aliases.find(([name, alias]) => {
@@ -133,7 +134,7 @@ const updateFactory = async (plugins: Workspace[]) => {
             const paramsString = params
                 // Replace them with the ones we have available in the factory.
                 .map((param: string) => {
-                    const finalParam = getParam(param);
+                    const finalParam = getParam(param, require(plugin.name).PLUGIN_NAME);
                     if (!finalParam) {
                         errors.push(
                             `[${error}] Missing parameter for ${green(param)} in ${green(
@@ -159,7 +160,7 @@ const updateFactory = async (plugins: Workspace[]) => {
             typesExportContent += `export type { types as ${pascalCase}Types } from '${plugin.name}';`;
             configContent += outdent`
                 if (options[${configKeyVar}] && options[${configKeyVar}].disabled !== true) {
-                    plugins.push(...${camelCase}.getPlugins(options as OptionsWith${pascalCase}, context));
+                    plugins.push(...${camelCase}.getPlugins(options as OptionsWith${pascalCase}, context, getLogger(${camelCase}.PLUGIN_NAME)));
                 }
             `;
 

--- a/packages/tools/src/helpers.ts
+++ b/packages/tools/src/helpers.ts
@@ -110,17 +110,22 @@ export const runAutoFixes = async () => {
     return errors;
 };
 
-export const getWorkspaces = async (filter?: (workspace: SlugLessWorkspace) => boolean) => {
+export const getWorkspaces = async (
+    filter?: (workspace: SlugLessWorkspace) => boolean,
+): Promise<Workspace[]> => {
     const { stdout: rawWorkspaces } = await execute('yarn', ['workspaces', 'list', '--json']);
     // Replace new lines with commas to make it JSON valid.
     const jsonString = `[${rawWorkspaces.replace(/\n([^\]])/g, ',\n$1')}]`;
     const workspacesArray = JSON.parse(jsonString) as SlugLessWorkspace[];
     return workspacesArray
         .filter((workspace: SlugLessWorkspace) => (filter ? filter(workspace) : true))
-        .map((workspace: SlugLessWorkspace) => ({
-            ...workspace,
-            slug: workspace.location.split('/').pop() as string,
-        }));
+        .map((workspace: SlugLessWorkspace) => {
+            const plugin: Workspace = {
+                ...workspace,
+                slug: workspace.location.split('/').pop() as string,
+            };
+            return plugin;
+        });
 };
 
 // TODO: Update this, it's a bit hacky.

--- a/packages/tools/src/helpers.ts
+++ b/packages/tools/src/helpers.ts
@@ -151,14 +151,11 @@ export const getSupportedBundlers = (getPlugins: GetPlugins<any>) => {
                 errors: [],
                 logs: [],
             },
-            getLogger() {
-                const fn = () => {};
-                // We don't care about the logger here.
-                return fn as unknown as Logger;
-            },
             inject() {},
             pluginNames: [],
         },
+        // We don't care about the logger here.
+        {} as unknown as Logger,
     );
 
     const bundlerSpecifics = [];


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Logger requires the plugin itself to instantiate its logger, so it may do it with any name it wants.

We'd need to keep control over how we display logs from other plugins in the ecosystem.

### How?

<!-- A brief description of implementation details of this PR. -->

- Pass down an already instantiated logger to all the plugins.
- Allow plugins to create "sub-logger" if they need more granularity on what to log from sub systems.
- Enforce all plugins to export their `PLUGIN_NAME` (using `yarn cli integrity`).
- Add tests.
