### PR TITLE
[ci] Release process update

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,43 @@
+name: Bump the versions
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'What to bump?'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - 'patch'
+        - 'minor'
+        - 'major'
+
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Needed for "yarn version" to work.
+        token: ${{ secrets.DD_INFRA_BOT_GH_ACTIONS_TOKEN }} # Needed for the push at the end of the action.
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: 'package.json'
+
+    - run: yarn install
+    - run: yarn version:all ${{ inputs.version }}
+    - run: git add .
+    - run: |
+        TAG_NAME="v$(yarn workspace @datadog/webpack-plugin info @datadog/webpack-plugin --json | jq -r '.children.Version')"
+        GIT_AUTHOR_NAME='dd-infra-bot',
+        GIT_COMMITTER_NAME='dd-infra-bot',
+        GIT_AUTHOR_EMAIL='robot-github-mergequeue@datadoghq.com',
+        GIT_COMMITTER_EMAIL='robot-github-mergequeue@datadoghq.com',
+
+        git config --global user.email $GIT_AUTHOR_EMAIL
+        git config --global user.name $GIT_AUTHOR_NAME
+
+        git commit -m $TAG_NAME
+        git tag -a $TAG_NAME -m $TAG_NAME
+        git push --follow-tags

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,13 +5,14 @@ on:
   workflow_dispatch: {} # Allow for manual trigger.
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version-file: 'package.json'
+
     - run: yarn config set npmAuthToken $YARN_NPM_AUTH_TOKEN
       env:
         YARN_NPM_AUTH_TOKEN: ${{ secrets.PUBLISH_NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
         "dev": "yarn cli prepare-link && yarn watch:all; yarn cli prepare-link --revert",
         "format": "yarn lint --fix",
         "lint": "eslint ./packages/**/*.{ts,js} --quiet",
-        "loop": "yarn workspaces foreach -Apti --include \"@datadog/*\" --exclude \"@datadog/build-plugins\"",
+        "loop-published": "yarn workspaces foreach -A --include \"@datadog/*\" --exclude \"@datadog/build-plugins\"",
+        "loop": "yarn loop-published -pti",
         "oss": "yarn cli oss -d packages -l mit",
         "publish:all": "yarn loop --no-private npm publish",
         "typecheck:all": "yarn workspaces foreach -Apti run typecheck",
-        "version:all": "yarn loop version --deferred ${0} && yarn version apply --all",
+        "version:all": "yarn loop-published version ${0} --immediate",
         "watch:all": "yarn loop run watch"
     },
     "husky": {


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Having a way to manually bump the versions without checking out `master` would be great.

### How?

<!-- A brief description of implementation details of this PR. -->

- Add a new `bump` action.
  1. run `yarn version:all <patch|minor|major>` based on the input of the workflow dispatch.
  2. commit the diff in `v<new_version>`.
  3. tag the commit with `v<new_version>`. 

[Successful run.](https://github.com/DataDog/build-plugins/actions/runs/13418889087/job/37486473979)