### PR TITLE
[internal] Update, fix and extract `cleanPluginName`

### DIFF
--- a/packages/core/src/helpers/plugins.test.ts
+++ b/packages/core/src/helpers/plugins.test.ts
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { INJECTED_FILE } from '@dd/core/constants';
+
+import { cleanPluginName, isInjectionFile } from './plugins';
+
+describe('plugins', () => {
+    describe('cleanPluginName', () => {
+        test.each([
+            {
+                description: 'remove datadog- prefix',
+                input: 'datadog-awesome-stuff',
+                result: 'awesome-stuff',
+            },
+            {
+                description: 'remove @dd/ prefix',
+                input: '@dd/awesome-stuff',
+                result: 'awesome-stuff',
+            },
+            {
+                description: 'remove -plugin suffix',
+                input: 'awesome-plugin',
+                result: 'awesome',
+            },
+            {
+                description: 'remove prefix and suffix',
+                input: 'datadog-awesome-plugin',
+                result: 'awesome',
+            },
+            {
+                description: 'handle multiple patterns',
+                input: '@dd/datadog-awesome-plugin',
+                result: 'awesome',
+            },
+            {
+                description: 'handle multiple patterns',
+                input: '@dd/internal-awesome-plugin',
+                result: 'awesome',
+            },
+            {
+                description: 'return the name unchanged if no patterns match',
+                input: 'regular-name',
+                result: 'regular-name',
+            },
+        ])('Should $description', ({ input, result }) => {
+            expect(cleanPluginName(input)).toBe(result);
+        });
+    });
+
+    describe('isInjectionFile', () => {
+        test.each([
+            {
+                description: 'true with INJECTED_FILE in the middle',
+                input: `path/to/${INJECTED_FILE}/file.js`,
+                result: true,
+            },
+            {
+                description: 'true with INJECTED_FILE at the beginning',
+                input: `${INJECTED_FILE}/something`,
+                result: true,
+            },
+            {
+                description: 'true with INJECTED_FILE at the end',
+                input: `path/to/${INJECTED_FILE}`,
+                result: true,
+            },
+            {
+                description: 'false with no INJECTED_FILE',
+                input: 'path/to/regular-file.js',
+                result: false,
+            },
+            {
+                description: 'return false for empty string',
+                input: '',
+                result: false,
+            },
+        ])('Should $description', ({ input, result }) => {
+            expect(isInjectionFile(input)).toBe(result);
+        });
+    });
+});

--- a/packages/core/src/helpers/plugins.ts
+++ b/packages/core/src/helpers/plugins.ts
@@ -21,7 +21,8 @@ import type {
 import path from 'path';
 
 export const cleanPluginName = (name: string) => {
-    return name.replace(/^@dd\/(datadog-|internal-|)|^datadog-|-plugin$/g, '');
+    // Will remove the "@dd/", "@dd/datadog-", "@dd/internal-", "datadog-" prefixes and the "-plugin" suffix.
+    return name.replace(/^@dd\/(datadog-|internal-)?|^datadog-|-plugin$/g, '');
 };
 
 // Is the file coming from the injection plugin?

--- a/packages/core/src/helpers/plugins.ts
+++ b/packages/core/src/helpers/plugins.ts
@@ -20,6 +20,10 @@ import type {
 } from '@dd/core/types';
 import path from 'path';
 
+export const cleanPluginName = (name: string) => {
+    return name.replace(/^@dd\/(datadog-|internal-|)|^datadog-|-plugin$/g, '');
+};
+
 // Is the file coming from the injection plugin?
 export const isInjectionFile = (filename: string) => filename.includes(INJECTED_FILE);
 

--- a/packages/factory/src/helpers/logger.ts
+++ b/packages/factory/src/helpers/logger.ts
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { cleanPluginName } from '@dd/core/helpers/plugins';
 import { formatDuration } from '@dd/core/helpers/strings';
 import type { BuildReport, GetLogger, LogLevel, TimeLog, TimeLogger, Timer } from '@dd/core/types';
 import c from 'chalk';
@@ -18,10 +19,7 @@ const logPriority: Record<LogLevel, number> = {
 export const NAME_SEP = '>';
 
 const cleanName = (name: string) => {
-    return name
-        .split(NAME_SEP)
-        .map((st) => st.replace(/^datadog-|-plugin$/g, ''))
-        .join(NAME_SEP);
+    return name.split(NAME_SEP).map(cleanPluginName).join(NAME_SEP);
 };
 
 export const getLoggerFactory =

--- a/packages/tools/src/commands/create-plugin/ask.ts
+++ b/packages/tools/src/commands/create-plugin/ask.ts
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { cleanPluginName } from '@dd/core/helpers/plugins';
 import { bold, dim, dimRed, green, red, slugify } from '@dd/tools/helpers';
 import checkbox from '@inquirer/checkbox';
 import input from '@inquirer/input';
@@ -12,16 +13,19 @@ import { allHooks, bundlerHooks, pluginTypes, universalHooks } from './hooks';
 import type { AnyHook, Choice, TypeOfPlugin } from './types';
 
 export const getName = async (nameInput?: string) => {
+    const processName = (name: string) => {
+        return cleanPluginName(slugify(name));
+    };
     if (nameInput) {
-        return slugify(nameInput);
+        return processName(nameInput);
     }
 
-    const name = await input({
+    const nameAnswer = await input({
         message: `Enter the name of your plugin (${dim('will auto format the name')}):`,
-        transformer: (n: string) => green(slugify(n)),
+        transformer: (n: string) => green(processName(n)),
     });
 
-    return slugify(name);
+    return processName(nameAnswer);
 };
 
 export const getDescription = async (descriptionInput?: string) => {

--- a/packages/tools/src/commands/create-plugin/index.test.ts
+++ b/packages/tools/src/commands/create-plugin/index.test.ts
@@ -30,7 +30,7 @@ describe('Command create-plugin', () => {
     const cases = [
         {
             name: 'Universal Plugin',
-            slug: 'universal-plugin',
+            slug: 'universal',
             description: 'Testing universal plugins.',
             codeowners: ['@codeowners-1', '@codeowners-2'],
             type: 'universal',
@@ -38,7 +38,7 @@ describe('Command create-plugin', () => {
         },
         {
             name: 'Bundler Plugin',
-            slug: 'bundler-plugin',
+            slug: 'bundler',
             description: 'Testing bundler plugins.',
             codeowners: ['@codeowners-1', '@codeowners-2'],
             type: 'bundler',
@@ -46,7 +46,7 @@ describe('Command create-plugin', () => {
         },
         {
             name: 'Internal Plugin',
-            slug: 'internal-plugin',
+            slug: 'internal',
             description: 'Testing internal plugins.',
             codeowners: ['@codeowners-1', '@codeowners-2'],
             type: 'internal',
@@ -92,8 +92,11 @@ describe('Command create-plugin', () => {
             ];
 
             if (type !== 'internal') {
-                // We don't create a types file for internal plugins.
-                expectedFiles.push(`packages/plugins/${slug}/src/types.ts`);
+                // We don't create types and tests files for internal plugins.
+                expectedFiles.push(
+                    `packages/plugins/${slug}/src/types.ts`,
+                    `packages/plugins/${slug}/src/index.test.ts`,
+                );
             }
 
             expect(Object.keys(files)).toEqual(expect.arrayContaining(expectedFiles));


### PR DESCRIPTION
### What and why?

Plugin names are currently processed inconsistently across the codebase, leading to potential inconsistencies in logs, spans, and metrics.

This PR creates a centralized helper function for plugin name normalization to ensure consistent naming conventions throughout the build system.

### How?

- Created a dedicated `cleanPluginName` helper function to standardize how plugin names are formatted and sanitized
- Updated all plugin name handling code to use this central helper
- Ensures consistent plugin names in logs, spans, and metrics for better observability

### PR Stack Hierarchy
> This project adds automated performance profiling to build plugins by standardizing plugin naming, enhancing logging capabilities, and refactoring the plugin initialization system to provide detailed execution insights without manual instrumentation.

1. **#156**
1. **#157**
1. **#158**
1. **👉 #159**
1. **#154**