### PR TITLE
[security] Make bump action allowed on the `v2` branch

### DIFF
--- a/.github/chainguard/self.bump.sts.yaml
+++ b/.github/chainguard/self.bump.sts.yaml
@@ -1,12 +1,12 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: repo:DataDog/build-plugins:ref:refs/heads/master
+subject_pattern: repo:DataDog/build-plugins:ref:refs/heads/(master|v2)
 
 claim_pattern:
   event_name: workflow_dispatch
-  ref: refs/heads/master
+  ref: refs/heads/(master|v2)
   ref_protected: "true"
-  job_workflow_ref: DataDog/build-plugins/.github/workflows/bump.yaml@.*
+  job_workflow_ref: DataDog/build-plugins/\.github/workflows/bump\.yaml@refs/heads/(master|v2)
 
 permissions:
   contents: write  # Required to create tags and push the bump commit

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -48,11 +48,15 @@ jobs:
         TAG_NAME="v$VERSION"
         echo "Tag name: $TAG_NAME"
 
+        CURRENT_BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+        echo "Current branch name: $CURRENT_BRANCH_NAME"
+
         BRANCH_NAME="bump-version-$TAG_NAME"
         echo "Branch name: $BRANCH_NAME"
 
 
         # Outputs for the next steps.
+        echo "current_branch_name=$CURRENT_BRANCH_NAME" >> $GITHUB_OUTPUT
         echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
         echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
         echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -109,7 +113,7 @@ jobs:
         PR_URL=$(gh pr create \
           --title "$TITLE" \
           --body "This PR bumps the package versions to \`${{ steps.vars.outputs.tag_name }}\`" \
-          --base master \
+          --base "${{ steps.vars.outputs.current_branch_name }}" \
           --head "${{ steps.vars.outputs.branch_name }}")
         OUTPUT="### PR Created\n**[$TITLE]($PR_URL)**"
         echo -e "$OUTPUT" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### What and why?

<!-- A short description of what changes this PR introduces and why. -->

Since we now have a `v2` branch, we need to be able to bump versions from it.

### How?

<!-- A brief description of implementation details of this PR. -->

Update the policy for the bump action.
