### PR TITLE
[auth] Unify `site` configuration used for API requests

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -2,6 +2,43 @@
 
 Everything you need to know about breaking changes and major version bumps.
 
+## v2 to v3
+
+### Unified `site` Configuration
+
+The Datadog site configuration has been unified under `auth.site`.<br/>
+This replaces the individual endpoint configurations at the product level.
+
+#### Removed Configuration Options
+
+The following configuration options have been removed:
+- `telemetry.endPoint` - Now derived from `auth.site`
+- `errorTracking.sourcemaps.intakeUrl` - Now derived from `auth.site`
+
+```diff
+{
+    auth: {
+        apiKey: 'xxx'
++       site: 'datadoghq.eu'
+    },
+    telemetry: {
+-       endPoint: 'https://app.datadoghq.eu'
+    },
+    errorTracking: {
+        sourcemaps: {
+-           intakeUrl: 'https://sourcemap-intake.datadoghq.eu/api/v2/srcmap',
+            // ... other options
+        }
+    }
+}
+```
+
+Supported `site` include: `'datadoghq.com'` (default), `'datadoghq.eu'`, `'us3.datadoghq.com'`, `'us5.datadoghq.com'`, `'ap1.datadoghq.com'`, etc.
+
+> [!NOTE]
+> - You can still use `DATADOG_SOURCEMAP_INTAKE_URL` to override the sourcemaps' intake url.
+> - The `DATADOG_SITE` environment variable takes priority over the `auth.site` configuration, allowing you to override the site at runtime without changing your configuration files.
+
 ## v1 to v2
 
 This is a major rewrite of the whole project.<br/>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To interact with Datadog directly from your builds.
 -   [Configuration](#configuration)
     -   [`auth.apiKey`](#authapikey)
     -   [`auth.appKey`](#authappkey)
+    -   [`auth.site`](#authsite)
     -   [`customPlugins`](#customplugins)
     -   [`enableGit`](#enablegit)
     -   [`logLevel`](#loglevel)
@@ -101,7 +102,6 @@ Follow the specific documentation for each bundler:
         sourcemaps?: {
             bailOnError?: boolean;
             dryRun?: boolean;
-            intakeUrl?: string;
             maxConcurrency?: number;
             minifiedPathPrefix: string;
             releaseVersion: string;
@@ -112,7 +112,6 @@ Follow the specific documentation for each bundler:
         enable?: boolean;
         enableStaticPrefix?: boolean;
         enableTracing?: boolean;
-        endPoint?: string;
         output?: boolean
             | string
             | {
@@ -142,6 +141,23 @@ In order to interact with Datadog, you have to use [your own API Key](https://ap
 > default `null`
 
 In order to interact with Datadog, you have to use [your own Application Key](https://app.datadoghq.com/organization-settings/application-keys).
+
+### `auth.site`
+
+> default `'datadoghq.com'`
+
+The Datadog site to use APIs from.
+
+Possible values are `'datadoghq.com'`, `'datadoghq.eu'`, `'us3.datadoghq.com'`, `'us5.datadoghq.com'`, `'ap1.datadoghq.com'`, etc.
+
+This configuration controls which Datadog site telemetry metrics and error tracking sourcemaps are sent to.
+
+> [!NOTE]
+> The `DATADOG_SITE` environment variable takes priority over this configuration.
+> The order of precedence is:
+> 1. `DATADOG_SITE` or `DD_SITE` environment variable (highest priority)
+> 2. `auth.site` configuration
+> 3. `'datadoghq.com'` (default)
 
 ### `customPlugins`
 
@@ -264,7 +280,6 @@ datadogWebpackPlugin({
         sourcemaps?: {
             bailOnError?: boolean,
             dryRun?: boolean,
-            intakeUrl?: string,
             maxConcurrency?: number,
             minifiedPathPrefix: string,
             releaseVersion: string,
@@ -292,7 +307,6 @@ datadogWebpackPlugin({
         enable?: boolean,
         enableStaticPrefix?: boolean,
         enableTracing?: boolean,
-        endPoint?: string,
         output?: boolean
             | string
             | {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -159,7 +159,7 @@ export type TriggerHook<R> = <K extends keyof CustomHooks>(
 ) => R;
 export type GlobalContext = {
     asyncHook: TriggerHook<Promise<void[]>>;
-    auth?: AuthOptions;
+    auth: AuthOptionsWithDefaults;
     build: BuildReport;
     bundler: BundlerReport;
     cwd: string;
@@ -224,7 +224,10 @@ export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'none';
 export type AuthOptions = {
     apiKey?: string;
     appKey?: string;
+    site?: string;
 };
+
+export type AuthOptionsWithDefaults = WithRequired<AuthOptions, 'site'>;
 
 export interface BaseOptions {
     auth?: AuthOptions;
@@ -244,14 +247,17 @@ export interface Options extends BaseOptions {
 }
 
 export type GetPluginsOptions = Required<BaseOptions>;
-export type OptionsWithDefaults = Assign<Options, GetPluginsOptions>;
+export type OptionsWithDefaults = Assign<
+    Assign<Options, GetPluginsOptions>,
+    { auth: AuthOptionsWithDefaults }
+>;
 
 export type PluginName = `datadog-${Lowercase<string>}-plugin`;
 
 type Data = { data?: BodyInit; headers?: Record<string, string> };
 export type RequestOpts = {
     url: string;
-    auth?: AuthOptions;
+    auth?: Pick<AuthOptions, 'apiKey' | 'appKey'>;
     method?: string;
     getData?: () => Promise<Data> | Data;
     type?: 'json' | 'text';

--- a/packages/factory/src/helpers/context.test.ts
+++ b/packages/factory/src/helpers/context.test.ts
@@ -25,11 +25,13 @@ describe('Factory Helpers', () => {
                 initialContexts[bundlerName].inject = context.inject;
                 initialContexts[bundlerName].hook = context.hook;
                 initialContexts[bundlerName].asyncHook = context.asyncHook;
+                // Need to individually copy, because 'apiKey' and 'appKey' a non enumerable.
+                initialContexts[bundlerName].auth = context.auth;
 
                 return [
                     {
                         name: 'custom-plugin',
-                        buildStart() {
+                        cwd() {
                             cwds[bundlerName] = context.cwd;
                         },
                     },
@@ -46,7 +48,10 @@ describe('Factory Helpers', () => {
             test('Should have the right initial context.', () => {
                 const context = initialContexts[name];
                 expect(context).toBeDefined();
-                expect(context.auth).toEqual(defaultPluginOptions.auth);
+                // Need to individually test, because 'apiKey' and 'appKey' a non enumerable.
+                expect(context.auth.apiKey).toEqual(defaultPluginOptions.auth.apiKey);
+                expect(context.auth.appKey).toEqual(defaultPluginOptions.auth.appKey);
+                expect(context.auth.site).toEqual(defaultPluginOptions.auth.site);
                 expect(context.bundler.name).toBe(name);
                 expect(BUNDLER_VERSIONS[name]).toBeTruthy();
                 expect(BUNDLER_VERSIONS[name]).toEqual(expect.any(String));

--- a/packages/factory/src/validate.ts
+++ b/packages/factory/src/validate.ts
@@ -2,14 +2,34 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { Options, OptionsWithDefaults } from '@dd/core/types';
+import type { AuthOptionsWithDefaults, Options, OptionsWithDefaults } from '@dd/core/types';
+
+const getEnvValue = (key: string) => {
+    return process.env[`DATADOG_${key}`] || process.env[`DD_${key}`];
+};
 
 export const validateOptions = (options: Options = {}): OptionsWithDefaults => {
+    const auth: AuthOptionsWithDefaults = {
+        // DATADOG_SITE env var takes precedence over configuration
+        site: getEnvValue('SITE') || options.auth?.site || 'datadoghq.com',
+    };
+
+    // Prevent these from being accidentally logged.
+    Object.defineProperty(auth, 'apiKey', {
+        value: getEnvValue('API_KEY') || options.auth?.apiKey,
+        enumerable: false,
+    });
+
+    Object.defineProperty(auth, 'appKey', {
+        value: getEnvValue('APP_KEY') || options.auth?.appKey,
+        enumerable: false,
+    });
+
     return {
-        auth: {},
         enableGit: true,
         logLevel: 'warn',
         metadata: {},
         ...options,
+        auth,
     };
 };

--- a/packages/plugins/error-tracking/README.md
+++ b/packages/plugins/error-tracking/README.md
@@ -13,7 +13,6 @@ Interact with Error Tracking directly from your build system.
 -   [Sourcemaps Upload](#sourcemaps-upload)
     -   [errorTracking.sourcemaps.bailOnError](#errortrackingsourcemapsbailonerror)
     -   [errorTracking.sourcemaps.dryRun](#errortrackingsourcemapsdryrun)
-    -   [errorTracking.sourcemaps.intakeUrl](#errortrackingsourcemapsintakeurl)
     -   [errorTracking.sourcemaps.maxConcurrency](#errortrackingsourcemapsmaxconcurrency)
     -   [errorTracking.sourcemaps.minifiedPathPrefix](#errortrackingsourcemapsminifiedpathprefix)
     -   [errorTracking.sourcemaps.releaseVersion](#errortrackingsourcemapsreleaseversion)
@@ -28,7 +27,6 @@ errorTracking?: {
     sourcemaps?: {
         bailOnError?: boolean;
         dryRun?: boolean;
-        intakeUrl?: string;
         maxConcurrency?: number;
         minifiedPathPrefix: string;
         releaseVersion: string;
@@ -42,8 +40,8 @@ errorTracking?: {
 Upload JavaScript sourcemaps to Datadog to un-minify your errors.
 
 > [!NOTE]
-> You can override the intake URL by setting the `DATADOG_SOURCEMAP_INTAKE_URL` environment variable (eg. `https://sourcemap-intake.datadoghq.com/v1/input`).
-> Or only the domain with the `DATADOG_SITE` environment variable (eg. `datadoghq.com`).
+> You can override the domain used in the request with the `DATADOG_SITE` environment variable or the `auth.site` options (eg. `datadoghq.eu`).
+> You can override the full intake URL by setting the `DATADOG_SOURCEMAP_INTAKE_URL` environment variable (eg. `https://sourcemap-intake.datadoghq.com/v1/input`).
 
 ### errorTracking.sourcemaps.bailOnError
 
@@ -57,11 +55,6 @@ Should the upload of sourcemaps fail the build on first error?
 
 It will not upload the sourcemaps to Datadog, but will do everything else.
 
-### errorTracking.sourcemaps.intakeUrl
-
-> default: `https://sourcemap-intake.datadoghq.com/api/v2/srcmap`
-
-Against which endpoint do you want to upload the sourcemaps.
 
 ### errorTracking.sourcemaps.maxConcurrency
 

--- a/packages/plugins/error-tracking/src/sourcemaps/sender.ts
+++ b/packages/plugins/error-tracking/src/sourcemaps/sender.ts
@@ -28,6 +28,16 @@ type FileMetadata = {
     file: string;
 };
 
+export const SOURCEMAPS_API_SUBDOMAIN = 'sourcemap-intake';
+export const SOURCEMAPS_API_PATH = 'api/v2/srcmap';
+
+export const getIntakeUrl = (site: string) => {
+    return (
+        process.env.DATADOG_SOURCEMAP_INTAKE_URL ||
+        `https://${SOURCEMAPS_API_SUBDOMAIN}.${site}/${SOURCEMAPS_API_PATH}`
+    );
+};
+
 // Use a function to get new streams for each retry.
 export const getData =
     (payload: Payload, defaultHeaders: Record<string, string> = {}) =>
@@ -68,7 +78,7 @@ export const upload = async (
     const errors: { metadata?: FileMetadata; error: Error }[] = [];
     const warnings: string[] = [];
 
-    if (!context.auth?.apiKey) {
+    if (!context.auth.apiKey) {
         errors.push({ error: new Error('No authentication token provided') });
         return { errors, warnings };
     }
@@ -106,8 +116,8 @@ export const upload = async (
             queue.add(async () => {
                 try {
                     await doRequest({
-                        auth: { apiKey: context.auth!.apiKey },
-                        url: options.intakeUrl,
+                        auth: { apiKey: context.auth.apiKey },
+                        url: getIntakeUrl(context.auth.site),
                         method: 'POST',
                         getData: getData(payload, defaultHeaders),
                         // On retry we store the error as a warning.

--- a/packages/plugins/error-tracking/src/types.ts
+++ b/packages/plugins/error-tracking/src/types.ts
@@ -7,7 +7,6 @@ export type MinifiedPathPrefix = `http://${string}` | `https://${string}` | `/${
 export type SourcemapsOptions = {
     bailOnError?: boolean;
     dryRun?: boolean;
-    intakeUrl?: string;
     maxConcurrency?: number;
     minifiedPathPrefix: MinifiedPathPrefix;
     releaseVersion: string;

--- a/packages/plugins/error-tracking/src/validate.test.ts
+++ b/packages/plugins/error-tracking/src/validate.test.ts
@@ -79,7 +79,6 @@ describe('Error Tracking Plugins validate', () => {
                 bailOnError: false,
                 dryRun: false,
                 maxConcurrency: 20,
-                intakeUrl: 'https://sourcemap-intake.datadoghq.com/api/v2/srcmap',
                 ...configObject,
             });
         });
@@ -97,41 +96,6 @@ describe('Error Tracking Plugins validate', () => {
             expect(stripAnsi(errors[0])).toBe(
                 "sourcemaps.minifiedPathPrefix must be a valid URL or start with '/'.",
             );
-        });
-
-        test('Should default to the expected intake url', () => {
-            const { config } = validateSourcemapsOptions({
-                errorTracking: {
-                    sourcemaps: getMinimalSourcemapsConfiguration(),
-                },
-            });
-
-            expect(config?.intakeUrl).toBe('https://sourcemap-intake.datadoghq.com/api/v2/srcmap');
-        });
-
-        test('Should use the provided configuration as the intake url', () => {
-            const { config } = validateSourcemapsOptions({
-                errorTracking: {
-                    sourcemaps: getMinimalSourcemapsConfiguration({
-                        intakeUrl: 'https://example.com',
-                    }),
-                },
-            });
-
-            expect(config?.intakeUrl).toBe('https://example.com');
-        });
-
-        test('Should use the env var if provided as the intake url', () => {
-            const initialEnvValue = process.env.DATADOG_SOURCEMAP_INTAKE_URL;
-            process.env.DATADOG_SOURCEMAP_INTAKE_URL = 'https://example.com';
-            const { config } = validateSourcemapsOptions({
-                errorTracking: {
-                    sourcemaps: getMinimalSourcemapsConfiguration(),
-                },
-            });
-
-            expect(config?.intakeUrl).toBe('https://example.com');
-            process.env.DATADOG_SOURCEMAP_INTAKE_URL = initialEnvValue;
         });
     });
 });

--- a/packages/plugins/error-tracking/src/validate.ts
+++ b/packages/plugins/error-tracking/src/validate.ts
@@ -12,8 +12,6 @@ import type {
     SourcemapsOptionsWithDefaults,
 } from './types';
 
-export const defaultIntakeUrl = `https://sourcemap-intake.${process.env.DATADOG_SITE || 'datadoghq.com'}/api/v2/srcmap`;
-
 // Deal with validation and defaults here.
 export const validateOptions = (config: Options, log: Logger): ErrorTrackingOptionsWithDefaults => {
     const errors: string[] = [];
@@ -99,10 +97,6 @@ export const validateSourcemapsOptions = (
             bailOnError: false,
             dryRun: false,
             maxConcurrency: 20,
-            intakeUrl:
-                process.env.DATADOG_SOURCEMAP_INTAKE_URL ||
-                validatedOptions.sourcemaps.intakeUrl ||
-                defaultIntakeUrl,
             ...validatedOptions.sourcemaps,
         };
 

--- a/packages/plugins/git/src/index.test.ts
+++ b/packages/plugins/git/src/index.test.ts
@@ -6,14 +6,11 @@ import type { Options, RepositoryData } from '@dd/core/types';
 import { uploadSourcemaps } from '@dd/error-tracking-plugin/sourcemaps/index';
 import { getRepositoryData } from '@dd/internal-git-plugin/helpers';
 import {
-    API_PATH,
-    FAKE_URL,
     defaultPluginOptions,
     getRepositoryDataMock,
     getSourcemapsConfiguration,
 } from '@dd/tests/_jest/helpers/mocks';
 import { BUNDLERS, runBundlers } from '@dd/tests/_jest/helpers/runBundlers';
-import nock from 'nock';
 
 jest.mock('@dd/internal-git-plugin/helpers', () => {
     const originalModule = jest.requireActual('@dd/internal-git-plugin/helpers');
@@ -40,15 +37,6 @@ const pluginOptions = {
 };
 
 describe('Git Plugin', () => {
-    beforeAll(() => {
-        // Mock requests.
-        nock(FAKE_URL).post(API_PATH).reply(200, {}).persist();
-    });
-
-    afterAll(() => {
-        nock.cleanAll();
-    });
-
     describe('Enabled', () => {
         const mockGitData = getRepositoryDataMock();
 

--- a/packages/plugins/rum/src/sdk.test.ts
+++ b/packages/plugins/rum/src/sdk.test.ts
@@ -24,7 +24,7 @@ describe('RUM Plugin - SDK', () => {
 
         test('Should throw if no auth.', () => {
             expect(() => {
-                getInjectionValue(options, { ...context, auth: {} });
+                getInjectionValue(options, { ...context, auth: { site: 'datadoghq.com' } });
             }).toThrow(
                 'Missing "auth.apiKey" and/or "auth.appKey" to fetch "rum.sdk.clientToken".',
             );

--- a/packages/plugins/rum/src/sdk.ts
+++ b/packages/plugins/rum/src/sdk.ts
@@ -43,7 +43,7 @@ export const getInjectionValue = (
         try {
             // Fetch the client token from the API.
             const appResponse = await doRequest<RumAppResponse>({
-                url: `https://api.datadoghq.com/api/v2/rum/applications/${sdkOpts.applicationId}`,
+                url: `https://api.${context.auth.site}/api/v2/rum/applications/${sdkOpts.applicationId}`,
                 type: 'json',
                 auth: context.auth,
             });

--- a/packages/plugins/rum/src/sdk.ts
+++ b/packages/plugins/rum/src/sdk.ts
@@ -31,7 +31,7 @@ export const getInjectionValue = (
     }
 
     // Let's try and fetch the clientToken from the API.
-    if (!context.auth?.apiKey || !context.auth?.appKey) {
+    if (!context.auth.apiKey || !context.auth.appKey) {
         throw new Error(
             'Missing "auth.apiKey" and/or "auth.appKey" to fetch "rum.sdk.clientToken".',
         );

--- a/packages/plugins/telemetry/README.md
+++ b/packages/plugins/telemetry/README.md
@@ -17,7 +17,6 @@ Display and send telemetry data as metrics to Datadog.
     -   [`enable`](#enable)
     -   [`enableStaticPrefix`](#enablestaticprefix)
     -   [`enableTracing`](#enabletracing)
-    -   [`endPoint`](#endpoint)
     -   [`output`](#output)
     -   [`prefix`](#prefix)
     -   [`tags`](#tags)
@@ -34,7 +33,6 @@ telemetry?: {
     enable?: boolean;
     enableStaticPrefix?: boolean;
     enableTracing?: boolean;
-    endPoint?: string;
     output?: boolean
         | string
         | {
@@ -48,6 +46,9 @@ telemetry?: {
     filters?: ((metric: Metric) => Metric | null)[];
 }
 ```
+
+> [!NOTE]
+> You can override the domain used in the request with the `DATADOG_SITE` environment variable or the `auth.site` options (eg. `datadoghq.eu`).
 
 ### `enable`
 
@@ -73,11 +74,6 @@ But it is way more time consuming on the build.
 
 And only supports <img src="/packages/assets/src/webpack.svg" alt="Webpack" width="17" /> Webpack and <img src="/packages/assets/src/esbuild.svg" alt="Esbuild" width="17" /> Esbuild (for now).
 
-### `endPoint`
-
-> default: `"app.datadoghq.com"`
-
-To which endpoint will the metrics be sent.
 
 ### `output`
 

--- a/packages/plugins/telemetry/src/common/helpers.test.ts
+++ b/packages/plugins/telemetry/src/common/helpers.test.ts
@@ -23,7 +23,6 @@ describe('Telemetry Helpers', () => {
                 enable: true,
                 enableStaticPrefix: true,
                 enableTracing: false,
-                endPoint: 'https://app.datadoghq.com',
                 filters: defaultFilters,
                 output: false,
                 prefix: '',
@@ -38,7 +37,6 @@ describe('Telemetry Helpers', () => {
                 [CONFIG_KEY]: {
                     enable: false,
                     enableTracing: true,
-                    endPoint: 'https://app.datadoghq.eu',
                     filters: [fakeFilter],
                     output: true,
                     prefix: 'prefix',
@@ -49,22 +47,11 @@ describe('Telemetry Helpers', () => {
                 enable: false,
                 enableStaticPrefix: true,
                 enableTracing: true,
-                endPoint: 'https://app.datadoghq.eu',
                 filters: [fakeFilter],
                 output: true,
                 prefix: 'prefix',
                 tags: ['tag1'],
             });
-        });
-
-        test('Should add https:// if the endpoint does not have one', () => {
-            const options = {
-                ...defaultPluginOptions,
-                [CONFIG_KEY]: {
-                    endPoint: 'app.datadoghq.eu',
-                },
-            };
-            expect(validateOptions(options).endPoint).toBe('https://app.datadoghq.eu');
         });
     });
 

--- a/packages/plugins/telemetry/src/common/helpers.ts
+++ b/packages/plugins/telemetry/src/common/helpers.ts
@@ -17,7 +17,6 @@ import type {
 import { defaultFilters } from './filters';
 
 export const validateOptions = (opts: Options): TelemetryOptionsWithDefaults => {
-    const endPoint = opts[CONFIG_KEY]?.endPoint || 'https://app.datadoghq.com';
     return {
         enable: !!opts[CONFIG_KEY],
         enableStaticPrefix: true,
@@ -27,7 +26,6 @@ export const validateOptions = (opts: Options): TelemetryOptionsWithDefaults => 
         prefix: '',
         tags: [],
         ...opts[CONFIG_KEY],
-        endPoint: endPoint.startsWith('http') ? endPoint : `https://${endPoint}`,
     };
 };
 

--- a/packages/plugins/telemetry/src/common/sender.ts
+++ b/packages/plugins/telemetry/src/common/sender.ts
@@ -6,9 +6,11 @@ import { doRequest } from '@dd/core/helpers/request';
 import type { Logger } from '@dd/core/types';
 import type { MetricToSend } from '@dd/telemetry-plugin/types';
 
+export const METRICS_API_PATH = 'api/v1/series';
+
 export const sendMetrics = (
     metrics: Set<MetricToSend>,
-    auth: { apiKey?: string; endPoint: string },
+    auth: { apiKey?: string; site: string },
     log: Logger,
 ) => {
     if (!auth.apiKey) {
@@ -40,7 +42,7 @@ Metrics:
 
     return doRequest({
         method: 'POST',
-        url: `${auth.endPoint}/api/v1/series?api_key=${auth.apiKey}`,
+        url: `https://api.${auth.site}/${METRICS_API_PATH}?api_key=${auth.apiKey}`,
         getData: () => ({
             data: JSON.stringify({ series: Array.from(metrics) } satisfies {
                 series: MetricToSend[];

--- a/packages/plugins/telemetry/src/index.test.ts
+++ b/packages/plugins/telemetry/src/index.test.ts
@@ -8,7 +8,7 @@ import { addMetrics } from '@dd/telemetry-plugin/common/aggregator';
 import type { MetricToSend } from '@dd/telemetry-plugin/types';
 import { getPlugins } from '@dd/telemetry-plugin';
 import {
-    FAKE_URL,
+    FAKE_SITE,
     filterOutParticularities,
     getComplexBuildOverrides,
     getGetPluginsArg,
@@ -16,6 +16,8 @@ import {
 import { BUNDLERS, runBundlers } from '@dd/tests/_jest/helpers/runBundlers';
 import type { Bundler } from '@dd/tests/_jest/helpers/types';
 import nock from 'nock';
+
+import { METRICS_API_PATH } from './common/sender';
 
 // Used to intercept metrics.
 jest.mock('@dd/telemetry-plugin/common/aggregator', () => {
@@ -89,10 +91,10 @@ describe('Telemetry Universal Plugin', () => {
     ];
 
     beforeAll(() => {
-        nock(FAKE_URL)
+        nock(`https://${FAKE_SITE}`)
             .persist()
             // Intercept metrics submissions.
-            .post('/api/v1/series?api_key=123')
+            .post(`/${METRICS_API_PATH}?api_key=123`)
             .reply(200, {});
     });
 
@@ -157,9 +159,9 @@ describe('Telemetry Universal Plugin', () => {
 
         beforeAll(async () => {
             const pluginConfig: Options = {
+                auth: { site: FAKE_SITE },
                 telemetry: {
                     enableTracing: true,
-                    endPoint: FAKE_URL,
                     filters: [],
                 },
                 logLevel: 'warn',
@@ -184,8 +186,8 @@ describe('Telemetry Universal Plugin', () => {
 
         beforeAll(async () => {
             const pluginConfig: Options = {
+                auth: { site: FAKE_SITE },
                 telemetry: {
-                    endPoint: FAKE_URL,
                     filters: [],
                 },
                 logLevel: 'warn',
@@ -457,9 +459,9 @@ describe('Telemetry Universal Plugin', () => {
 
         beforeAll(async () => {
             const pluginConfig: Options = {
+                auth: { site: FAKE_SITE },
                 telemetry: {
                     enableStaticPrefix: false,
-                    endPoint: FAKE_URL,
                     filters: [],
                 },
                 logLevel: 'warn',

--- a/packages/plugins/telemetry/src/index.ts
+++ b/packages/plugins/telemetry/src/index.ts
@@ -94,7 +94,7 @@ export const getPlugins: GetPlugins = ({ options, context }) => {
             const timeSend = log.time('sending metrics to Datadog');
             await sendMetrics(
                 metrics,
-                { apiKey: context.auth?.apiKey, endPoint: validatedOptions.endPoint },
+                { apiKey: context.auth.apiKey, site: context.auth.site },
                 log,
             );
             timeSend.end();

--- a/packages/plugins/telemetry/src/types.ts
+++ b/packages/plugins/telemetry/src/types.ts
@@ -41,7 +41,6 @@ export type TelemetryOptions = {
     enableStaticPrefix?: boolean;
     /** @deprecated */
     enableTracing?: boolean;
-    endPoint?: string;
     filters?: Filter[];
     output?: OutputOptions;
     prefix?: string;

--- a/packages/tests/src/_jest/helpers/env.ts
+++ b/packages/tests/src/_jest/helpers/env.ts
@@ -63,6 +63,14 @@ export const setupEnv = (env: TestEnv): void => {
     if (JEST_SILENT) {
         process.env.JEST_SILENT = '1';
     }
+
+    // Remove local variables.
+    delete process.env.DATADOG_API_KEY;
+    delete process.env.DD_API_KEY;
+    delete process.env.DATADOG_APP_KEY;
+    delete process.env.DD_APP_KEY;
+    delete process.env.DATADOG_SITE;
+    delete process.env.DD_SITE;
 };
 
 export const logEnv = (env: TestEnv) => {

--- a/packages/tests/src/_jest/helpers/mocks.ts
+++ b/packages/tests/src/_jest/helpers/mocks.ts
@@ -54,9 +54,7 @@ import path from 'path';
 import { getTempWorkingDir } from './env';
 import type { BundlerOptionsOverrides, BundlerOverrides } from './types';
 
-export const FAKE_URL = 'https://example.com';
-export const API_PATH = '/v2/srcmap';
-export const INTAKE_URL = `${FAKE_URL}${API_PATH}`;
+export const FAKE_SITE = 'example.com';
 
 export const defaultEntry = './easy_project/main.js';
 export const defaultEntries = {
@@ -64,7 +62,7 @@ export const defaultEntries = {
     app2: './hard_project/main2.js',
 };
 
-export const defaultAuth = { apiKey: '123', appKey: '123' };
+export const defaultAuth = { apiKey: '123', appKey: '123', site: FAKE_SITE };
 export const defaultPluginOptions: GetPluginsOptions = {
     auth: defaultAuth,
     enableGit: true,
@@ -458,7 +456,6 @@ export const getTelemetryConfiguration = (
 ): TelemetryOptions => ({
     enableStaticPrefix: true,
     enableTracing: true,
-    endPoint: FAKE_URL,
     output: true,
     prefix: 'prefix',
     tags: ['tag'],
@@ -484,7 +481,6 @@ export const getSourcemapsConfiguration = (
         bailOnError: false,
         dryRun: false,
         maxConcurrency: 10,
-        intakeUrl: INTAKE_URL,
         minifiedPathPrefix: '/prefix',
         releaseVersion: '1.0.0',
         service: 'error-tracking-build-plugin-sourcemaps',


### PR DESCRIPTION
## Unify site configuration under `auth.site`

This PR introduces a unified site configuration that centralizes the Datadog site definition under `auth.site`. This replaces the individual endpoint configurations that were previously
scattered across different plugins.

### What changed

- **Added `auth.site` configuration**: A single source of truth for the Datadog site (defaults to `'datadoghq.com'`)
- **Removed redundant configurations**, now computed from `auth.site`:
  - `telemetry.endPoint`
  - `errorTracking.sourcemaps.intakeUrl`
- **Environment variable support**: `DATADOG_SITE` takes priority over configuration
- **Backward compatibility**: `DATADOG_SOURCEMAP_INTAKE_URL` still works as an override

### Migration

```diff
{
    auth: {
        apiKey: 'xxx',
+       site: 'datadoghq.eu'
    },
    telemetry: {
-       endPoint: 'https://app.datadoghq.eu'
    },
    errorTracking: {
        sourcemaps: {
-           intakeUrl: 'https://sourcemap-intake.datadoghq.eu/api/v2/srcmap',
        }
    }
}
```

### Implementation details

- Telemetry metrics endpoint: https://api.${site}/api/v1/series
- Sourcemaps intake URL: https://sourcemap-intake.${site}/api/v2/srcmap
- Added comprehensive test coverage for the new getIntakeUrl function