### PR TITLE
[dx] Add dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "build:all": "yarn loop run build",
         "clean:all": "yarn loop run clean",
         "cli": "yarn workspace @dd/tools cli",
-        "dev": "yarn cli prepare-link && yarn watch:all || yarn cli prepare-link --revert",
+        "dev": "yarn cli prepare-link && yarn watch:all; yarn cli prepare-link --revert",
         "format": "yarn lint --fix",
         "lint": "eslint ./packages/**/*.{ts,js} --quiet",
         "loop": "yarn workspaces foreach -Apti --include \"@datadog/*\" --exclude \"@datadog/build-plugins\"",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "build:all": "yarn loop run build",
         "clean:all": "yarn loop run clean",
         "cli": "yarn workspace @dd/tools cli",
+        "dev": "yarn cli prepare-link && yarn watch:all || yarn cli prepare-link --revert",
         "format": "yarn lint --fix",
         "lint": "eslint ./packages/**/*.{ts,js} --quiet",
         "loop": "yarn workspaces foreach -Apti --include \"@datadog/*\" --exclude \"@datadog/build-plugins\"",

--- a/packages/tools/src/commands/prepare-link/index.ts
+++ b/packages/tools/src/commands/prepare-link/index.ts
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+import { Command, Option } from 'clipanion';
+import fs from 'fs';
+import path from 'path';
+
+class PrepareLink extends Command {
+    static paths = [['prepare-link']];
+
+    static usage = Command.Usage({
+        category: `Contribution`,
+        description: `Prepare our published packages to be linked from another project.`,
+        details: `
+            This command will change the package.json values of "exports" so they can be used from another project.
+
+            This is necessary to be sure that the outside project loads the built files and not the dev files.
+        `,
+        examples: [
+            [`Prepare for link`, `$0 prepare-link`],
+            [`Revert change`, `$0 prepare-link --revert`],
+        ],
+    });
+
+    revert = Option.Boolean('--revert', {
+        description: 'Revert the changes.',
+    });
+
+    async execute() {
+        const { getWorkspaces, green, red } = await import('@dd/tools/helpers');
+        const { ROOT } = await import('@dd/tools/constants');
+
+        const workspaces = await getWorkspaces();
+
+        // Only get the published packages.
+        const publishedPackages = workspaces.filter((workspace) =>
+            workspace.name.match(/^@datadog\/.*-plugin$/),
+        );
+
+        try {
+            for (const pkg of publishedPackages) {
+                const pkgJsonPath = path.resolve(ROOT, pkg.location, 'package.json');
+                const pkgJson = require(pkgJsonPath);
+                if (this.revert) {
+                    pkgJson.exports = { '.': './src/index.ts' };
+                } else {
+                    pkgJson.exports = pkgJson.publishConfig.exports;
+                }
+
+                fs.writeFileSync(pkgJsonPath, `${JSON.stringify(pkgJson, null, 4)}\n`);
+            }
+
+            console.log(
+                green(
+                    `All packages have been ${this.revert ? 'restored from linking.' : 'prepared for linking.'}`,
+                ),
+            );
+        } catch (error: any) {
+            console.error(red(error));
+        }
+    }
+}
+
+export default [PrepareLink];

--- a/packages/tools/src/commands/prepare-link/index.ts
+++ b/packages/tools/src/commands/prepare-link/index.ts
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
+
 import { Command, Option } from 'clipanion';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

This is annoying to test integration in external projects using `yarn link`.

### How?

<!-- A brief description of implementation details of this PR. -->

Create a `yarn dev` workflow:

1. Prepare the published packages to be linked by changing their `exports` value so it exports built files.
2. Launch `yarn watch:all` to rebuild anything that changes
3. Once done, it revert the package.json changes.
