### PR TITLE
[fix] Do not mutate existing exports fields

### DIFF
--- a/packages/tools/src/commands/prepare-link/index.ts
+++ b/packages/tools/src/commands/prepare-link/index.ts
@@ -43,12 +43,18 @@ class PrepareLink extends Command {
                 const pkgJsonPath = path.resolve(ROOT, pkg.location, 'package.json');
                 const pkgJson = require(pkgJsonPath);
                 if (this.revert) {
-                    pkgJson.exports = {
-                        './dist/src': './dist/src/index.js',
-                        './dist/src/*': './dist/src/*',
-                        '.': './src/index.ts',
-                    };
+                    if (!pkgJson.previousExports) {
+                        pkgJson.exports = {
+                            './dist/src': './dist/src/index.js',
+                            './dist/src/*': './dist/src/*',
+                            '.': './src/index.ts',
+                        };
+                    } else {
+                        pkgJson.exports = pkgJson.previousExports;
+                        delete pkgJson.previousExports;
+                    }
                 } else {
+                    pkgJson.previousExports = pkgJson.exports;
                     pkgJson.exports = pkgJson.publishConfig.exports;
                 }
 


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Running `yarn dev` or `yarn cli prepare-link` would mutate the `package.json`'s `exports` field and replace its content with the default value.

Which is problematic for `@datadog/rollup-plugin`, because we also have a "basic" build for it, that we use to instrument ourselves.

### How?

<!-- A brief description of implementation details of this PR. -->

Save the previous value of `exports` into `previousExports` and re-use it during the reset.
