### PR TITLE
[feat] Output plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,3 +36,6 @@ packages/plugins/true-end                                            @yoannmoine
 
 # Async Queue
 packages/plugins/async-queue                                          @yoannmoinet
+
+# Output
+packages/plugins/output                                               @yoannmoinet

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To interact with Datadog directly from your builds.
 -   [Features](#features)
     -   [Error Tracking](#error-tracking-----)
     -   [Metrics](#metrics-----)
+    -   [Output](#output-----)
 -   [Contributing](#contributing)
 -   [License](#license)
 <!-- #toc -->
@@ -117,6 +118,20 @@ Follow the specific documentation for each bundler:
         tags?: string[];
         timestamp?: number;
         filters?: ((metric: Metric) => Metric | null)[];
+    };
+    output?: {
+        enable?: boolean;
+        path?: string;
+        files?: {
+            build?: boolean | string;
+            bundler?: boolean | string;
+            dependencies?: boolean | string;
+            errors?: boolean | string;
+            logs?: boolean | string;
+            metrics?: boolean | string;
+            timings?: boolean | string;
+            warnings?: boolean | string;
+        };
     };
 }
 ```
@@ -305,6 +320,37 @@ datadogWebpackPlugin({
         tags?: string[],
         timestamp?: number,
         filters?: ((metric: Metric) => Metric | null)[],
+    }
+});
+```
+
+</details>
+
+### Output <img src="packages/assets/src/esbuild.svg" alt="ESBuild" width="17" /> <img src="packages/assets/src/rollup.svg" alt="Rollup" width="17" /> <img src="packages/assets/src/rspack.svg" alt="Rspack" width="17" /> <img src="packages/assets/src/vite.svg" alt="Vite" width="17" /> <img src="packages/assets/src/webpack.svg" alt="Webpack" width="17" />
+
+> Export build reports, metrics, and bundler data to JSON files for analysis and monitoring.
+
+#### [📝 Full documentation ➡️](/packages/plugins/output#readme)
+
+<details>
+
+<summary>Configuration</summary>
+
+```typescript
+datadogWebpackPlugin({
+    output?: {
+        enable?: boolean,
+        path?: string,
+        files?: {
+            build?: boolean | string,
+            bundler?: boolean | string,
+            dependencies?: boolean | string,
+            errors?: boolean | string,
+            logs?: boolean | string,
+            metrics?: boolean | string,
+            timings?: boolean | string,
+            warnings?: boolean | string,
+        },
     }
 });
 ```

--- a/packages/core/src/helpers/plugins.ts
+++ b/packages/core/src/helpers/plugins.ts
@@ -3,15 +3,11 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { INJECTED_FILE } from '@dd/core/constants';
-import { outputJsonSync } from '@dd/core/helpers/fs';
 import type {
     BuildReport,
     Entry,
     FileReport,
-    GetCustomPlugins,
-    GlobalContext,
     Input,
-    IterableElement,
     Options,
     Output,
     SerializedBuildReport,
@@ -19,8 +15,6 @@ import type {
     SerializedInput,
     SerializedOutput,
 } from '@dd/core/types';
-import path from 'path';
-import type { OutputBundle } from 'rollup';
 
 export const cleanPluginName = (name: string) => {
     // Will remove the "@dd/", "@dd/datadog-", "@dd/internal-", "datadog-" prefixes and the "-plugin" suffix.
@@ -184,84 +178,6 @@ export const unserializeBuildReport = (report: SerializedBuildReport): BuildRepo
         inputs,
         outputs,
     };
-};
-
-// Returns a customPlugin to output some debug files.
-type CustomPlugins = ReturnType<GetCustomPlugins>;
-export const debugFilesPlugins = (context: GlobalContext): CustomPlugins => {
-    const outputFilePath = () =>
-        path.resolve(context.bundler.outDir, `output.${context.bundler.name}.json`);
-    const reportFilePath = () =>
-        path.resolve(context.bundler.outDir, `report.${context.bundler.name}.json`);
-    const xpackPlugin: IterableElement<CustomPlugins>['webpack'] &
-        IterableElement<CustomPlugins>['rspack'] = (compiler) => {
-        type Stats = Parameters<Parameters<typeof compiler.hooks.done.tap>[1]>[0];
-
-        compiler.hooks.done.tap('bundler-outputs', (stats: Stats) => {
-            const statsJson = stats.toJson({
-                all: false,
-                assets: true,
-                children: true,
-                chunks: true,
-                chunkGroupAuxiliary: true,
-                chunkGroupChildren: true,
-                chunkGroups: true,
-                chunkModules: true,
-                chunkRelations: true,
-                entrypoints: true,
-                errors: true,
-                ids: true,
-                modules: true,
-                nestedModules: true,
-                reasons: true,
-                relatedAssets: true,
-                warnings: true,
-            });
-            outputJsonSync(outputFilePath(), statsJson);
-        });
-    };
-
-    const viteOutputs: OutputBundle[] = [];
-    const rollupOutputs: OutputBundle[] = [];
-
-    return [
-        {
-            name: 'build-report',
-            enforce: 'post',
-            buildReport(report) {
-                outputJsonSync(reportFilePath(), serializeBuildReport(report));
-            },
-        },
-        {
-            name: 'bundler-outputs',
-            enforce: 'post',
-            esbuild: {
-                setup(build) {
-                    build.onEnd((result) => {
-                        outputJsonSync(outputFilePath(), result.metafile);
-                    });
-                },
-            },
-            rspack: xpackPlugin,
-            rollup: {
-                writeBundle(options, bundle) {
-                    rollupOutputs.push(bundle);
-                },
-                closeBundle() {
-                    outputJsonSync(outputFilePath(), rollupOutputs);
-                },
-            },
-            vite: {
-                writeBundle(options, bundle) {
-                    viteOutputs.push(bundle);
-                },
-                closeBundle() {
-                    outputJsonSync(outputFilePath(), viteOutputs);
-                },
-            },
-            webpack: xpackPlugin,
-        },
-    ];
 };
 
 // Verify that we should get the git information based on the options.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,6 +12,8 @@ import type { ErrorTrackingOptions } from '@dd/error-tracking-plugin/types';
 import type * as errorTracking from '@dd/error-tracking-plugin';
 import type { MetricsOptions } from '@dd/metrics-plugin/types';
 import type * as metrics from '@dd/metrics-plugin';
+import type { OutputOptions } from '@dd/output-plugin/types';
+import type * as output from '@dd/output-plugin';
 import type { RumOptions } from '@dd/rum-plugin/types';
 import type * as rum from '@dd/rum-plugin';
 // #imports-injection-marker
@@ -254,6 +256,7 @@ export interface Options extends BaseOptions {
     // #types-injection-marker
     [errorTracking.CONFIG_KEY]?: ErrorTrackingOptions;
     [metrics.CONFIG_KEY]?: MetricsOptions;
+    [output.CONFIG_KEY]?: OutputOptions;
     [rum.CONFIG_KEY]?: RumOptions;
     // #types-injection-marker
     customPlugins?: GetCustomPlugins;

--- a/packages/factory/package.json
+++ b/packages/factory/package.json
@@ -30,6 +30,7 @@
         "@dd/internal-injection-plugin": "workspace:*",
         "@dd/internal-true-end-plugin": "workspace:*",
         "@dd/metrics-plugin": "workspace:*",
+        "@dd/output-plugin": "workspace:*",
         "@dd/rum-plugin": "workspace:*",
         "chalk": "2.3.1",
         "unplugin": "2.3.5"

--- a/packages/factory/src/index.ts
+++ b/packages/factory/src/index.ts
@@ -36,6 +36,7 @@ import { ALL_ENVS, HOST_NAME } from '@dd/core/constants';
 // #imports-injection-marker
 import * as errorTracking from '@dd/error-tracking-plugin';
 import * as metrics from '@dd/metrics-plugin';
+import * as output from '@dd/output-plugin';
 import * as rum from '@dd/rum-plugin';
 import { getAnalyticsPlugins } from '@dd/internal-analytics-plugin';
 import { getAsyncQueuePlugins } from '@dd/internal-async-queue-plugin';
@@ -49,6 +50,7 @@ import { getTrueEndPlugins } from '@dd/internal-true-end-plugin';
 // #types-export-injection-marker
 export type { types as ErrorTrackingTypes } from '@dd/error-tracking-plugin';
 export type { types as MetricsTypes } from '@dd/metrics-plugin';
+export type { types as OutputTypes } from '@dd/output-plugin';
 export type { types as RumTypes } from '@dd/rum-plugin';
 // #types-export-injection-marker
 
@@ -148,6 +150,7 @@ export const buildPluginFactory = ({
             // #configs-injection-marker
             ['error-tracking', errorTracking.getPlugins],
             ['metrics', metrics.getPlugins],
+            ['output', output.getPlugins],
             ['rum', rum.getPlugins],
             // #configs-injection-marker
         );

--- a/packages/plugins/build-report/src/index.test.ts
+++ b/packages/plugins/build-report/src/index.test.ts
@@ -3,11 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { existsSync, rm } from '@dd/core/helpers/fs';
-import {
-    serializeBuildReport,
-    unserializeBuildReport,
-    debugFilesPlugins,
-} from '@dd/core/helpers/plugins';
+import { serializeBuildReport, unserializeBuildReport } from '@dd/core/helpers/plugins';
 import { getUniqueId } from '@dd/core/helpers/strings';
 import type {
     Input,
@@ -42,6 +38,7 @@ const getPluginConfig: (
 ) => Options = (bundlerOutdir, buildReports, overrides = {}) => {
     return {
         ...defaultPluginOptions,
+        output: {},
         // Use a custom plugin to intercept contexts to verify it at the moment they're used.
         customPlugins: ({ context }) => [
             {
@@ -58,7 +55,6 @@ const getPluginConfig: (
                     buildReports[bundlerName] = unserializeBuildReport(serializedBuildReport);
                 },
             },
-            ...debugFilesPlugins(context),
         ],
         ...overrides,
     };

--- a/packages/plugins/injection/src/index.test.ts
+++ b/packages/plugins/injection/src/index.test.ts
@@ -3,7 +3,6 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { outputFileSync } from '@dd/core/helpers/fs';
-import { debugFilesPlugins } from '@dd/core/helpers/plugins';
 import type { Assign, BundlerName, Options, ToInjectItem } from '@dd/core/types';
 import { InjectPosition } from '@dd/core/types';
 import { AFTER_INJECTION, BEFORE_INJECTION } from '@dd/internal-injection-plugin/constants';
@@ -223,6 +222,7 @@ describe('Injection Plugin', () => {
             return [
                 {
                     name: 'get-outdirs',
+                    output: {},
                     writeBundle() {
                         // Store the seeded outdir to inspect the produced files.
                         const buildState: BuildState = buildStates[context.bundler.name] || {};
@@ -238,7 +238,6 @@ describe('Injection Plugin', () => {
                         }
                     },
                 },
-                ...debugFilesPlugins(context),
             ];
         };
 

--- a/packages/plugins/injection/src/index.test.ts
+++ b/packages/plugins/injection/src/index.test.ts
@@ -222,7 +222,6 @@ describe('Injection Plugin', () => {
             return [
                 {
                     name: 'get-outdirs',
-                    output: {},
                     writeBundle() {
                         // Store the seeded outdir to inspect the produced files.
                         const buildState: BuildState = buildStates[context.bundler.name] || {};
@@ -305,7 +304,7 @@ describe('Injection Plugin', () => {
         }
 
         const { errors } = await runBundlers(
-            { customPlugins: getPlugins(injections[0], buildStates) },
+            { output: {}, customPlugins: getPlugins(injections[0], buildStates) },
             overrides,
         );
         localState.errors.push(...errors);

--- a/packages/plugins/metrics/src/index.test.ts
+++ b/packages/plugins/metrics/src/index.test.ts
@@ -38,6 +38,7 @@ const getPluginConfig = (
             filters: [],
             ...overrides,
         },
+        output: {},
         logLevel: 'warn',
         customPlugins: ({ context }) => {
             return [

--- a/packages/plugins/output/README.md
+++ b/packages/plugins/output/README.md
@@ -1,0 +1,106 @@
+# Output Plugin <!-- #omit in toc -->
+
+Export build reports, metrics, and bundler data to JSON files for analysis and monitoring.
+
+<!-- The title and the following line will both be added to the root README.md  -->
+
+## Table of content <!-- #omit in toc -->
+
+<!-- This is auto generated with yarn cli integrity -->
+
+<!-- #toc -->
+-   [Configuration](#configuration)
+    -   [`enable`](#enable)
+    -   [`path`](#path)
+    -   [`files`](#files)
+-   [Examples](#examples)
+<!-- #toc -->
+
+## Configuration
+
+```ts
+output?: {
+    enable?: boolean;
+    path?: string;
+    files?: {
+        build?: boolean | string;
+        bundler?: boolean | string;
+        dependencies?: boolean | string;
+        errors?: boolean | string;
+        logs?: boolean | string;
+        metrics?: boolean | string;
+        timings?: boolean | string;
+        warnings?: boolean | string;
+    };
+}
+```
+
+### `enable`
+
+> default: `false`
+
+Enable or disable the output plugin.
+
+### `path`
+
+> default: `'./'`
+
+Base directory for output files. Can be relative to the build output directory or an absolute path.
+
+### `files`
+
+> default: All files enabled
+
+Control which files to output and their names. Each property accepts:
+- `true`: Output with default filename
+- `false`: Do not output this file
+- `string`: Output with custom filename
+
+| Property        | Output File           | Description                                                                                            |
+| :-------------- | :-------------------- | :----------------------------------------------------------------------------------------------------- |
+| `build`         | `build.json`          | Comprehensive build information including bundler details, metadata, timing, and file outputs          |
+| `bundler`       | `bundler.json`        | Bundler-specific data (metafile for esbuild, stats for webpack/rspack, bundle info for rollup/vite)    |
+| `dependencies`  | `dependencies.json`   | Input file dependencies mapping                                                                        |
+| `errors`        | `errors.json`         | Array of build errors with details and stack traces                                                    |
+| `logs`          | `logs.json`           | Build process logs                                                                                     |
+| `metrics`       | `metrics.json`        | Build metrics (when available)                                                                         |
+| `timings`       | `timings.json`        | Performance timings for build phases                                                                   |
+| `warnings`      | `warnings.json`       | Array of build warnings                                                                                |
+
+## Examples
+
+Enable all outputs with defaults:
+
+```javascript
+{
+    output: {
+        enable: true
+    }
+}
+```
+
+Custom output directory:
+
+```javascript
+{
+    output: {
+        enable: true,
+        path: './reports'
+    }
+}
+```
+
+Selective outputs with custom filenames:
+
+```javascript
+{
+    output: {
+        enable: true,
+        files: {
+            build: true,
+            errors: 'build-errors.json',
+            warnings: 'build-warnings.json'
+        }
+    }
+}
+```

--- a/packages/plugins/output/README.md
+++ b/packages/plugins/output/README.md
@@ -37,7 +37,7 @@ output?: {
 
 ### `enable`
 
-> default: `false`
+> default: `true`
 
 Enable or disable the output plugin.
 
@@ -60,11 +60,11 @@ Control which files to output and their names. Each property accepts:
 | :-------------- | :-------------------- | :----------------------------------------------------------------------------------------------------- |
 | `build`         | `build.json`          | Comprehensive build information including bundler details, metadata, timing, and file outputs          |
 | `bundler`       | `bundler.json`        | Bundler-specific data (metafile for esbuild, stats for webpack/rspack, bundle info for rollup/vite)    |
-| `dependencies`  | `dependencies.json`   | Input file dependencies mapping                                                                        |
-| `errors`        | `errors.json`         | Array of build errors with details and stack traces                                                    |
+| `dependencies`  | `dependencies.json`   | Input files dependency tree                                                                            |
+| `errors`        | `errors.json`         | Array of build errors                                                                                  |
 | `logs`          | `logs.json`           | Build process logs                                                                                     |
 | `metrics`       | `metrics.json`        | Build metrics (when available)                                                                         |
-| `timings`       | `timings.json`        | Performance timings for build phases                                                                   |
+| `timings`       | `timings.json`        | For the supported bundlers, will contain some build timings                                            |
 | `warnings`      | `warnings.json`       | Array of build warnings                                                                                |
 
 ## Examples
@@ -73,9 +73,7 @@ Enable all outputs with defaults:
 
 ```javascript
 {
-    output: {
-        enable: true
-    }
+    output: {}
 }
 ```
 
@@ -84,7 +82,6 @@ Custom output directory:
 ```javascript
 {
     output: {
-        enable: true,
         path: './reports'
     }
 }
@@ -95,11 +92,12 @@ Selective outputs with custom filenames:
 ```javascript
 {
     output: {
-        enable: true,
+        path: './reports',
         files: {
-            build: true,
-            errors: 'build-errors.json',
-            warnings: 'build-warnings.json'
+            build: true, // Will output ./reports/build.json
+            errors: 'build-errors.json', // Will output ./reports/build-errors.json
+            warnings: 'build-warnings.json' // Will output ./reports/build-warnings.json
+            // The other files won't be produced.
         }
     }
 }

--- a/packages/plugins/output/package.json
+++ b/packages/plugins/output/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "@dd/output-plugin",
+    "packageManager": "yarn@4.0.2",
+    "license": "MIT",
+    "private": true,
+    "author": "Datadog",
+    "description": "Output JSON files with data from the build.",
+    "homepage": "https://github.com/DataDog/build-plugins/tree/main/packages/plugins/output#readme",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DataDog/build-plugins",
+        "directory": "packages/plugins/output"
+    },
+    "exports": {
+        ".": "./src/index.ts",
+        "./*": "./src/*.ts"
+    },
+    "scripts": {
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@dd/core": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "5.4.3"
+    }
+}

--- a/packages/plugins/output/src/constants.ts
+++ b/packages/plugins/output/src/constants.ts
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { PluginName } from '@dd/core/types';
+
+export const CONFIG_KEY = 'output' as const;
+export const PLUGIN_NAME: PluginName = 'datadog-output-plugin' as const;
+export const FILE_KEYS = [
+    'build',
+    'bundler',
+    'dependencies',
+    'errors',
+    'logs',
+    'metrics',
+    'timings',
+    'warnings',
+] as const;

--- a/packages/plugins/output/src/index.test.ts
+++ b/packages/plugins/output/src/index.test.ts
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { getPlugins } from '@dd/output-plugin';
+import { getGetPluginsArg } from '@dd/tests/_jest/helpers/mocks';
+
+describe('Output Plugin', () => {
+    describe('getPlugins', () => {
+        test('Should not initialize the plugin if not enabled', async () => {
+            expect(getPlugins(getGetPluginsArg({ output: { enable: false } }))).toHaveLength(0);
+            expect(getPlugins(getGetPluginsArg())).toHaveLength(0);
+        });
+
+        test('Should initialize the plugin if enabled', async () => {
+            expect(getPlugins(getGetPluginsArg({ output: { enable: true } }))).toHaveLength(1);
+        });
+    });
+});

--- a/packages/plugins/output/src/index.test.ts
+++ b/packages/plugins/output/src/index.test.ts
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import { getPlugins } from '@dd/output-plugin';
+import { getPlugins, getFilePath } from '@dd/output-plugin';
 import { getGetPluginsArg } from '@dd/tests/_jest/helpers/mocks';
 
 describe('Output Plugin', () => {
@@ -14,6 +14,72 @@ describe('Output Plugin', () => {
 
         test('Should initialize the plugin if enabled', async () => {
             expect(getPlugins(getGetPluginsArg({ output: { enable: true } }))).toHaveLength(1);
+        });
+    });
+
+    describe('getFilePath', () => {
+        const cases = [
+            {
+                description: 'resolve relative path with filename',
+                outDir: '/project/dist',
+                pathOption: './',
+                filename: 'build.json',
+                expected: '/project/dist/build.json',
+            },
+            {
+                description: 'resolve relative subdirectory with filename',
+                outDir: '/project/dist',
+                pathOption: './reports',
+                filename: 'metrics.json',
+                expected: '/project/dist/reports/metrics.json',
+            },
+            {
+                description: 'handle absolute path ignoring outDir',
+                outDir: '/project/dist',
+                pathOption: '/absolute/reports',
+                filename: 'errors.json',
+                expected: '/absolute/reports/errors.json',
+            },
+            {
+                description: 'resolve parent directory path',
+                outDir: '/project/dist',
+                pathOption: '../output',
+                filename: 'logs.json',
+                expected: '/project/output/logs.json',
+            },
+            {
+                description: 'handle nested relative paths',
+                outDir: '/project/dist',
+                pathOption: './data/reports',
+                filename: 'warnings.json',
+                expected: '/project/dist/data/reports/warnings.json',
+            },
+            {
+                description: 'handle filename with path',
+                outDir: '/project/dist',
+                pathOption: './',
+                filename: 'subfolder/build.json',
+                expected: '/project/dist/subfolder/build.json',
+            },
+            {
+                description: 'handle empty path option as current directory',
+                outDir: '/project/dist',
+                pathOption: '',
+                filename: 'bundler.json',
+                expected: '/project/dist/bundler.json',
+            },
+            {
+                description: 'normalize paths with multiple slashes',
+                outDir: '/project/dist/',
+                pathOption: './reports/',
+                filename: 'dependencies.json',
+                expected: '/project/dist/reports/dependencies.json',
+            },
+        ];
+
+        test.each(cases)('Should $description', ({ outDir, pathOption, filename, expected }) => {
+            const result = getFilePath(outDir, pathOption, filename);
+            expect(result).toBe(expected);
         });
     });
 });

--- a/packages/plugins/output/src/index.ts
+++ b/packages/plugins/output/src/index.ts
@@ -55,13 +55,17 @@ const getXpackPlugin =
 const getRollupPlugin = (
     write: (outputs: OutputBundle[]) => void,
 ): PluginOptions['rollup'] & PluginOptions['vite'] => {
-    const outputs: OutputBundle[] = [];
+    const outputs: Set<OutputBundle> = new Set();
     return {
+        buildStart() {
+            // Clear set on build start.
+            outputs.clear();
+        },
         writeBundle(opts, bundle) {
-            outputs.push(bundle);
+            outputs.add(bundle);
         },
         closeBundle() {
-            write(outputs);
+            write(Array.from(outputs));
         },
     };
 };

--- a/packages/plugins/output/src/index.ts
+++ b/packages/plugins/output/src/index.ts
@@ -94,7 +94,6 @@ export const getPlugins: GetPlugins = ({ options, context }) => {
         }
     };
 
-    // TODO: Add metrics report.
     return [
         {
             name: PLUGIN_NAME,
@@ -115,6 +114,9 @@ export const getPlugins: GetPlugins = ({ options, context }) => {
                 writeFile('dependencies', serializedReport.inputs);
                 writeFile('errors', serializedReport.errors);
                 writeFile('warnings', serializedReport.warnings);
+            },
+            metrics(metrics) {
+                writeFile('metrics', Array.from(metrics));
             },
             esbuild: {
                 setup(build) {

--- a/packages/plugins/output/src/index.ts
+++ b/packages/plugins/output/src/index.ts
@@ -1,0 +1,134 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { outputJsonSync } from '@dd/core/helpers/fs';
+import { serializeBuildReport } from '@dd/core/helpers/plugins';
+import type { GetPlugins, PluginOptions } from '@dd/core/types';
+import path from 'path';
+import type { OutputBundle } from 'rollup';
+
+import { CONFIG_KEY, PLUGIN_NAME } from './constants';
+import type { FileKey, FileValue, OutputOptions } from './types';
+import { validateOptions } from './validate';
+
+export { CONFIG_KEY, PLUGIN_NAME };
+
+export const helpers = {
+    // Add the helpers you'd like to expose here.
+};
+
+export type types = {
+    // Add the types you'd like to expose here.
+    OutputOptions: OutputOptions;
+};
+
+const getXpackPlugin =
+    (write: (stats: any) => void): PluginOptions['webpack'] & PluginOptions['rspack'] =>
+    (compiler) => {
+        type Stats = Parameters<Parameters<typeof compiler.hooks.done.tap>[1]>[0];
+        compiler.hooks.done.tap('bundler-outputs', (stats: Stats) => {
+            const statsJson = stats.toJson({
+                all: false,
+                assets: true,
+                children: true,
+                chunks: true,
+                chunkGroupAuxiliary: true,
+                chunkGroupChildren: true,
+                chunkGroups: true,
+                chunkModules: true,
+                chunkRelations: true,
+                entrypoints: true,
+                errors: true,
+                ids: true,
+                modules: true,
+                nestedModules: true,
+                reasons: true,
+                relatedAssets: true,
+                warnings: true,
+            });
+
+            write(statsJson);
+        });
+    };
+
+const getRollupPlugin = (
+    write: (outputs: OutputBundle[]) => void,
+): PluginOptions['rollup'] & PluginOptions['vite'] => {
+    const outputs: OutputBundle[] = [];
+    return {
+        writeBundle(opts, bundle) {
+            outputs.push(bundle);
+        },
+        closeBundle() {
+            write(outputs);
+        },
+    };
+};
+
+export const getPlugins: GetPlugins = ({ options, context }) => {
+    // Verify configuration.
+    const validatedOptions = validateOptions(options);
+
+    // If the plugin is not enabled, return an empty array.
+    if (!validatedOptions.enable) {
+        return [];
+    }
+
+    const writeFile = (name: FileKey, data: any) => {
+        const fileValue: FileValue = validatedOptions.files[name];
+        if (data && fileValue !== false) {
+            // If we have an absolute path, we use it as is.
+            const outputPath = path.isAbsolute(validatedOptions.path)
+                ? validatedOptions.path
+                : // Otherwise, we resolve it relative to the bundler output directory.
+                  path.resolve(context.bundler.outDir, validatedOptions.path);
+            const reportPath = path.resolve(outputPath, fileValue);
+            outputJsonSync(reportPath, data);
+        }
+    };
+
+    // TODO: Add metrics report.
+    return [
+        {
+            name: PLUGIN_NAME,
+            buildReport(report) {
+                const serializedReport = serializeBuildReport(report);
+                writeFile('build', {
+                    bundler: serializedReport.bundler,
+                    metadata: serializedReport.metadata,
+                    start: serializedReport.start,
+                    end: serializedReport.end,
+                    duration: serializedReport.duration,
+                    writeDuration: serializedReport.writeDuration,
+                    entries: serializedReport.entries,
+                    outputs: serializedReport.outputs,
+                });
+                writeFile('logs', serializedReport.logs);
+                writeFile('timings', serializedReport.timings);
+                writeFile('dependencies', serializedReport.inputs);
+                writeFile('errors', serializedReport.errors);
+                writeFile('warnings', serializedReport.warnings);
+            },
+            esbuild: {
+                setup(build) {
+                    build.onEnd((result) => {
+                        writeFile('bundler', result.metafile);
+                    });
+                },
+            },
+            rspack: getXpackPlugin((stats) => {
+                writeFile('bundler', stats);
+            }),
+            rollup: getRollupPlugin((outputs) => {
+                writeFile('bundler', outputs);
+            }),
+            vite: getRollupPlugin((outputs) => {
+                writeFile('bundler', outputs);
+            }),
+            webpack: getXpackPlugin((stats) => {
+                writeFile('bundler', stats);
+            }),
+        },
+    ];
+};

--- a/packages/plugins/output/src/index.ts
+++ b/packages/plugins/output/src/index.ts
@@ -66,6 +66,15 @@ const getRollupPlugin = (
     };
 };
 
+export const getFilePath = (outDir: string, pathOption: string, filename: string): string => {
+    // If we have an absolute path, we use it as is.
+    const outputPath = path.isAbsolute(pathOption)
+        ? pathOption
+        : // Otherwise, we resolve it relative to the bundler output directory.
+          path.resolve(outDir, pathOption);
+    return path.resolve(outputPath, filename);
+};
+
 export const getPlugins: GetPlugins = ({ options, context }) => {
     // Verify configuration.
     const validatedOptions = validateOptions(options);
@@ -78,13 +87,10 @@ export const getPlugins: GetPlugins = ({ options, context }) => {
     const writeFile = (name: FileKey, data: any) => {
         const fileValue: FileValue = validatedOptions.files[name];
         if (data && fileValue !== false) {
-            // If we have an absolute path, we use it as is.
-            const outputPath = path.isAbsolute(validatedOptions.path)
-                ? validatedOptions.path
-                : // Otherwise, we resolve it relative to the bundler output directory.
-                  path.resolve(context.bundler.outDir, validatedOptions.path);
-            const reportPath = path.resolve(outputPath, fileValue);
-            outputJsonSync(reportPath, data);
+            outputJsonSync(
+                getFilePath(context.bundler.outDir, validatedOptions.path, fileValue),
+                data,
+            );
         }
     };
 

--- a/packages/plugins/output/src/types.ts
+++ b/packages/plugins/output/src/types.ts
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { Assign } from '@dd/core/types';
+
+import type { FILE_KEYS } from './constants';
+
+export type FileKey = (typeof FILE_KEYS)[number];
+export type FileValue = boolean | string;
+export type DefaultFileValue = string | false;
+export type OutputOptions = {
+    enable?: boolean;
+    files?: {
+        [K in FileKey]?: FileValue;
+    };
+    path?: string;
+};
+
+export type OutputOptionsWithDefaults = Assign<
+    Required<OutputOptions>,
+    {
+        files: {
+            [K in FileKey]: DefaultFileValue;
+        };
+    }
+>;

--- a/packages/plugins/output/src/validate.test.ts
+++ b/packages/plugins/output/src/validate.test.ts
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { validateOptions } from './validate';
+
+describe('validateOptions', () => {
+    describe('enable', () => {
+        const cases = [
+            {
+                description: 'return false when no output config provided',
+                input: {},
+                expected: false,
+            },
+            {
+                description: 'return true when output config is an empty object',
+                input: { output: {} },
+                expected: true,
+            },
+            {
+                description: 'return true when output config has enable: true',
+                input: { output: { enable: true } },
+                expected: true,
+            },
+            {
+                description: 'return false when output config has enable: false',
+                input: { output: { enable: false } },
+                expected: false,
+            },
+        ];
+
+        test.each(cases)('Should $description', ({ input, expected }) => {
+            const result = validateOptions(input);
+            expect(result.enable).toBe(expected);
+        });
+    });
+
+    describe('path', () => {
+        const cases = [
+            {
+                description: 'use default path when not provided',
+                input: { output: {} },
+                expected: './',
+            },
+            {
+                description: 'use custom path when provided',
+                input: { output: { path: './custom-reports' } },
+                expected: './custom-reports',
+            },
+            {
+                description: 'use absolute path when provided',
+                input: { output: { path: '/absolute/path' } },
+                expected: '/absolute/path',
+            },
+        ];
+
+        test.each(cases)('Should $description', ({ input, expected }) => {
+            const result = validateOptions(input);
+            expect(result.path).toBe(expected);
+        });
+    });
+
+    describe('files', () => {
+        test('Should have all files enabled by default when files is undefined', () => {
+            const result = validateOptions({ output: {} });
+            expect(result.files).toEqual({
+                build: 'build.json',
+                bundler: 'bundler.json',
+                dependencies: 'dependencies.json',
+                errors: 'errors.json',
+                logs: 'logs.json',
+                metrics: 'metrics.json',
+                timings: 'timings.json',
+                warnings: 'warnings.json',
+            });
+        });
+
+        test('Should have all files disabled by default when files is empty object', () => {
+            const result = validateOptions({ output: { files: {} } });
+            expect(result.files).toEqual({
+                build: false,
+                bundler: false,
+                dependencies: false,
+                errors: false,
+                logs: false,
+                metrics: false,
+                timings: false,
+                warnings: false,
+            });
+        });
+
+        test('Should handle mixed file configuration', () => {
+            const result = validateOptions({
+                output: {
+                    files: {
+                        build: false,
+                        timings: 'some-other-name-without-extension',
+                        logs: './logs/some-name-with-extension.txt',
+                        errors: 'error-log.json',
+                        warnings: true,
+                    },
+                },
+            });
+
+            expect(result.files).toEqual({
+                build: false,
+                bundler: false,
+                dependencies: false,
+                errors: 'error-log.json',
+                logs: './logs/some-name-with-extension.txt.json',
+                metrics: false,
+                timings: 'some-other-name-without-extension.json',
+                warnings: 'warnings.json',
+            });
+        });
+    });
+});

--- a/packages/plugins/output/src/validate.ts
+++ b/packages/plugins/output/src/validate.ts
@@ -11,11 +11,11 @@ import type { FileKey, OutputOptions, OutputOptionsWithDefaults } from './types'
 const sanitizeOutputPath = (key: FileKey, value: boolean | string) => {
     if (typeof value === 'string') {
         // Ensure we end with the correct extension.
-        return value.replace(/\.json$/, '.json');
+        return value.replace(/(\.json)?$/, '.json');
     }
 
     // Transform the value into a path.
-    return value === true ? `./${key}.json` : value;
+    return value === true ? `${key}.json` : value;
 };
 
 const validateFilesOptions = (

--- a/packages/plugins/output/src/validate.ts
+++ b/packages/plugins/output/src/validate.ts
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { Options } from '@dd/core/types';
+
+import { CONFIG_KEY } from './constants';
+import type { FileKey, OutputOptions, OutputOptionsWithDefaults } from './types';
+
+// Sanitize the output path.
+const sanitizeOutputPath = (key: FileKey, value: boolean | string) => {
+    if (typeof value === 'string') {
+        // Ensure we end with the correct extension.
+        return value.replace(/\.json$/, '.json');
+    }
+
+    // Transform the value into a path.
+    return value === true ? `./${key}.json` : value;
+};
+
+const validateFilesOptions = (
+    files: OutputOptions['files'],
+): OutputOptionsWithDefaults['files'] => {
+    // If no files object is provided, we'll output all files.
+    const defaultValue = typeof files === 'undefined';
+
+    const validatedFiles: OutputOptionsWithDefaults['files'] = {
+        // Listing everything to keep TS happy.
+        build: sanitizeOutputPath('build', files?.build ?? defaultValue),
+        bundler: sanitizeOutputPath('bundler', files?.bundler ?? defaultValue),
+        dependencies: sanitizeOutputPath('dependencies', files?.dependencies ?? defaultValue),
+        errors: sanitizeOutputPath('errors', files?.errors ?? defaultValue),
+        logs: sanitizeOutputPath('logs', files?.logs ?? defaultValue),
+        metrics: sanitizeOutputPath('metrics', files?.metrics ?? defaultValue),
+        timings: sanitizeOutputPath('timings', files?.timings ?? defaultValue),
+        warnings: sanitizeOutputPath('warnings', files?.warnings ?? defaultValue),
+    };
+
+    return validatedFiles;
+};
+
+// Deal with validation and defaults here.
+export const validateOptions = (options: Options): OutputOptionsWithDefaults => {
+    const validatedOptions: OutputOptionsWithDefaults = {
+        // By using an empty object, we consider the plugin as enabled.
+        enable: !!options[CONFIG_KEY],
+        path: './',
+        ...options[CONFIG_KEY],
+        files: validateFilesOptions(options[CONFIG_KEY]?.files),
+    };
+
+    return validatedOptions;
+};

--- a/packages/plugins/output/tsconfig.json
+++ b/packages/plugins/output/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": "./",
+        "rootDir": "./",
+        "outDir": "./dist"
+    },
+    "include": ["**/*"],
+    "exclude": ["dist", "node_modules"]
+}

--- a/packages/published/esbuild-plugin/src/index.ts
+++ b/packages/published/esbuild-plugin/src/index.ts
@@ -11,6 +11,7 @@ import type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 } from '@dd/factory';
@@ -24,6 +25,7 @@ export type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 };

--- a/packages/published/rollup-plugin/src/index.ts
+++ b/packages/published/rollup-plugin/src/index.ts
@@ -11,6 +11,7 @@ import type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 } from '@dd/factory';
@@ -24,6 +25,7 @@ export type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 };

--- a/packages/published/rspack-plugin/src/index.ts
+++ b/packages/published/rspack-plugin/src/index.ts
@@ -11,6 +11,7 @@ import type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 } from '@dd/factory';
@@ -24,6 +25,7 @@ export type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 };

--- a/packages/published/vite-plugin/src/index.ts
+++ b/packages/published/vite-plugin/src/index.ts
@@ -11,6 +11,7 @@ import type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 } from '@dd/factory';
@@ -24,6 +25,7 @@ export type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 };

--- a/packages/published/webpack-plugin/src/index.ts
+++ b/packages/published/webpack-plugin/src/index.ts
@@ -11,6 +11,7 @@ import type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 } from '@dd/factory';
@@ -24,6 +25,7 @@ export type {
     // #types-export-injection-marker
     ErrorTrackingTypes,
     MetricsTypes,
+    OutputTypes,
     RumTypes,
     // #types-export-injection-marker
 };

--- a/packages/tools/src/commands/create-plugin/templates.ts
+++ b/packages/tools/src/commands/create-plugin/templates.ts
@@ -91,17 +91,17 @@ export const getFiles = (context: Context): File[] => {
                 content: () => {
                     return outdent`
                         import { getPlugins } from '@dd/${plugin.slug}-plugin';
-                        import { getContextMock } from '@dd/tests/_jest/helpers/mocks';
+                        import { getGetPluginsArg } from '@dd/tests/_jest/helpers/mocks';
 
                         describe('${title} Plugin', () => {
                             describe('getPlugins', () => {
                                 test('Should not initialize the plugin if not enabled', async () => {
-                                    expect(getPlugins({ options: { ${camelCase}: { enable: false } }, context: getContextMock(), bundler: {} })).toHaveLength(0);
-                                    expect(getPlugins({ options: {}, context: getContextMock(), bundler: {} })).toHaveLength(0);
+                                    expect(getPlugins(getGetPluginsArg({ ${camelCase}: { enable: false } }))).toHaveLength(0);
+                                    expect(getPlugins(getGetPluginsArg())).toHaveLength(0);
                                 });
 
                                 test('Should initialize the plugin if enabled', async () => {
-                                    expect(getPlugins({ options: { ${camelCase}: { enable: true } }, context: getContextMock(), bundler: {} })).toHaveLength(1);
+                                    expect(getPlugins(getGetPluginsArg({ ${camelCase}: { enable: true } }))).toHaveLength(1);
                                 });
                             });
                         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,6 +1914,7 @@ __metadata:
     "@dd/internal-injection-plugin": "workspace:*"
     "@dd/internal-true-end-plugin": "workspace:*"
     "@dd/metrics-plugin": "workspace:*"
+    "@dd/output-plugin": "workspace:*"
     "@dd/rum-plugin": "workspace:*"
     chalk: "npm:2.3.1"
     typescript: "npm:5.4.3"
@@ -2015,6 +2016,15 @@ __metadata:
       optional: true
     webpack:
       optional: true
+  languageName: unknown
+  linkType: soft
+
+"@dd/output-plugin@workspace:*, @dd/output-plugin@workspace:packages/plugins/output":
+  version: 0.0.0-use.local
+  resolution: "@dd/output-plugin@workspace:packages/plugins/output"
+  dependencies:
+    "@dd/core": "workspace:*"
+    typescript: "npm:5.4.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What and why?

This PR adds the Output Plugin, providing the ability to export build reports, metrics, and bundler data to JSON files for analysis and/or monitoring.

### How?

- **New `output` plugin** (`packages/plugins/output/`) that exports various build artifacts to JSON files including build reports, metrics, timings, logs, errors, warnings, dependencies, and bundler data
- **Migrated debug functionality** from the separate debugFilesPlugin to be incorporated directly into the Output Plugin for better consolidation
- **Smaller fixes**
  - Fix `create-plugin` with updated templates.
  - Fixed some documentations.