### PR TITLE
fix(apps): parse backend module source instead of reading ModuleInfo#ast

### DIFF
--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -41,17 +41,24 @@ function extractViteTransform(plugins: PluginOptions[]) {
 }
 
 function emitModuleParsed(
-    config: { plugins?: Array<{ moduleParsed?: (moduleInfo: unknown) => void }> },
+    config: {
+        plugins?: Array<{
+            moduleParsed?: (this: { parse: typeof parseAst }, moduleInfo: unknown) => void;
+        }>;
+    },
     id: string,
     code: string,
     importedIds: string[] = [],
 ) {
     for (const plugin of config.plugins ?? []) {
-        plugin.moduleParsed?.({
-            id,
-            ast: parseAst(code),
-            importedIds,
-        });
+        plugin.moduleParsed?.call(
+            { parse: parseAst },
+            {
+                id,
+                code,
+                importedIds,
+            },
+        );
     }
 }
 

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.test.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.test.ts
@@ -6,40 +6,52 @@ import { parseAst } from 'rollup/parseAst';
 
 import { createBackendModuleGraphCollector } from './backend-module-graph-collector';
 
-describe('Backend Functions - backend module graph collector', () => {
-    test('Should collect parsed local module records from Rollup moduleParsed hooks', () => {
-        const collector = createBackendModuleGraphCollector('/project');
-        const moduleParsed = collector.plugin.moduleParsed as (moduleInfo: unknown) => void;
+type FakeModuleInfo = { id: string; code?: string | null };
 
-        moduleParsed({
-            id: '/project/src/backend/actions.backend.js?import',
-            ast: parseAst(`
-                import { getEcho } from './helpers/http.js';
-                export function run() {
-                    return getEcho();
-                }
-            `),
-            importedIds: ['/project/src/backend/helpers/http.js?import'],
-            importedIdResolutions: [{ id: '/project/src/backend/helpers/http.js?import' }],
-        });
-        moduleParsed({
-            id: '/project/node_modules/package/index.js',
-            ast: parseAst('export const value = true;'),
-            importedIds: [],
-            importedIdResolutions: [],
-        });
-        moduleParsed({
-            id: '\0virtual-helper.js',
-            ast: parseAst('export const value = true;'),
-            importedIds: [],
-            importedIdResolutions: [],
-        });
-        moduleParsed({
-            id: 'virtual:dd-backend-dev:example.js',
-            ast: parseAst('export const value = true;'),
-            importedIds: [],
-            importedIdResolutions: [],
-        });
+/**
+ * Invokes the hook with a plugin context exposing `parse`, which is where it gets
+ * its parser. `rollup/parseAst` is what Rollup's real context uses.
+ */
+const getEmit = (collector: ReturnType<typeof createBackendModuleGraphCollector>) => {
+    const moduleParsed = collector.plugin.moduleParsed as (
+        this: { parse: typeof parseAst },
+        moduleInfo: unknown,
+    ) => void;
+
+    // Fills the remaining fields in place rather than spreading into a new
+    // object: a spread would drop (or trigger) an `ast` getter, and one case
+    // below depends on that getter surviving intact.
+    return (moduleInfo: FakeModuleInfo, importedIds: string[] = []) =>
+        moduleParsed.call(
+            { parse: parseAst },
+            Object.assign(moduleInfo, {
+                importedIds,
+                importedIdResolutions: importedIds.map((id) => ({ id })),
+            }),
+        );
+};
+
+describe('Backend Functions - backend module graph collector', () => {
+    test('Should collect parsed local module records from moduleParsed hooks', () => {
+        const collector = createBackendModuleGraphCollector('/project');
+        const emit = getEmit(collector);
+
+        emit(
+            {
+                id: '/project/src/backend/actions.backend.js?import',
+                code: `
+                    import { getEcho } from './helpers/http.js';
+                    export function run() {
+                        return getEcho();
+                    }
+                `,
+            },
+            ['/project/src/backend/helpers/http.js?import'],
+        );
+        emit({ id: '/project/node_modules/package/index.js', code: 'export const value = true;' });
+        emit({ id: '\0virtual-helper.js', code: 'export const value = true;' });
+        emit({ id: 'virtual:dd-backend-dev:example.js', code: 'export const value = true;' });
+        emit({ id: '/project/src/backend/external.js', code: null });
 
         expect([...collector.getModuleRecords().keys()]).toEqual([
             '/project/src/backend/actions.backend.js',
@@ -54,5 +66,29 @@ describe('Backend Functions - backend module graph collector', () => {
                 },
             ],
         });
+    });
+
+    test('Should collect records under a bundler that does not support ModuleInfo#ast', () => {
+        const collector = createBackendModuleGraphCollector('/project');
+        const emit = getEmit(collector);
+
+        // Rolldown, the bundler Vite 8 uses by default, keeps `ast` on its
+        // Rollup-compat object but stubs the getter to throw. Reading the
+        // property at all is the failure, so it must throw rather than be absent.
+        const moduleInfo: FakeModuleInfo = Object.defineProperty(
+            { id: '/project/src/backend/actions.backend.ts', code: 'export const id = "conn-1";' },
+            'ast',
+            {
+                get() {
+                    throw new Error('UNSUPPORTED: ModuleInfo#ast');
+                },
+                enumerable: true,
+            },
+        );
+
+        expect(() => emit(moduleInfo)).not.toThrow();
+        expect([...collector.getModuleRecords().keys()]).toEqual([
+            '/project/src/backend/actions.backend.ts',
+        ]);
     });
 });

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
@@ -2,13 +2,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { BaseNode } from 'estree';
 import type { ModuleInfo } from 'rollup';
 import type { Plugin } from 'vite';
 
 import {
     createParsedModuleRecord,
     type ParsedModuleRecord,
+    shouldTraverseCollectedModule,
 } from '../backend/ast-parsing/module-graph';
 
 const VIRTUAL_MODULE_ID_RE = /^(?:\0|virtual:)/;
@@ -30,10 +30,32 @@ export function createBackendModuleGraphCollector(buildRoot: string): BackendMod
                     return;
                 }
 
+                // `createParsedModuleRecord` applies this same predicate, but
+                // only after the AST exists. Checking it here keeps us from
+                // parsing every `node_modules` module just to discard it.
+                if (!shouldTraverseCollectedModule(moduleId, buildRoot)) {
+                    return;
+                }
+
+                // Parse the source instead of reading `moduleInfo.ast`: Rolldown,
+                // the bundler Vite 8 uses by default, stubs that getter to throw
+                // `UNSUPPORTED: ModuleInfo#ast`. `code` is null for external and
+                // synthetic modules.
+                //
+                // `this.parse` is the bundler's own parser, which already parsed
+                // this exact source to compute `importedIds` — so whatever the
+                // bundler accepted parses here too, and no TypeScript-capable
+                // parser is needed (`moduleParsed` runs after `transform`, so
+                // types and JSX are already gone).
+                if (typeof moduleInfo.code !== 'string') {
+                    return;
+                }
+
+                const parsed = this.parse(moduleInfo.code);
                 const record = createParsedModuleRecord(
                     moduleId,
                     buildRoot,
-                    moduleInfo.ast as BaseNode,
+                    parsed,
                     getStaticDependencyIds(moduleInfo).map(normalizeViteModuleId),
                 );
                 if (!record) {

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -113,17 +113,24 @@ function mockBuildResult(code: string) {
 }
 
 function emitModuleParsed(
-    config: { plugins?: Array<{ moduleParsed?: (moduleInfo: unknown) => void }> },
+    config: {
+        plugins?: Array<{
+            moduleParsed?: (this: { parse: typeof parseAst }, moduleInfo: unknown) => void;
+        }>;
+    },
     id: string,
     code: string,
     importedIds: string[] = [],
 ) {
     for (const plugin of config.plugins ?? []) {
-        plugin.moduleParsed?.({
-            id,
-            ast: parseAst(code),
-            importedIds,
-        });
+        plugin.moduleParsed?.call(
+            { parse: parseAst },
+            {
+                id,
+                code,
+                importedIds,
+            },
+        );
     }
 }
 

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -48,16 +48,23 @@ function mockBuildResult() {
 }
 
 function emitModuleParsed(
-    config: { plugins?: Array<{ moduleParsed?: (moduleInfo: unknown) => void }> },
+    config: {
+        plugins?: Array<{
+            moduleParsed?: (this: { parse: typeof parseAst }, moduleInfo: unknown) => void;
+        }>;
+    },
     id: string,
     code: string,
 ) {
     for (const plugin of config.plugins ?? []) {
-        plugin.moduleParsed?.({
-            id,
-            ast: parseAst(code),
-            importedIds: [],
-        });
+        plugin.moduleParsed?.call(
+            { parse: parseAst },
+            {
+                id,
+                code,
+                importedIds: [],
+            },
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

Vite 8 swaps its bundler from Rollup to **Rolldown**, which deliberately refuses one thing the Apps plugin depended on:

```
Error: UNSUPPORTED: ModuleInfo#ast
    plugin: 'datadog-apps-plugin'
    hook: 'closeBundle'
```

The backend module-graph collector read `moduleInfo.ast` in `moduleParsed` to derive each backend function's `allowedConnectionIds`. Rolldown keeps that property on its Rollup-compat object but stubs the getter to throw — its AST lives in Rust memory, so materialising it per module isn't something it wants to do. That's a permanent API boundary, not a bug to wait out.

The failure lands badly: the client bundle transforms and writes **successfully**, then the plugin's nested `vite.build()` for the backend function dies in `closeBundle`. Nothing in the error points at your `.backend.ts`, at Vite 8, or at Rolldown.

Reproduced end to end on a real Vite 8.1.5 + Rolldown 1.1.5 build — the versions from the investigation.

## Fix

Parse `moduleInfo.code` with the plugin context's own `parse`. Rolldown withholds only the pre-built AST; the source and resolved dependency IDs are both still there.

```diff
-import type { BaseNode } from 'estree';
@@
+                if (typeof moduleInfo.code !== 'string') {
+                    return;
+                }
+
+                const parsed = this.parse(moduleInfo.code);
                 const record = createParsedModuleRecord(
                     moduleId,
                     buildRoot,
-                    moduleInfo.ast as BaseNode,
+                    parsed,
                     getStaticDependencyIds(moduleInfo).map(normalizeViteModuleId),
                 );
```

Three things keep this small:

- **Using the bundler's own parser is correct by construction.** The bundler already parsed this exact source to compute `importedIds`, so whatever it accepted parses here too. A bundled third-party parser could disagree with the bundler; its own cannot.
- **No TypeScript-capable parser is needed.** `moduleParsed` runs after `transform`, so types and JSX are already gone — verified on the Vite 8 build above, where `'x' as string` arrives as `"x"` and `<div/>` arrives as `_jsx("div", …)`. **Zero new dependencies**; no lockfile or published-package changes.
- **The cast disappears.** `this.parse()` returns a directly assignable node, so the previous `as BaseNode` goes away rather than being replaced.

The null check isn't defensive — `moduleInfo.code` is `string | null`, so it's required to compile. `typeof` rather than `=== null` also covers a bundler leaving the field undefined.

## One extra line worth calling out

`shouldTraverseCollectedModule` now runs *before* the parse. `createParsedModuleRecord` applies the same predicate, but only once an AST exists — and reading a pre-built AST was free, while parsing is not. Without this, the change would parse every `node_modules` module in the backend graph just to discard it. It prevents a performance regression this fix would otherwise introduce.

## Testing

- The existing collector test now drives `code` instead of `ast`.
- **One new regression test**: a `moduleInfo` whose `ast` getter throws `UNSUPPORTED: ModuleInfo#ast`. Verified it fails against `master` with exactly that error, so it genuinely pins the bug.
- Three test helpers updated to supply `code` and a context carrying `parse` — mechanical, but unavoidable.

`yarn test:unit` (1880 passed), `yarn typecheck:all`, `yarn format`, `yarn cli integrity` all clean.

## Deliberately not here

- **Narrowing the Vite peer range to `<= 7.x`** — that was a stopgap for a broken path. With this fixed, Vite 8 works, so narrowing it would regress the support added in `b6ea2c22`. Happy to add a fail-fast capability guard instead if you'd prefer one.
- **Real Rolldown in the test matrix** — the repo pins `vite@6.3.5`; adding Vite 8 touches `yarn.lock` and `runBundlers`, and belongs in its own PR. The regression test pins the failing behaviour meanwhile.
- **Scaffolder version bump** — lives in the `create-apps` repo.

## Separate bug found while investigating

`collectStaticModuleDependencies` mispairs static specifiers with resolved IDs whenever a module imports the same specifier twice, because bundlers report one resolved ID per *unique* specifier. On a 6-specifier module it mispaired three and dropped one, which can attribute a `connectionId` to the wrong file or miss it. **It is unrelated to Vite 8 and present today on Vite 6/7.** Kept out of this PR to stay minimal; the fix and its tests are preserved on the `claude/apps-static-dep-pairing` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
