### PR TITLE
[log] Add tags and mocks to span logger

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,7 +45,8 @@ export type SerializedOutput = Assign<Output, { inputs: string[] }>;
 export type Timer = {
     label: string;
     pluginName: string;
-    spans: { start: number; end?: number }[];
+    spans: { start: number; end?: number; tags?: string[] }[];
+    tags: string[];
     total: number;
     logLevel: LogLevel;
 };
@@ -109,12 +110,13 @@ export type TimeLogger = {
     resume: () => void;
     end: () => void;
     pause: () => void;
+    tag: (tags: string[], opts?: { span?: boolean }) => void;
 };
 
 // The rest parameter is a LogLevel or a boolean to auto start the timer.
 export type TimeLog = (
     label: string,
-    opts?: { level?: LogLevel; start?: boolean; log?: boolean },
+    opts?: { level?: LogLevel; start?: boolean; log?: boolean; tags?: string[] },
 ) => TimeLogger;
 export type GetLogger = (name: string) => Logger;
 export type Logger = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -105,6 +105,7 @@ export type ToInjectItem = {
 };
 
 export type TimeLogger = {
+    timer: Timer;
     resume: () => void;
     end: () => void;
     pause: () => void;

--- a/packages/factory/README.md
+++ b/packages/factory/README.md
@@ -147,12 +147,14 @@ timer.end();
 - `start`: Whether to start the timer immediately. Defaults to `true`.
 - `log`: Whether to log the timer. Defaults to `true`.
 - `level`: The log level to use. Defaults to `debug`.
+- `tags`: Initial tags to associate with the timer. Defaults to `[]`.
 
 ```typescript
 {
     start: boolean,
     log: boolean,
     level: LogLevel,
+    tags: string[]
 }
 ```
 
@@ -168,10 +170,28 @@ timer.resume();
 timer.end();
 ```
 
+Add tags to the timer or to active spans.
+
+```typescript
+// Add tags to the entire timer
+timer.tag(['feature:upload', 'operation:compress']);
+
+// Add tags to the current active span only
+timer.tag(['step:initialize'], { span: true });
+```
+
 Use it with a specific log level.
 
 ```typescript
 const timer = log.time('my-task', { level: 'error' });
+// [... do stuff ...]
+timer.end();
+```
+
+Initialize with tags.
+
+```typescript
+const timer = log.time('my-task', { tags: ['type:report', 'priority:high'] });
 // [... do stuff ...]
 timer.end();
 ```
@@ -206,10 +226,13 @@ All the timers will be reported in `context.build.timings`, with all their spans
             "spans": [
                 {
                     "start": 1715438400000,
-                    "end": 1715438401000
+                    "end": 1715438401000,
+                    "tags": ["step:initialize"]
                 }
             ],
-            "total": 1000
+            "tags": ["feature:upload", "operation:compress"],
+            "total": 1000,
+            "logLevel": "debug"
         }
     ]
 }

--- a/packages/factory/src/helpers/logger.test.ts
+++ b/packages/factory/src/helpers/logger.test.ts
@@ -216,11 +216,30 @@ describe('logger', () => {
                             end: expect.any(Number),
                         },
                     ],
+                    tags: [],
                     total: 300,
                     logLevel: 'debug',
                 });
                 expect(timing.spans[0].end! - timing.spans[0].start).toBe(100);
                 expect(timing.spans[1].end! - timing.spans[1].start).toBe(200);
+            });
+
+            test('Should tag the timer.', () => {
+                const [logger] = setupLogger('testLogger');
+                const timer = logger.time('test time 1');
+                timer.tag(['tag1', 'tag2']);
+                timer.end();
+
+                expect(timer.timer.tags).toEqual(['tag1', 'tag2']);
+            });
+
+            test('Should tag the spans.', () => {
+                const [logger] = setupLogger('testLogger');
+                const timer = logger.time('test time 1');
+                timer.tag(['tag1', 'tag2'], { span: true });
+                timer.end();
+
+                expect(timer.timer.spans[0].tags).toEqual(['tag1', 'tag2']);
             });
         });
 

--- a/packages/factory/src/helpers/logger.ts
+++ b/packages/factory/src/helpers/logger.ts
@@ -81,6 +81,9 @@ export const getLoggerFactory =
                 total: 0,
             };
 
+            // Add it to the build report.
+            build.timings.push(timer);
+
             const getUncompleteSpans = () => timer.spans.filter((span) => !span.end);
 
             // Push a new span.
@@ -121,9 +124,6 @@ export const getLoggerFactory =
                 if (toLog) {
                     log(`[${c.cyan(label)}] : ${c.cyan(formatDuration(duration))}`, level);
                 }
-
-                // Add it to the build report.
-                build.timings.push(timer);
             };
 
             // Add a tag to the timer or the ongoing spans.

--- a/packages/factory/src/helpers/logger.ts
+++ b/packages/factory/src/helpers/logger.ts
@@ -3,7 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { formatDuration } from '@dd/core/helpers/strings';
-import type { BuildReport, GetLogger, LogLevel, TimeLog, Timer } from '@dd/core/types';
+import type { BuildReport, GetLogger, LogLevel, TimeLog, TimeLogger, Timer } from '@dd/core/types';
 import c from 'chalk';
 
 const logPriority: Record<LogLevel, number> = {
@@ -128,11 +128,14 @@ export const getLoggerFactory =
                 resume();
             }
 
-            return {
+            const timeLogger: TimeLogger = {
+                timer,
                 resume,
                 end,
                 pause,
             };
+
+            return timeLogger;
         };
 
         return {

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -13,6 +13,7 @@ import type {
     LogLevel,
     Options,
     RepositoryData,
+    TimeLogger,
 } from '@dd/core/types';
 import type {
     Metadata,
@@ -56,21 +57,24 @@ export const defaultPluginOptions: GetPluginsOptions = {
     logLevel: 'debug',
 };
 
+export const mockTimer: TimeLogger = {
+    timer: {
+        label: 'span logger',
+        pluginName: 'my-plugin',
+        spans: [],
+        tags: [],
+        total: 0,
+        logLevel: 'debug',
+    },
+    end: jest.fn(),
+    resume: jest.fn(),
+    pause: jest.fn(),
+    tag: jest.fn(),
+};
 export const mockLogFn = jest.fn((text: any, level: LogLevel) => {});
-const logFn: Logger = {
+export const mockLogger: Logger = {
     getLogger: jest.fn(),
-    time: () => ({
-        timer: {
-            label: 'span logger',
-            pluginName: 'my-plugin',
-            spans: [],
-            total: 0,
-            logLevel: 'debug',
-        },
-        end: jest.fn(),
-        resume: jest.fn(),
-        pause: jest.fn(),
-    }),
+    time: () => mockTimer,
     error: (text: any) => {
         mockLogFn(text, 'error');
     },
@@ -84,7 +88,6 @@ const logFn: Logger = {
         mockLogFn(text, 'debug');
     },
 };
-export const mockLogger: Logger = logFn;
 
 export const getEsbuildMock = (overrides: Partial<PluginBuild> = {}): PluginBuild => {
     return {

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -60,6 +60,13 @@ export const mockLogFn = jest.fn((text: any, level: LogLevel) => {});
 const logFn: Logger = {
     getLogger: jest.fn(),
     time: () => ({
+        timer: {
+            label: 'span logger',
+            pluginName: 'my-plugin',
+            spans: [],
+            total: 0,
+            logLevel: 'debug',
+        },
         end: jest.fn(),
         resume: jest.fn(),
         pause: jest.fn(),


### PR DESCRIPTION
### What and why?

To improve observability and provide richer insights into build performance, this PR enhances the span logger with tagging capabilities. 

This allows us to attach contextual information to each span and/or timer, making debugging and performance analysis more granular (also better prepared for DD submission). 

Additionally, streamlined mock implementations are added to improve testing of the logging functionality.

### How?

- Modified the span logger to return timer object for more flexible usage
- Added tagging capabilities to the time logger to annotate spans with contextual metadata
- Integrated timer into the build report sooner in the process
- Streamlined mock implementations to simplify and strengthen testing

### PR Stack Hierarchy
> This project adds automated performance profiling to build plugins by standardizing plugin naming, enhancing logging capabilities, and refactoring the plugin initialization system to provide detailed execution insights without manual instrumentation.

1. **#156**
1. **#157**
1. **👉 #158**
1. **#159**
1. **#154**