### PR TITLE
Update bump.yaml

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -15,12 +15,14 @@ on:
 
 jobs:
   bump:
+    permissions:
+      contents: write  # Required to create tags and push the bump commit
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Needed for "yarn version" to work.
-        token: ${{ secrets.DD_INFRA_BOT_GH_ACTIONS_TOKEN }} # Needed for the push at the end of the action.
+        token: ${{ secrets.GITHUB_TOKEN }} # Needed for the push at the end of the action.
     - uses: actions/setup-node@v4
       with:
         node-version-file: 'package.json'


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Action is [failing](https://github.com/DataDog/build-plugins/actions/runs/16490445526/job/46623688688) with a fine-grained token.

### How?

<!-- A brief description of implementation details of this PR. -->

Update process to use the default token `GITHUB_TOKEN` and define the needed `permissions`.

- [x] [Manage to bump the versions](https://github.com/DataDog/build-plugins/actions/runs/16491444959/job/46626847429)
