### PR TITLE
[types] Fix exported type of Options

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Datadog
+Copyright (c) 2025 Datadog
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Datadog build-plugins
-Copyright 2024-present Datadog, Inc.
+Copyright 2025-present Datadog, Inc.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/packages/published/esbuild-plugin/src/index.ts
+++ b/packages/published/esbuild-plugin/src/index.ts
@@ -6,6 +6,7 @@
 // Anything between #types-export-injection-marker
 // will be updated using the 'yarn cli integrity' command.
 
+import type { Options } from '@dd/core/types';
 import * as factory from '@dd/factory';
 import esbuild from 'esbuild';
 
@@ -16,7 +17,7 @@ export const datadogEsbuildPlugin = factory.buildPluginFactory({
     version: pkg.version,
 }).esbuild;
 
-export type { Options as EsbuildPluginOptions } from '@dd/core/types';
+export type EsbuildPluginOptions = Options;
 
 export type {
     // #types-export-injection-marker

--- a/packages/published/rollup-plugin/src/index.ts
+++ b/packages/published/rollup-plugin/src/index.ts
@@ -6,6 +6,7 @@
 // Anything between #types-export-injection-marker
 // will be updated using the 'yarn cli integrity' command.
 
+import type { Options } from '@dd/core/types';
 import * as factory from '@dd/factory';
 import rollup from 'rollup';
 
@@ -16,7 +17,7 @@ export const datadogRollupPlugin = factory.buildPluginFactory({
     version: pkg.version,
 }).rollup;
 
-export type { Options as RollupPluginOptions } from '@dd/core/types';
+export type RollupPluginOptions = Options;
 
 export type {
     // #types-export-injection-marker

--- a/packages/published/rspack-plugin/src/index.ts
+++ b/packages/published/rspack-plugin/src/index.ts
@@ -6,6 +6,7 @@
 // Anything between #types-export-injection-marker
 // will be updated using the 'yarn cli integrity' command.
 
+import type { Options } from '@dd/core/types';
 import * as factory from '@dd/factory';
 import rspack from '@rspack/core';
 
@@ -16,7 +17,7 @@ export const datadogRspackPlugin = factory.buildPluginFactory({
     version: pkg.version,
 }).rspack;
 
-export type { Options as RspackPluginOptions } from '@dd/core/types';
+export type RspackPluginOptions = Options;
 
 export type {
     // #types-export-injection-marker

--- a/packages/published/vite-plugin/src/index.ts
+++ b/packages/published/vite-plugin/src/index.ts
@@ -6,6 +6,7 @@
 // Anything between #types-export-injection-marker
 // will be updated using the 'yarn cli integrity' command.
 
+import type { Options } from '@dd/core/types';
 import * as factory from '@dd/factory';
 import vite from 'vite';
 
@@ -16,7 +17,7 @@ export const datadogVitePlugin = factory.buildPluginFactory({
     version: pkg.version,
 }).vite;
 
-export type { Options as VitePluginOptions } from '@dd/core/types';
+export type VitePluginOptions = Options;
 
 export type {
     // #types-export-injection-marker

--- a/packages/published/webpack-plugin/src/index.ts
+++ b/packages/published/webpack-plugin/src/index.ts
@@ -6,6 +6,7 @@
 // Anything between #types-export-injection-marker
 // will be updated using the 'yarn cli integrity' command.
 
+import type { Options } from '@dd/core/types';
 import * as factory from '@dd/factory';
 import webpack from 'webpack';
 
@@ -16,7 +17,7 @@ export const datadogWebpackPlugin = factory.buildPluginFactory({
     version: pkg.version,
 }).webpack;
 
-export type { Options as WebpackPluginOptions } from '@dd/core/types';
+export type WebpackPluginOptions = Options;
 
 export type {
     // #types-export-injection-marker


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

https://github.com/DataDog/build-plugins/issues/126

### How?

<!-- A brief description of implementation details of this PR. -->

Seems like rollup's `dts` plugin doesn't navigate through an `export [...] from [...]`.

Fix #126 
