### PR TITLE
[fix] Vite: Ensure `directories` is set before calling `getCwd`

### DIFF
--- a/packages/plugins/bundler-report/src/index.ts
+++ b/packages/plugins/bundler-report/src/index.ts
@@ -144,14 +144,15 @@ export const getBundlerReportPlugins: GetInternalPlugins = (arg: GetPluginsArg) 
         vite: {
             ...(rollupPlugin() as PluginOptions['vite']),
             config(config) {
+                if (config.build?.outDir) {
+                    context.bundler.outDir = config.build.outDir;
+                }
+                directories.add(context.bundler.outDir);
+
                 if (config.root) {
                     context.cwd = config.root;
                 } else {
                     context.cwd = getCwd(directories, context.bundler.outDir) || context.cwd;
-                }
-
-                if (config.build?.outDir) {
-                    context.bundler.outDir = config.build.outDir;
                 }
 
                 context.hook('cwd', context.cwd);


### PR DESCRIPTION
### What and why?
Potential resolution to #175 

Vite builds fail due to a TypeError when attempting to set the cwd. The code as is is never inserting paths to the `directories` Set, causing the error down the line.

<!-- A short description of what changes this PR introduces and why. -->

### How?
This PR
- moves the outDir check / set earlier in the flow
- calls `directories.add` with the derived path to ensure it is set
- this allows the `getCwd` call to not fail with the TypeError

<!-- A brief description of implementation details of this PR. -->
