### PR TITLE
Fix Live Debugger returned arrow instrumentation

### DIFF
--- a/packages/plugins/live-debugger/src/transform/index.test.ts
+++ b/packages/plugins/live-debugger/src/transform/index.test.ts
@@ -358,6 +358,34 @@ describe('transformCode', () => {
                 expectedInstrumentedCount: 1,
                 expectedTotalFunctions: 2,
             },
+            {
+                description: 'block-body arrow returning an expression-body arrow',
+                code: 'export const make = (cond) => { return () => cond ? a() : b(); };',
+                namedOnly: false,
+                expectedInstrumentedCount: 2,
+                expectedTotalFunctions: 2,
+            },
+            {
+                description: 'function declaration returning an expression-body arrow',
+                code: 'export function build(x) { const y = x + 1; return () => y > 0 ? pos(y) : neg(y); }',
+                namedOnly: false,
+                expectedInstrumentedCount: 2,
+                expectedTotalFunctions: 2,
+            },
+            {
+                description: 'block-body arrow returning an expression-body arrow with JSX mapping',
+                code: 'type Row = { id: string }; export const C = (rows: Row[]) => { const n = rows.length; return () => rows.map((r) => <li key={r.id}>{n}</li>); };',
+                namedOnly: false,
+                expectedInstrumentedCount: 3,
+                expectedTotalFunctions: 3,
+            },
+            {
+                description: 'block-body arrow returning a block-body arrow',
+                code: 'export const make = (cond) => { return () => { return cond ? a() : b(); }; };',
+                namedOnly: false,
+                expectedInstrumentedCount: 2,
+                expectedTotalFunctions: 2,
+            },
         ];
 
         test.each(nestedSyntaxCases)(
@@ -375,6 +403,7 @@ describe('transformCode', () => {
                 expect(result.instrumentedCount).toBe(expectedInstrumentedCount);
                 expect(result.totalFunctions).toBe(expectedTotalFunctions);
                 expect(probeMatches?.length).toBe(expectedInstrumentedCount);
+                expect(result.code).toContain('$dd_return');
                 expect(result.code).toContain('catch(e)');
             },
         );

--- a/packages/plugins/live-debugger/src/transform/index.ts
+++ b/packages/plugins/live-debugger/src/transform/index.ts
@@ -419,9 +419,8 @@ export function transformCode(options: TransformOptions): TransformResult {
         superCallRangesHandledByExpressionBodies,
     );
 
-    // Process inner (deeper) functions before outer ones so that MagicString
-    // appendLeft calls at shared positions (e.g. where an outer return wraps
-    // an inner arrow function) stack in the correct order.
+    // Process inner (deeper) functions before outer ones so same-side
+    // MagicString insertions at shared positions stack in the correct order.
     for (let i = targets.length - 1; i >= 0; i--) {
         injectInstrumentation(s, code, targets[i]);
     }
@@ -566,7 +565,7 @@ function injectInstrumentation(s: MagicStringType, code: string, target: Functio
                 const assignmentSuffix = ret.hasSequenceExpressionArgument ? ')' : '';
 
                 s.appendLeft(ret.argStart, assignmentPrefix);
-                s.appendLeft(
+                s.appendRight(
                     ret.argEnd,
                     `${assignmentSuffix}, ${probeVarName} ? $dd_return(${probeVarName}, ${rvVarName}, ${receiverArg}${returnCaptureArgs}) : ${rvVarName})`,
                 );


### PR DESCRIPTION
### What and why?

Fix a Live Debugger transform bug that could emit invalid JavaScript when instrumenting a block-bodied function that returns an anonymous expression-bodied arrow.

For example, this input:

```js
export const make = (cond) => {
    return () => cond ? a() : b();
};
```

Could generate output shaped like this before the fix, formatted here for readability:

```js
return (
    $dd_rv1 = () => {
        const $dd_p0 = $dd_probes('src/utils.ts;<anonymous>');
        try {
            if ($dd_p0) $dd_entry($dd_p0, this);
            const $dd_rv0 =
                cond ? a() : b(),
                $dd_p1 ? $dd_return($dd_p1, $dd_rv1, this, {cond}) : $dd_rv1
            );

            if ($dd_p0) $dd_return($dd_p0, $dd_rv0, this);
            return $dd_rv0;
        } catch(e) {
            if ($dd_p0) $dd_throw($dd_p0, e, this);
            throw e;
        }
    }
);
```

In all-functions mode, both the inner arrow suffix and the outer return wrapper could be inserted at the same byte offset. The outer return-capture tail landed before the inner arrow suffix closed, leaving invalid JavaScript. Named-only mode avoided the issue by skipping the anonymous inner arrow.

### How?

Change the outer `return EXPR` wrapper tail from `appendLeft` to `appendRight` at `ret.argEnd`, so an inner expression-body arrow suffix already queued at that offset is emitted first and closes the inner instrumentation before the outer return capture tail.

Add regression cases for block-bodied arrows and function declarations returning expression-bodied arrows, including a JSX mapping case, plus a block-bodied inner arrow control. The table continues to parse transformed output and now also asserts return instrumentation is still present.
