### PR TITLE
[fix] Remove uniqueId from the stub injection files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: packages/published/**/dist
-        key: ${{ matrix.node }}-cache-build-${{ hashFiles('packages/published/**', 'yarn.lock', 'packages/tools/src/rollupConfig.mjs') }}
+        key: ${{ matrix.node }}-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**', 'packages/plugins/**', 'packages/published/**', 'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
 
     - name: Configure Datadog Test Optimization
       uses: datadog/test-visibility-github-action@v2
@@ -69,7 +69,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: packages/published/**/dist
-        key: node18-cache-build-${{ hashFiles('packages/published/**', 'yarn.lock') }}
+        key: node18-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**', 'packages/plugins/**', 'packages/published/**', 'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
 
     - name: Cache playwright binaries
       id: cache-playwright-binaries
@@ -141,14 +141,14 @@ jobs:
       uses: actions/cache@v4
       with:
         path: packages/published/rollup-plugin/dist-basic
-        key: node18-cache-build-rollup-${{ hashFiles('packages/published/rollup-plugin/**', 'yarn.lock') }}
+        key: node18-cache-build-rollup-${{ hashFiles('packages/core/**', 'packages/factory/**', 'packages/plugins/**', 'packages/published/**', 'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
 
     - name: Cache build:all
       id: cache-build
       uses: actions/cache@v4
       with:
         path: packages/published/**/dist
-        key: node18-cache-build-${{ hashFiles('packages/published/**', 'yarn.lock') }}
+        key: node18-cache-build-${{ hashFiles('packages/core/**', 'packages/factory/**', 'packages/plugins/**', 'packages/published/**', 'packages/tools/src/rollupConfig.mjs', 'yarn.lock') }}
 
     - run: yarn install
 

--- a/packages/plugins/injection/src/esbuild.ts
+++ b/packages/plugins/injection/src/esbuild.ts
@@ -6,7 +6,6 @@ import { INJECTED_FILE } from '@dd/core/constants';
 import { getEsbuildEntries } from '@dd/core/helpers/bundlers';
 import { outputFile } from '@dd/core/helpers/fs';
 import { getAbsolutePath } from '@dd/core/helpers/paths';
-import { getUniqueId } from '@dd/core/helpers/strings';
 import type { Logger, PluginOptions, GlobalContext, ResolvedEntry } from '@dd/core/types';
 import { InjectPosition } from '@dd/core/types';
 import fs from 'fs';
@@ -27,7 +26,9 @@ export const getEsbuildPlugin = (
     setup(build) {
         const { onStart, onResolve, onLoad, onEnd, esbuild, initialOptions } = build;
         const entries: ResolvedEntry[] = [];
-        const filePath = `${getUniqueId()}.${InjectPosition.MIDDLE}.${INJECTED_FILE}.js`;
+        // Use a narrower identifier to avoid cross build collisions.
+        const id = context.bundler.fullName;
+        const filePath = `${id}.${InjectPosition.MIDDLE}.${INJECTED_FILE}.js`;
         const tmpDir = fs.realpathSync(os.tmpdir());
         const absoluteFilePath = path.resolve(tmpDir, filePath);
         const injectionRx = new RegExp(`${filePath}$`);

--- a/packages/plugins/injection/src/xpack.ts
+++ b/packages/plugins/injection/src/xpack.ts
@@ -4,7 +4,6 @@
 
 import { INJECTED_FILE } from '@dd/core/constants';
 import { outputFileSync, rmSync } from '@dd/core/helpers/fs';
-import { getUniqueId } from '@dd/core/helpers/strings';
 import type { GlobalContext, Logger, PluginOptions, ToInjectItem } from '@dd/core/types';
 import { InjectPosition } from '@dd/core/types';
 import { createRequire } from 'module';
@@ -38,9 +37,11 @@ export const getXpackPlugin =
     (compiler) => {
         const cache = new WeakMap();
         const ConcatSource = getConcatSource(bundler);
+        // Use a narrower identifier to avoid cross build collisions.
+        const id = context.bundler.fullName;
         const filePath = path.resolve(
             context.bundler.outDir,
-            `${getUniqueId()}.${InjectPosition.MIDDLE}.${INJECTED_FILE}.js`,
+            `${id}.${InjectPosition.MIDDLE}.${INJECTED_FILE}.js`,
         );
 
         // NOTE: RSpack MAY try to resolve the entry points before the loader is ready.


### PR DESCRIPTION
## Summary

The injection plugin was creating non deterministic build chunk hashes because the name of the virtual files used in the injection plugin used a random string to enforce uniqueness and reduce potential conflicts between parallel builds.

Remove unique IDs from stub injection file names in the injection plugin.

This simplifies the file naming by using a consistent, predictable format for temporary injection files and helps make the build more deterministic.

## Changes

- **Removed unique ID generation**: Eliminated the use of `getUniqueId()` from injection file paths in both esbuild and xpack implementations. Replaced it with the name of the bundler in order to avoid "some" collisions while keeping it deterministic.
- **Updated unit tests**: Re-enforce the tests by expecting no errors from the builds

## Technical Details

The injection plugin was previously generating unique IDs for each temporary stub file created during the build process. This change removes that complexity, as the combination of position and injected file name already provides sufficient uniqueness for the build context.

It could be impacting if we have multiple builds targeting the same output directory trying to resolve these virtual entry files at the exact same time.
Which is quite unlikely to happen.

## Impact

- **No breaking changes** - This is an internal implementation detail
- **No user-facing changes** - The plugin API and behavior remain unchanged
