### PR TITLE
[APPS-2791] Fix: set ssr:true when bundling backend functions

### DIFF
--- a/packages/plugins/apps/src/vite/build-config.test.ts
+++ b/packages/plugins/apps/src/vite/build-config.test.ts
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+/**
+ * Real, unmocked test: getBaseBackendBuildConfig must produce a working
+ * bundle for a backend function that imports a real Node built-in module
+ * (e.g. node:crypto), not the browser-target `__vite-browser-external:*`
+ * externalization stub Vite falls back to when `build.ssr` isn't set.
+ *
+ * Discovered while building a local-execution POC: without `ssr: true`,
+ * Vite defaults to a browser-target build, and any `*.backend.ts` file that
+ * imports a real Node built-in fails to bundle correctly -- this affects
+ * dev-server.ts's existing bundleBackendFunction() today (both the current
+ * cloud round-trip and any future local-execution path), not just new code.
+ */
+
+import { outputFileSync } from '@dd/core/helpers/fs';
+import { getTempWorkingDir } from '@dd/tests/_jest/helpers/env';
+import { build } from 'vite';
+
+import { getBaseBackendBuildConfig } from './build-config';
+
+describe('getBaseBackendBuildConfig', () => {
+    test('bundles a backend function that imports a real Node builtin module with a working import, not a browser-external stub', async () => {
+        const workingDir = getTempWorkingDir(`build-config-ssr-${Date.now()}`);
+        const absolutePath = `${workingDir}/src/usesCrypto.backend.ts`;
+
+        outputFileSync(
+            absolutePath,
+            `
+            import { randomBytes } from 'node:crypto';
+            export async function usesCrypto() {
+                return randomBytes(4).toString('hex');
+            }
+        `,
+        );
+
+        const virtualId = 'virtual:dd-backend-test:usesCrypto';
+        const virtualContent = `import { usesCrypto } from ${JSON.stringify(absolutePath)};\nexport async function main($) { return await usesCrypto(); }`;
+        const baseConfig = getBaseBackendBuildConfig(
+            workingDir,
+            { [virtualId]: virtualContent },
+            [],
+        );
+
+        const result = await build({
+            ...baseConfig,
+            build: {
+                ...baseConfig.build,
+                write: false,
+                rollupOptions: {
+                    ...baseConfig.build.rollupOptions,
+                    input: virtualId,
+                    output: baseConfig.build.rollupOptions.output,
+                },
+            },
+        });
+
+        const output = Array.isArray(result) ? result[0] : result;
+        if (!('output' in output)) {
+            throw new Error('Unexpected vite.build result');
+        }
+        const chunk = output.output[0];
+        const code = chunk.type === 'chunk' ? chunk.code : '';
+
+        // Without `ssr: true`, Vite externalizes node:crypto to
+        // `__vite-browser-external:node:crypto`, which has no real exports --
+        // calling randomBytes() from it throws at runtime, and the import
+        // specifier itself is rewritten away from 'node:crypto'. Assert the
+        // real, working import survived instead.
+        expect(code).toContain("from 'node:crypto'");
+        expect(code).not.toContain('__vite-browser-external');
+    });
+});

--- a/packages/plugins/apps/src/vite/build-config.test.ts
+++ b/packages/plugins/apps/src/vite/build-config.test.ts
@@ -2,20 +2,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-/**
- * Real, unmocked test: getBaseBackendBuildConfig must produce a working
- * bundle for a backend function that imports a real Node built-in module
- * (e.g. node:crypto), not the browser-target `__vite-browser-external:*`
- * externalization stub Vite falls back to when `build.ssr` isn't set.
- *
- * Discovered while building a local-execution POC: without `ssr: true`,
- * Vite defaults to a browser-target build, and any `*.backend.ts` file that
- * imports a real Node built-in fails to bundle correctly -- this affects
- * dev-server.ts's existing bundleBackendFunction() today (both the current
- * cloud round-trip and any future local-execution path), not just new code.
- */
+// Real, unmocked build: confirms a backend function importing a real Node
+// builtin (node:crypto) bundles correctly instead of being externalized.
 
-import { outputFileSync } from '@dd/core/helpers/fs';
+import { outputFileSync, rmSync } from '@dd/core/helpers/fs';
 import { getTempWorkingDir } from '@dd/tests/_jest/helpers/env';
 import { build } from 'vite';
 
@@ -23,53 +13,55 @@ import { getBaseBackendBuildConfig } from './build-config';
 
 describe('getBaseBackendBuildConfig', () => {
     test('bundles a backend function that imports a real Node builtin module with a working import, not a browser-external stub', async () => {
-        const workingDir = getTempWorkingDir(`build-config-ssr-${Date.now()}`);
-        const absolutePath = `${workingDir}/src/usesCrypto.backend.ts`;
+        const seed = `build-config-ssr-${Date.now()}`;
+        const workingDir = getTempWorkingDir(seed);
 
-        outputFileSync(
-            absolutePath,
-            `
+        try {
+            const absolutePath = `${workingDir}/src/usesCrypto.backend.ts`;
+
+            outputFileSync(
+                absolutePath,
+                `
             import { randomBytes } from 'node:crypto';
             export async function usesCrypto() {
                 return randomBytes(4).toString('hex');
             }
         `,
-        );
+            );
 
-        const virtualId = 'virtual:dd-backend-test:usesCrypto';
-        const virtualContent = `import { usesCrypto } from ${JSON.stringify(absolutePath)};\nexport async function main($) { return await usesCrypto(); }`;
-        const baseConfig = getBaseBackendBuildConfig(
-            workingDir,
-            { [virtualId]: virtualContent },
-            [],
-        );
+            const virtualId = 'virtual:dd-backend-test:usesCrypto';
+            const virtualContent = `import { usesCrypto } from ${JSON.stringify(absolutePath)};\nexport async function main($) { return await usesCrypto(); }`;
+            const baseConfig = getBaseBackendBuildConfig(
+                workingDir,
+                { [virtualId]: virtualContent },
+                [],
+            );
 
-        const result = await build({
-            ...baseConfig,
-            build: {
-                ...baseConfig.build,
-                write: false,
-                rollupOptions: {
-                    ...baseConfig.build.rollupOptions,
-                    input: virtualId,
-                    output: baseConfig.build.rollupOptions.output,
+            const result = await build({
+                ...baseConfig,
+                build: {
+                    ...baseConfig.build,
+                    write: false,
+                    rollupOptions: {
+                        ...baseConfig.build.rollupOptions,
+                        input: virtualId,
+                        output: baseConfig.build.rollupOptions.output,
+                    },
                 },
-            },
-        });
+            });
 
-        const output = Array.isArray(result) ? result[0] : result;
-        if (!('output' in output)) {
-            throw new Error('Unexpected vite.build result');
+            const output = Array.isArray(result) ? result[0] : result;
+            if (!('output' in output)) {
+                throw new Error('Unexpected vite.build result');
+            }
+            const chunk = output.output[0];
+            const code = chunk.type === 'chunk' ? chunk.code : '';
+
+            // The browser-external stub has no real exports and rewrites away the import specifier.
+            expect(code).toContain("from 'node:crypto'");
+            expect(code).not.toContain('__vite-browser-external');
+        } finally {
+            rmSync(workingDir);
         }
-        const chunk = output.output[0];
-        const code = chunk.type === 'chunk' ? chunk.code : '';
-
-        // Without `ssr: true`, Vite externalizes node:crypto to
-        // `__vite-browser-external:node:crypto`, which has no real exports --
-        // calling randomBytes() from it throws at runtime, and the import
-        // specifier itself is rewritten away from 'node:crypto'. Assert the
-        // real, working import survived instead.
-        expect(code).toContain("from 'node:crypto'");
-        expect(code).not.toContain('__vite-browser-external');
     });
 });

--- a/packages/plugins/apps/src/vite/build-config.ts
+++ b/packages/plugins/apps/src/vite/build-config.ts
@@ -48,11 +48,9 @@ export function getBaseBackendBuildConfig(
         build: {
             minify: false,
             target: 'esnext',
-            // Backend functions run server-side, never in a browser. Without
-            // this, Vite defaults to a browser-target build and externalizes
-            // real Node builtin imports (node:crypto, fs, etc.) to a
-            // `__vite-browser-external:*` stub with no real exports, silently
-            // breaking any backend function that imports one directly.
+            // Backend functions run server-side. Without this, Vite's default
+            // browser-target build externalizes Node builtins (node:crypto, fs)
+            // to a stub with no real exports.
             ssr: true,
             rollupOptions: {
                 output: { format: 'es', exports: 'named', inlineDynamicImports: true },
@@ -69,14 +67,10 @@ export function getBaseBackendBuildConfig(
         resolve: {
             extensions: [...BACKEND_CODE_EXTENSIONS, '.json'],
         },
-        // Vite's SSR build mode (enabled above) externalizes any real npm
-        // dependency it finds in node_modules by default, on the assumption
-        // a server runtime can `require()` it at runtime. Backend-function
-        // bundles don't get that guarantee: dev-server.ts writes them to a
-        // standalone temp file, and the local-execution path imports the
-        // bundle from a data: URL with no filesystem context at all -- so
-        // every real dependency must be inlined, matching the pre-ssr:true
-        // browser-mode behavior this config otherwise replaces.
+        // SSR mode externalizes node_modules deps by default, assuming a
+        // server runtime can require() them at runtime. Backend bundles have
+        // no such runtime available (sent in-memory or uploaded standalone),
+        // so every dependency must be inlined instead.
         ssr: {
             noExternal: true,
         },

--- a/packages/plugins/apps/src/vite/build-config.ts
+++ b/packages/plugins/apps/src/vite/build-config.ts
@@ -48,6 +48,12 @@ export function getBaseBackendBuildConfig(
         build: {
             minify: false,
             target: 'esnext',
+            // Backend functions run server-side, never in a browser. Without
+            // this, Vite defaults to a browser-target build and externalizes
+            // real Node builtin imports (node:crypto, fs, etc.) to a
+            // `__vite-browser-external:*` stub with no real exports, silently
+            // breaking any backend function that imports one directly.
+            ssr: true,
             rollupOptions: {
                 output: { format: 'es', exports: 'named', inlineDynamicImports: true },
                 preserveEntrySignatures: 'exports-only',
@@ -62,6 +68,17 @@ export function getBaseBackendBuildConfig(
         },
         resolve: {
             extensions: [...BACKEND_CODE_EXTENSIONS, '.json'],
+        },
+        // Vite's SSR build mode (enabled above) externalizes any real npm
+        // dependency it finds in node_modules by default, on the assumption
+        // a server runtime can `require()` it at runtime. Backend-function
+        // bundles don't get that guarantee: dev-server.ts writes them to a
+        // standalone temp file, and the local-execution path imports the
+        // bundle from a data: URL with no filesystem context at all -- so
+        // every real dependency must be inlined, matching the pre-ssr:true
+        // browser-mode behavior this config otherwise replaces.
+        ssr: {
+            noExternal: true,
         },
         plugins: [createVirtualPlugin('dd-backend-resolve', virtualEntries), ...plugins],
     };


### PR DESCRIPTION
## Motivation

- `getBaseBackendBuildConfig` never sets Vite's `build.ssr` option, so Vite defaults to a browser-target build for `*.backend.ts` bundling.
- Any backend function that imports a real Node builtin module directly (e.g. `import { randomBytes } from 'node:crypto'`) gets that import externalized to a broken `__vite-browser-external:node:crypto` stub instead of a working import — bundling fails with `"randomBytes" is not exported by "__vite-browser-external:node:crypto"`.
- Discovered as a side effect of prototyping local Node execution for backend functions ([APPS-2792](https://datadoghq.atlassian.net/browse/APPS-2792), a separate, related initiative) — not something that prototype introduces. This affects `bundleBackendFunction()` in the existing `dev-server.ts` today, for the current `npm run dev` cloud round-trip.
- **Update**: setting `ssr: true` alone introduces a second, related issue — Vite's SSR build mode externalizes any *real npm dependency* it finds in `node_modules` by default too, not just Node builtins, on the assumption a server runtime can `require()` it at runtime. That assumption doesn't hold here: `dev-server.ts` writes bundles to a standalone temp file, and this repo's own `packages/plugins/apps/src/backend/integration.test.ts` (which builds and then directly `import()`s the real emitted bundle) caught this immediately — `@datadog/apps-backend/user` came back as an unresolvable bare import once `ssr: true` landed. Fixed by also setting `ssr.noExternal: true`, forcing every real dependency to stay inlined, matching the browser-mode behavior this config otherwise replaces.
- [APPS-2791](https://datadoghq.atlassian.net/browse/APPS-2791)

## Changes

| What changed | File |
|---|---|
| Added `ssr: true` to the `build` options — backend functions run server-side, never in a browser | `packages/plugins/apps/src/vite/build-config.ts` |
| Added `ssr: { noExternal: true }` — keeps real npm dependencies inlined under SSR mode instead of externalized as unresolvable bare imports | `packages/plugins/apps/src/vite/build-config.ts` |
| Added a regression test bundling a fixture backend function that imports `node:crypto`, asserting the output contains a working import and no `__vite-browser-external` stub | `packages/plugins/apps/src/vite/build-config.test.ts` (new) |

## QA Instructions

```bash
yarn install
```

Confirm the new test fails without the fix (for reference — already verified locally, not something you need to re-check by reverting):
```bash
git stash -- packages/plugins/apps/src/vite/build-config.ts
BUILD_PLUGINS_ENV=test FORCE_COLOR=true JEST_CONFIG_TRANSPILE_ONLY=true VITE_CJS_IGNORE_WARNING=true NODE_OPTIONS="--experimental-vm-modules" yarn workspace @dd/tests exec jest --config jest.config.ts packages/plugins/apps/src/vite/build-config.test.ts
# Expected: FAILS with "randomBytes is not exported by __vite-browser-external:node:crypto" ✅ VERIFIED
git stash pop
```

Confirm the `noExternal` fix specifically — this is what the real `@datadog/apps-backend` integration test catches:
```bash
BUILD_PLUGINS_ENV=test FORCE_COLOR=true JEST_CONFIG_TRANSPILE_ONLY=true VITE_CJS_IGNORE_WARNING=true NODE_OPTIONS="--experimental-vm-modules" yarn workspace @dd/tests exec jest --config jest.config.ts packages/plugins/apps/src/backend/integration.test.ts
# Expected: 4 tests passing (fails with "Cannot find module '@datadog/apps-backend/user'" without ssr.noExternal) ✅ VERIFIED
```

Run the full suite:
```bash
BUILD_PLUGINS_ENV=test FORCE_COLOR=true JEST_CONFIG_TRANSPILE_ONLY=true VITE_CJS_IGNORE_WARNING=true NODE_OPTIONS="--experimental-vm-modules" yarn workspace @dd/tests exec jest --config jest.config.ts packages/plugins/apps
# Expected: 23 test suites, 285 tests, all passing ✅ VERIFIED
```

```bash
cd packages/plugins/apps && npx tsc -b tsconfig.client.json --emitDeclarationOnly && npx tsc --noEmit
# Expected: no output, clean exit ✅ VERIFIED
```

### Manual QA — real scaffolded app, local dev server + real staging cloud round-trip

Automated tests cover the bundling output; this confirms the fix through the actual `npm run dev` path a customer would hit, both fixes at once (Node builtin + real npm dependency in the same function).

**Setup**: built and `npm link`'d this branch's `@datadog/vite-plugin` (`yarn cli prepare-link` + `npm link` per `CONTRIBUTING.md`'s external-project linking flow), scaffolded a fresh app (`npm create @datadog/apps@latest -- test-ssr-fix --template vite-react -y`), linked the local build in, added:
```ts
// src/qaCheck.backend.ts
import { randomBytes } from 'node:crypto';
import { getExecutionUser } from '@datadog/apps-backend/user';

export async function qaCheck() {
    const nonce = randomBytes(4).toString('hex');
    const user = await getExecutionUser();
    return { nonce, userEmail: user.email, orgId: user.orgId };
}
```

**Local (`npm run dev`, `POST /__dd/debugBundle`)**: confirmed the emitted bundle contains a real working `import { randomBytes } from 'node:crypto'` (not `__vite-browser-external`) and `@datadog/apps-backend/user`'s `getExecutionUser` fully inlined as real function bodies (not left as an unresolvable bare import) ✅ VERIFIED

**Staging (`dd-auth --domain dd.datad0g.com -- npm run dev`, `POST /__dd/executeAction` — real `preview-async` cloud round-trip)**:
```json
{"success":true,"result":{"data":{"nonce":"267d20a9","orgId":"bd4276fd-000e-11ea-a34b-3f3c8bba65b8","userEmail":"tiffany.trinh@datadoghq.com"}}}
```
Real nonce from `node:crypto`, real org/user identity from the real `@datadog/apps-backend` npm dependency, executed through the actual staging cloud infrastructure end-to-end ✅ VERIFIED

## Blast Radius

- Affects any customer `*.backend.ts` function that imports a Node builtin module directly (previously silently broken at build time; now works), and any function that imports a real npm dependency (previously would have been silently externalized to an unresolvable bare import once `ssr: true` landed; now stays inlined).
- No config flag — this is a correctness fix to shared bundling config, not a new capability.
- Verified no regressions across the full `packages/plugins/apps` test suite (285 tests) — this fix specifically closes a regression the suite's own `integration.test.ts` caught against a real, unmocked bundle.
- Risk: **low**. `ssr: true` + `ssr.noExternal: true` together change Vite's target/externalization assumptions, but backend functions never ran in a browser and never relied on runtime `node_modules` resolution in the first place, so this only removes two incorrect defaults, and existing test coverage across the package (dev-server, virtual-entry, connection-collector, etc.) all still passes unchanged.

## Documentation

- [Design doc: Local Node execution for High Code Apps backend functions](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651) — see the Appendix for the original finding.


[APPS-2792]: https://datadoghq.atlassian.net/browse/APPS-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPS-2791]: https://datadoghq.atlassian.net/browse/APPS-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

