### PR TITLE
Fix live debugger curried function instrumentation

### DIFF
--- a/packages/plugins/live-debugger/src/transform/index.test.ts
+++ b/packages/plugins/live-debugger/src/transform/index.test.ts
@@ -294,27 +294,90 @@ describe('transformCode', () => {
     });
 
     describe('nested functions', () => {
-        it('should instrument nested functions independently', () => {
-            const result = transformCode({
-                ...BASE_OPTIONS,
+        const nestedSyntaxCases = [
+            {
+                description: 'nested function declarations',
                 code: 'function outer(a) { function inner(b) { return b; } return inner(a); }',
-            });
-
-            expect(result.instrumentedCount).toBe(2);
-            expect(result.totalFunctions).toBe(2);
-        });
-
-        it('should handle nested arrow expression bodies without conflicts', () => {
-            const result = transformCode({
-                ...BASE_OPTIONS,
+                namedOnly: false,
+                expectedInstrumentedCount: 2,
+                expectedTotalFunctions: 2,
+            },
+            {
+                description: 'arrow returning named function expression',
+                code: 'const make = (dep) => function named() { return dep; };',
+                namedOnly: false,
+                expectedInstrumentedCount: 2,
+                expectedTotalFunctions: 2,
+            },
+            {
+                description: 'arrow returning named function expression',
+                code: 'const make = (dep) => function named() { return dep; };',
+                namedOnly: true,
+                expectedInstrumentedCount: 2,
+                expectedTotalFunctions: 2,
+            },
+            {
+                description: 'exported arrow returning function expression with inner declaration',
+                code: 'export const remarkSymbol = (o) => function remarkSymbolPlugin() { const d = o; function add(){ d; } add(); };',
+                namedOnly: false,
+                expectedInstrumentedCount: 3,
+                expectedTotalFunctions: 3,
+            },
+            {
+                description: 'exported arrow returning function expression with inner declaration',
+                code: 'export const remarkSymbol = (o) => function remarkSymbolPlugin() { const d = o; function add(){ d; } add(); };',
+                namedOnly: true,
+                expectedInstrumentedCount: 3,
+                expectedTotalFunctions: 3,
+            },
+            {
+                description: 'triple-nested function expression callback',
+                code: 'const build = (n) => function useThing() { return cb(function record(){ size(n); }, []); };',
+                namedOnly: false,
+                expectedInstrumentedCount: 3,
+                expectedTotalFunctions: 3,
+            },
+            {
+                description: 'triple-nested function expression callback',
+                code: 'const build = (n) => function useThing() { return cb(function record(){ size(n); }, []); };',
+                namedOnly: true,
+                expectedInstrumentedCount: 3,
+                expectedTotalFunctions: 3,
+            },
+            {
+                description: 'nested arrow expression bodies',
                 code: 'const f = (x) => (y) => x + y;',
-            });
+                namedOnly: false,
+                expectedInstrumentedCount: 2,
+                expectedTotalFunctions: 2,
+            },
+            {
+                description: 'curried arrow expression body with anonymous inner arrow skipped',
+                code: 'const f = (a) => (b) => a + b;',
+                namedOnly: true,
+                expectedInstrumentedCount: 1,
+                expectedTotalFunctions: 2,
+            },
+        ];
 
-            expect(result.instrumentedCount).toBe(2);
-            // Both functions should be instrumented
-            const probeMatches = result.code.match(/\$dd_probes/g);
-            expect(probeMatches?.length).toBe(2);
-        });
+        test.each(nestedSyntaxCases)(
+            'should produce valid output for $description with namedOnly $namedOnly',
+            ({ code, namedOnly, expectedInstrumentedCount, expectedTotalFunctions }) => {
+                const result = transformCode({
+                    ...BASE_OPTIONS,
+                    code,
+                    namedOnly,
+                });
+
+                const syntaxError = validateSyntax(result.code, '/src/utils.ts');
+                const probeMatches = result.code.match(/\$dd_probes/g);
+                expect(syntaxError).toBeNull();
+                expect(result.instrumentedCount).toBe(expectedInstrumentedCount);
+                expect(result.totalFunctions).toBe(expectedTotalFunctions);
+                expect(probeMatches?.length).toBe(expectedInstrumentedCount);
+                expect(result.code).toContain('catch(e)');
+            },
+        );
     });
 
     describe('skipping', () => {

--- a/packages/plugins/live-debugger/src/transform/index.ts
+++ b/packages/plugins/live-debugger/src/transform/index.ts
@@ -526,8 +526,9 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
         ].join('\n');
 
         // Anchor each injected line to the original expression's location by
-        // editing the boundary chars of the body. Two updates avoid losing
-        // per-character mappings of the original expression in between.
+        // editing the first boundary char and appending after the body. This
+        // avoids overwriting nested function instrumentation when a curried
+        // arrow's expression body ends at the inner function's closing brace.
         // For a single-char body (e.g. `() => 1`) the two ranges would
         // collide, so we fall back to one update covering the whole body.
         if (bodyEnd - bodyStart >= 2) {
@@ -535,7 +536,7 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
                 ? `${prefix}(${code[bodyStart]}`
                 : prefix + code[bodyStart];
             s.update(bodyStart, bodyStart + 1, bodyPrefix);
-            s.update(bodyEnd - 1, bodyEnd, code[bodyEnd - 1] + suffix);
+            s.appendRight(bodyEnd, suffix);
         } else {
             s.update(bodyStart, bodyEnd, prefix + code.slice(bodyStart, bodyEnd) + suffix);
         }


### PR DESCRIPTION
### What and why?

Fixes a Live Debugger transform bug where curried functions like this could emit invalid JavaScript:

```ts
const make = (dep) => function named() {
    return dep;
};
```

Before this fix, the outer arrow instrumentation could overwrite the inner function's closing-brace instrumentation. The generated output effectively looked like this, with the inner `try` missing its `catch`/`finally`:

```js
const make = (dep) => {
    const $dd_p0 = $dd_probes('src/utils.ts;make');
    try {
        if ($dd_p0) $dd_entry($dd_p0, this, {dep});
        const $dd_rv0 = function named() {
            const $dd_p1 = $dd_probes('src/utils.ts;named');
            try {
                let $dd_rv1;
                if ($dd_p1) $dd_entry($dd_p1, this);
                return ($dd_rv1 = dep, $dd_p1 ? $dd_return($dd_p1, $dd_rv1, this) : $dd_rv1);
        };
        if ($dd_p0) $dd_return($dd_p0, $dd_rv0, this, {dep});
        return $dd_rv0;
    } catch(e) { if ($dd_p0) $dd_throw($dd_p0, e, this, {dep}); throw e; }
};
```

That invalid output fails downstream parsers with errors like `Missing catch or finally clause` or `Expected a semicolon`.

### How?

The expression-body path now updates the first body character as before, but appends the suffix at `bodyEnd` instead of rewriting `[bodyEnd - 1, bodyEnd]`. This keeps the inner block-body postamble intact when the arrow body is another function or arrow.

Added table-driven nested-function regression coverage for named function expressions, exported function-expression factories, triple-nested callback shapes, and curried arrows across `namedOnly` modes.
