### PR TITLE
[APPS-2792] Add: reject Node built-in imports in backend files

### DIFF
--- a/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
@@ -11,12 +11,11 @@ import type {
     Program,
     Property,
     Super,
-    VariableDeclarator,
 } from 'estree';
 
 import { resolveIdentifier } from './module-scope';
 import type { ModuleScopeAnalysis } from './module-scope';
-import { staticStringValue } from './type-guards';
+import { isVariableDeclaratorNode, staticStringValue } from './type-guards';
 import { walkAst } from './walk-ast';
 
 const GLOBAL_THIS_NAME = 'globalThis';
@@ -61,14 +60,16 @@ function resolvesToAmbientGlobal(
         return false;
     }
 
-    // Cast needed: `definition.node` is typed against eslint's bundled `@types/estree`, a distinct package from the `estree` types used elsewhere in this file.
-    const declarator = definition.node as VariableDeclarator;
+    // `definition.node` is typed against eslint's bundled `@types/estree`, a distinct package (structurally identical) from the `estree` types used elsewhere in this file — narrowed via a type guard rather than asserted.
+    if (!isVariableDeclaratorNode(definition.node)) {
+        return false;
+    }
     // A destructured binding (`const { x } = y`) names a specific property of `y`, not `y` itself, so it must not inherit `y`'s ambient-global identity.
-    if (declarator.id.type !== 'Identifier' || !declarator.init) {
+    if (definition.node.id.type !== 'Identifier' || !definition.node.init) {
         return false;
     }
 
-    return resolvesToAmbientGlobal(declarator.init, scopeAnalysis, visited);
+    return resolvesToAmbientGlobal(definition.node.init, scopeAnalysis, visited);
 }
 
 function staticMemberName(node: MemberExpression): string | undefined {

--- a/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
@@ -64,12 +64,28 @@ function resolvesToAmbientGlobal(
     if (!isVariableDeclaratorNode(definition.node)) {
         return false;
     }
-    // A destructured binding (`const { x } = y`) names a specific property of `y`, not `y` itself, so it must not inherit `y`'s ambient-global identity.
-    if (definition.node.id.type !== 'Identifier' || !definition.node.init) {
+    const { id, init } = definition.node;
+    if (!init) {
         return false;
     }
 
-    return resolvesToAmbientGlobal(definition.node.init, scopeAnalysis, visited);
+    if (id.type === 'Identifier') {
+        return resolvesToAmbientGlobal(init, scopeAnalysis, visited);
+    }
+    // A destructured binding (`const { x } = y`) names a specific property of `y`, not `y` itself — except when that property's own key is a `globalThis`/`global` self-reference (`const { globalThis: g } = globalThis`), since `y.globalThis === y` when `y` is the ambient global, making `g` a real alias for it rather than an arbitrary property.
+    if (id.type === 'ObjectPattern') {
+        const selfReferenceProperty = id.properties.find(
+            (property) =>
+                property.type === 'Property' &&
+                property.value === definition.name &&
+                isAmbientGlobalReceiverName(staticPropertyName(property) ?? ''),
+        );
+        if (selfReferenceProperty) {
+            return resolvesToAmbientGlobal(init, scopeAnalysis, visited);
+        }
+    }
+
+    return false;
 }
 
 function staticMemberName(node: MemberExpression): string | undefined {
@@ -120,6 +136,14 @@ export function forEachAmbientGlobalAccess(
             const name = staticPropertyName(property);
             if (name && names.has(name)) {
                 handlers.onNamedAccess(name);
+            }
+            // `const { globalThis: { fetch } } = globalThis` is a real self-reference (globalThis.globalThis === globalThis), so recurse the same way resolvesToAmbientGlobal's MemberExpression case does — otherwise a name nested one level inside a `globalThis`/`global` destructure key escapes detection entirely.
+            if (
+                name &&
+                isAmbientGlobalReceiverName(name) &&
+                property.value.type === 'ObjectPattern'
+            ) {
+                checkDestructure(property.value, init);
             }
         }
     };

--- a/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
@@ -8,6 +8,7 @@ import type {
     MemberExpression,
     ObjectExpression,
     ObjectPattern,
+    PrivateIdentifier,
     Program,
     Property,
     Super,
@@ -38,7 +39,7 @@ function resolvesToAmbientGlobal(
 ): boolean {
     // `globalThis.globalThis`/`global.global` is a real self-reference — recurse through it before treating other receiver shapes as opaque.
     if (node.type === 'MemberExpression') {
-        const propertyName = staticMemberName(node);
+        const propertyName = staticMemberName(node, scopeAnalysis);
         if (!propertyName || !isAmbientGlobalReceiverName(propertyName)) {
             return false;
         }
@@ -90,7 +91,7 @@ function resolvesToAmbientGlobal(
                 if (property.type !== 'Property') {
                     return false;
                 }
-                const propertyName = staticPropertyName(property) ?? '';
+                const propertyName = staticPropertyName(property, scopeAnalysis) ?? '';
                 if (!isAmbientGlobalReceiverName(propertyName)) {
                     return false;
                 }
@@ -108,11 +109,14 @@ function resolvesToAmbientGlobal(
     return false;
 }
 
-function staticMemberName(node: MemberExpression): string | undefined {
+function staticMemberName(
+    node: MemberExpression,
+    scopeAnalysis: ModuleScopeAnalysis,
+): string | undefined {
     if (!node.computed) {
         return node.property.type === 'Identifier' ? node.property.name : undefined;
     }
-    return staticStringValue(node.property);
+    return resolveStaticPropertyName(node.property, scopeAnalysis);
 }
 
 // A defaulted property value (`{ x = fallback }`) is an AssignmentPattern wrapping the real binding — unwrap it so a defaulted alias is treated the same as a bare one.
@@ -120,12 +124,55 @@ function unwrapDefaultValue(value: Property['value']): Property['value'] {
     return value.type === 'AssignmentPattern' ? value.left : value;
 }
 
-function staticPropertyName(property: Property): string | undefined {
-    // A non-computed key can still be a quoted string literal (`{ 'fetch': f }`) — fall through to staticStringValue for that shape.
+function staticPropertyName(
+    property: Property,
+    scopeAnalysis: ModuleScopeAnalysis,
+): string | undefined {
+    // A non-computed key can still be a quoted string literal (`{ 'fetch': f }`) — fall through to resolveStaticPropertyName for that shape.
     if (!property.computed && property.key.type === 'Identifier') {
         return property.key.name;
     }
-    return staticStringValue(property.key);
+    return resolveStaticPropertyName(property.key, scopeAnalysis);
+}
+
+// A computed key (`globalThis[f]`, `const { [key]: r } = globalThis`) is just as knowable as a
+// literal when it traces back to one through a chain of `const` aliases — the same reasoning
+// resolvesToAmbientGlobal applies to the object side of a member expression applies here to the
+// property side, since neither shape evaluates anything dynamic. `visited` is independent of
+// resolvesToAmbientGlobal's own set: it walks a different alias chain (the key's value, not the
+// receiver object), and guards the same way against a self-referential `const` cycle hanging the
+// linter instead of just failing to resolve.
+function resolveStaticPropertyName(
+    node: Expression | PrivateIdentifier,
+    scopeAnalysis: ModuleScopeAnalysis,
+    visited: Set<eslintScope.Variable> = new Set(),
+): string | undefined {
+    const direct = staticStringValue(node);
+    if (direct !== undefined) {
+        return direct;
+    }
+    if (node.type !== 'Identifier') {
+        return undefined;
+    }
+
+    const variable = resolveIdentifier(node, scopeAnalysis);
+    if (!variable || visited.has(variable) || variable.defs.length !== 1) {
+        return undefined;
+    }
+    visited.add(variable);
+
+    const [definition] = variable.defs;
+    if (definition.type !== 'Variable' || definition.parent.kind !== 'const') {
+        return undefined;
+    }
+    if (!isVariableDeclaratorNode(definition.node)) {
+        return undefined;
+    }
+    const { id, init } = definition.node;
+    if (id.type !== 'Identifier' || !init) {
+        return undefined;
+    }
+    return resolveStaticPropertyName(init, scopeAnalysis, visited);
 }
 
 // A for-of binding identifier is a declaration site, not a reference, so `resolveIdentifier` (which only resolves references) can't find it — look it up via eslint-scope's declarator-to-Variable index instead.
@@ -146,6 +193,7 @@ const BULK_COPY_CALLS: ReadonlyArray<{ readonly object: string; readonly propert
 
 function matchBulkCopyCall(
     callee: Expression | Super,
+    scopeAnalysis: ModuleScopeAnalysis,
 ): { readonly object: string; readonly property: string } | undefined {
     if (callee.type !== 'MemberExpression' || callee.object.type !== 'Identifier') {
         return undefined;
@@ -154,7 +202,7 @@ function matchBulkCopyCall(
     // computed access resolving to a static string (`["assign"]`) — reusing it here (instead of
     // requiring callee.property.type === 'Identifier') closes a gap where `Object["assign"](...)`
     // evaded detection entirely.
-    const propertyName = staticMemberName(callee);
+    const propertyName = staticMemberName(callee, scopeAnalysis);
     if (!propertyName) {
         return undefined;
     }
@@ -194,7 +242,7 @@ export function forEachAmbientGlobalAccess(
                 handlers.onBulkCopy();
                 continue;
             }
-            const name = staticPropertyName(property);
+            const name = staticPropertyName(property, scopeAnalysis);
             if (name && names.has(name)) {
                 handlers.onNamedAccess(name);
             }
@@ -222,7 +270,7 @@ export function forEachAmbientGlobalAccess(
             if (!resolvesToAmbientGlobal(node.object, scopeAnalysis)) {
                 return;
             }
-            const name = staticMemberName(node);
+            const name = staticMemberName(node, scopeAnalysis);
             if (name && names.has(name)) {
                 handlers.onNamedAccess(name);
             }
@@ -304,7 +352,7 @@ export function forEachAmbientGlobalAccess(
         },
         // Built-in statics like `Object.assign({}, globalThis)` reify every property at once — the same threat as a rest-destructure or spread, but with no named-property access for the visitors above to see. Scoped to this known list, not a user-defined equivalent or an aliased `Object`/`Reflect`.
         CallExpression(node) {
-            const match = matchBulkCopyCall(node.callee);
+            const match = matchBulkCopyCall(node.callee, scopeAnalysis);
             if (!match) {
                 return;
             }

--- a/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
@@ -1,0 +1,164 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type * as eslintScope from 'eslint-scope';
+import type {
+    Expression,
+    MemberExpression,
+    ObjectExpression,
+    ObjectPattern,
+    Program,
+    Property,
+    Super,
+    VariableDeclarator,
+} from 'estree';
+
+import { resolveIdentifier } from './module-scope';
+import type { ModuleScopeAnalysis } from './module-scope';
+import { staticStringValue } from './type-guards';
+import { walkAst } from './walk-ast';
+
+const GLOBAL_THIS_NAME = 'globalThis';
+const NODE_GLOBAL_ALIAS_NAME = 'global';
+
+// `global` is Node's own alias for the ambient global object.
+function isAmbientGlobalReceiverName(name: string): boolean {
+    return name === GLOBAL_THIS_NAME || name === NODE_GLOBAL_ALIAS_NAME;
+}
+
+// Only an unresolved `globalThis`/`global` identifier or a chain of single-`const` aliases counts — a `let`, parameter, or ambiguous binding is treated as opaque to avoid a false positive from something that might not always hold the ambient global.
+function resolvesToAmbientGlobal(
+    node: Expression | Super,
+    scopeAnalysis: ModuleScopeAnalysis,
+    visited: Set<eslintScope.Variable> = new Set(),
+): boolean {
+    // `globalThis.globalThis`/`global.global` is a real, valid self-reference — recurse through it before falling back to opaque for any other receiver shape.
+    if (node.type === 'MemberExpression') {
+        const propertyName = staticMemberName(node);
+        if (!propertyName || !isAmbientGlobalReceiverName(propertyName)) {
+            return false;
+        }
+        return resolvesToAmbientGlobal(node.object, scopeAnalysis, visited);
+    }
+
+    if (node.type !== 'Identifier') {
+        return false;
+    }
+
+    const variable = resolveIdentifier(node, scopeAnalysis);
+    if (!variable) {
+        return isAmbientGlobalReceiverName(node.name);
+    }
+
+    if (visited.has(variable) || variable.defs.length !== 1) {
+        return false;
+    }
+    visited.add(variable);
+
+    const [definition] = variable.defs;
+    if (definition.type !== 'Variable' || definition.parent.kind !== 'const') {
+        return false;
+    }
+
+    // Cast needed: `definition.node` is typed against eslint's bundled `@types/estree`, a distinct package from the `estree` types used elsewhere in this file.
+    const declarator = definition.node as VariableDeclarator;
+    // A destructured binding (`const { x } = y`) names a specific property of `y`, not `y` itself, so it must not inherit `y`'s ambient-global identity.
+    if (declarator.id.type !== 'Identifier' || !declarator.init) {
+        return false;
+    }
+
+    return resolvesToAmbientGlobal(declarator.init, scopeAnalysis, visited);
+}
+
+function staticMemberName(node: MemberExpression): string | undefined {
+    if (!node.computed) {
+        return node.property.type === 'Identifier' ? node.property.name : undefined;
+    }
+    return staticStringValue(node.property);
+}
+
+function staticPropertyName(property: Property): string | undefined {
+    // A non-computed key can still be a quoted string literal (`{ 'fetch': f }`), not just an Identifier — fall through to staticStringValue so that shape resolves too.
+    if (!property.computed && property.key.type === 'Identifier') {
+        return property.key.name;
+    }
+    return staticStringValue(property.key);
+}
+
+export interface AmbientGlobalAccessHandlers {
+    /** A specific restricted/divergent name was reached by name. */
+    onNamedAccess(name: string): void;
+    /** A rest destructure of `globalThis`/`global` copied every ambient global at once, with no specific name to report. */
+    onRestDestructure(): void;
+}
+
+// Walks every syntactic form that can reach the ambient global object and reports matching names; shared by `rejectRestrictedGlobals` and `warnAboutDivergentGlobals`, which only differ in throw vs. warn.
+export function forEachAmbientGlobalAccess(
+    program: Program,
+    scopeAnalysis: ModuleScopeAnalysis,
+    names: ReadonlySet<string>,
+    handlers: AmbientGlobalAccessHandlers,
+): void {
+    for (const [identifier, reference] of scopeAnalysis.referencesByIdentifier) {
+        if (!names.has(identifier.name) || reference.resolved) {
+            continue;
+        }
+        handlers.onNamedAccess(identifier.name);
+    }
+
+    const checkDestructure = (pattern: ObjectPattern, init: Expression | null | undefined) => {
+        if (!init || !resolvesToAmbientGlobal(init, scopeAnalysis)) {
+            return;
+        }
+        for (const property of pattern.properties) {
+            if (property.type === 'RestElement') {
+                handlers.onRestDestructure();
+                continue;
+            }
+            const name = staticPropertyName(property);
+            if (name && names.has(name)) {
+                handlers.onNamedAccess(name);
+            }
+        }
+    };
+
+    walkAst(program, null, {
+        MemberExpression(node) {
+            if (!resolvesToAmbientGlobal(node.object, scopeAnalysis)) {
+                return;
+            }
+            const name = staticMemberName(node);
+            if (name && names.has(name)) {
+                handlers.onNamedAccess(name);
+            }
+        },
+        VariableDeclarator(node) {
+            if (node.id.type === 'ObjectPattern') {
+                checkDestructure(node.id, node.init);
+            }
+        },
+        AssignmentExpression(node) {
+            if (node.left.type === 'ObjectPattern') {
+                checkDestructure(node.left, node.right);
+            }
+        },
+        // A destructuring default value (`function run({ fetch } = globalThis)`) is an AssignmentPattern, not reached by the VariableDeclarator/AssignmentExpression visitors above.
+        AssignmentPattern(node) {
+            if (node.left.type === 'ObjectPattern') {
+                checkDestructure(node.left, node.right);
+            }
+        },
+        // The mirror image of a rest-destructure — `{ ...globalThis }` copies every ambient global into a new object just as `const { ...x } = globalThis` does.
+        ObjectExpression(node: ObjectExpression) {
+            for (const property of node.properties) {
+                if (
+                    property.type === 'SpreadElement' &&
+                    resolvesToAmbientGlobal(property.argument, scopeAnalysis)
+                ) {
+                    handlers.onRestDestructure();
+                }
+            }
+        },
+    });
+}

--- a/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
@@ -11,6 +11,7 @@ import type {
     Program,
     Property,
     Super,
+    VariableDeclarator,
 } from 'estree';
 
 import { resolveIdentifier } from './module-scope';
@@ -26,13 +27,16 @@ function isAmbientGlobalReceiverName(name: string): boolean {
     return name === GLOBAL_THIS_NAME || name === NODE_GLOBAL_ALIAS_NAME;
 }
 
-// Only an unresolved `globalThis`/`global` identifier or a chain of single-`const` aliases counts — a `let`, parameter, or ambiguous binding is treated as opaque to avoid a false positive from something that might not always hold the ambient global.
+// Tracks a for-of loop's ambient-global binding (see the ForOfStatement visitor below) — a loop variable has no `.init` for resolvesToAmbientGlobal's normal alias-chain check to inspect. Reset per forEachAmbientGlobalAccess call.
+let forOfAmbientAliases = new Set<eslintScope.Variable>();
+
+// Only an unresolved `globalThis`/`global` identifier or a chain of single-`const` aliases counts — a `let`, parameter, or other ambiguous binding is treated as opaque.
 function resolvesToAmbientGlobal(
     node: Expression | Super,
     scopeAnalysis: ModuleScopeAnalysis,
     visited: Set<eslintScope.Variable> = new Set(),
 ): boolean {
-    // `globalThis.globalThis`/`global.global` is a real, valid self-reference — recurse through it before falling back to opaque for any other receiver shape.
+    // `globalThis.globalThis`/`global.global` is a real self-reference — recurse through it before treating other receiver shapes as opaque.
     if (node.type === 'MemberExpression') {
         const propertyName = staticMemberName(node);
         if (!propertyName || !isAmbientGlobalReceiverName(propertyName)) {
@@ -50,6 +54,10 @@ function resolvesToAmbientGlobal(
         return isAmbientGlobalReceiverName(node.name);
     }
 
+    if (forOfAmbientAliases.has(variable)) {
+        return true;
+    }
+
     if (visited.has(variable) || variable.defs.length !== 1) {
         return false;
     }
@@ -60,7 +68,7 @@ function resolvesToAmbientGlobal(
         return false;
     }
 
-    // `definition.node` is typed against eslint's bundled `@types/estree`, a distinct package (structurally identical) from the `estree` types used elsewhere in this file — narrowed via a type guard rather than asserted.
+    // `definition.node` is typed against eslint-scope's bundled (structurally identical) `estree` types — narrowed via a type guard rather than asserted.
     if (!isVariableDeclaratorNode(definition.node)) {
         return false;
     }
@@ -72,14 +80,18 @@ function resolvesToAmbientGlobal(
     if (id.type === 'Identifier') {
         return resolvesToAmbientGlobal(init, scopeAnalysis, visited);
     }
-    // A destructured binding (`const { x } = y`) names a specific property of `y`, not `y` itself — except when that property's own key is a `globalThis`/`global` self-reference (`const { globalThis: g } = globalThis`), since `y.globalThis === y` when `y` is the ambient global, making `g` a real alias for it rather than an arbitrary property.
+    // A destructure normally names a property of `y`, not `y` itself — unless the key is a `globalThis`/`global` self-reference (`const { globalThis: g } = globalThis`), since `y.globalThis === y` makes `g` a real alias.
     if (id.type === 'ObjectPattern') {
-        const selfReferenceProperty = id.properties.find(
-            (property) =>
-                property.type === 'Property' &&
-                property.value === definition.name &&
-                isAmbientGlobalReceiverName(staticPropertyName(property) ?? ''),
-        );
+        const selfReferenceProperty = id.properties.find((property) => {
+            if (property.type !== 'Property') {
+                return false;
+            }
+            const propertyName = staticPropertyName(property) ?? '';
+            return (
+                unwrapDefaultValue(property.value) === definition.name &&
+                isAmbientGlobalReceiverName(propertyName)
+            );
+        });
         if (selfReferenceProperty) {
             return resolvesToAmbientGlobal(init, scopeAnalysis, visited);
         }
@@ -95,28 +107,65 @@ function staticMemberName(node: MemberExpression): string | undefined {
     return staticStringValue(node.property);
 }
 
+// A defaulted property value (`{ x = fallback }`) is an AssignmentPattern wrapping the real binding — unwrap it so a defaulted alias is treated the same as a bare one.
+function unwrapDefaultValue(value: Property['value']): Property['value'] {
+    return value.type === 'AssignmentPattern' ? value.left : value;
+}
+
 function staticPropertyName(property: Property): string | undefined {
-    // A non-computed key can still be a quoted string literal (`{ 'fetch': f }`), not just an Identifier — fall through to staticStringValue so that shape resolves too.
+    // A non-computed key can still be a quoted string literal (`{ 'fetch': f }`) — fall through to staticStringValue for that shape.
     if (!property.computed && property.key.type === 'Identifier') {
         return property.key.name;
     }
     return staticStringValue(property.key);
 }
 
+// A for-of binding identifier is a declaration site, not a reference, so `resolveIdentifier` (which only resolves references) can't find it — look it up via eslint-scope's declarator-to-Variable index instead.
+function findDeclaredVariable(
+    declarator: VariableDeclarator,
+    scopeAnalysis: ModuleScopeAnalysis,
+): eslintScope.Variable | undefined {
+    return scopeAnalysis.scopeManager.getDeclaredVariables(declarator)[0];
+}
+
+// Standard-library statics that reify every property VALUE of their argument at once (see the CallExpression visitor below). `Object.keys`/`Reflect.ownKeys` are excluded since they return only name strings, not values. Matched by identifier name only — a locally-shadowed `Object`/`Reflect` is an accepted gap.
+const BULK_COPY_CALLS: ReadonlyArray<{ readonly object: string; readonly property: string }> = [
+    { object: 'Object', property: 'assign' },
+    { object: 'Object', property: 'values' },
+    { object: 'Object', property: 'entries' },
+    { object: 'Object', property: 'getOwnPropertyDescriptors' },
+];
+
+function matchesBulkCopyCall(callee: Expression | Super): boolean {
+    if (callee.type !== 'MemberExpression' || callee.computed) {
+        return false;
+    }
+    if (callee.object.type !== 'Identifier' || callee.property.type !== 'Identifier') {
+        return false;
+    }
+    const objectName = callee.object.name;
+    const propertyName = callee.property.name;
+    return BULK_COPY_CALLS.some(
+        (candidate) => candidate.object === objectName && candidate.property === propertyName,
+    );
+}
+
 export interface AmbientGlobalAccessHandlers {
     /** A specific restricted/divergent name was reached by name. */
     onNamedAccess(name: string): void;
-    /** A rest destructure of `globalThis`/`global` copied every ambient global at once, with no specific name to report. */
-    onRestDestructure(): void;
+    /** Every ambient global was copied at once (a rest destructure, an object spread, or a bulk-copy call like `Object.assign`/`Object.values`), with no specific name to report. */
+    onBulkCopy(): void;
 }
 
-// Walks every syntactic form that can reach the ambient global object and reports matching names; shared by `rejectRestrictedGlobals` and `warnAboutDivergentGlobals`, which only differ in throw vs. warn.
+// Walks every syntactic form that can reach the ambient global object and reports matching names; shared by `rejectRestrictedGlobals` and `warnAboutDivergentGlobals`.
 export function forEachAmbientGlobalAccess(
     program: Program,
     scopeAnalysis: ModuleScopeAnalysis,
     names: ReadonlySet<string>,
     handlers: AmbientGlobalAccessHandlers,
 ): void {
+    forOfAmbientAliases = new Set();
+
     for (const [identifier, reference] of scopeAnalysis.referencesByIdentifier) {
         if (!names.has(identifier.name) || reference.resolved) {
             continue;
@@ -124,28 +173,34 @@ export function forEachAmbientGlobalAccess(
         handlers.onNamedAccess(identifier.name);
     }
 
-    const checkDestructure = (pattern: ObjectPattern, init: Expression | null | undefined) => {
-        if (!init || !resolvesToAmbientGlobal(init, scopeAnalysis)) {
-            return;
-        }
+    // Shared by both `const { x } = globalThis`-style destructures and a for-of loop's inline destructure below — the per-property checking is identical once the source is known to be the ambient global.
+    const checkDestructuredPattern = (pattern: ObjectPattern) => {
         for (const property of pattern.properties) {
             if (property.type === 'RestElement') {
-                handlers.onRestDestructure();
+                handlers.onBulkCopy();
                 continue;
             }
             const name = staticPropertyName(property);
             if (name && names.has(name)) {
                 handlers.onNamedAccess(name);
             }
-            // `const { globalThis: { fetch } } = globalThis` is a real self-reference (globalThis.globalThis === globalThis), so recurse the same way resolvesToAmbientGlobal's MemberExpression case does — otherwise a name nested one level inside a `globalThis`/`global` destructure key escapes detection entirely.
+            // `const { globalThis: { fetch } } = globalThis` is a real self-reference, so recurse the same way resolvesToAmbientGlobal's MemberExpression case does — otherwise a name nested inside a `globalThis`/`global` key escapes detection.
+            const nestedPattern = unwrapDefaultValue(property.value);
             if (
                 name &&
                 isAmbientGlobalReceiverName(name) &&
-                property.value.type === 'ObjectPattern'
+                nestedPattern.type === 'ObjectPattern'
             ) {
-                checkDestructure(property.value, init);
+                checkDestructuredPattern(nestedPattern);
             }
         }
+    };
+
+    const checkDestructure = (pattern: ObjectPattern, init: Expression | null | undefined) => {
+        if (!init || !resolvesToAmbientGlobal(init, scopeAnalysis)) {
+            return;
+        }
+        checkDestructuredPattern(pattern);
     };
 
     walkAst(program, null, {
@@ -168,21 +223,82 @@ export function forEachAmbientGlobalAccess(
                 checkDestructure(node.left, node.right);
             }
         },
-        // A destructuring default value (`function run({ fetch } = globalThis)`) is an AssignmentPattern, not reached by the VariableDeclarator/AssignmentExpression visitors above.
+        // A destructuring default value (`function run({ fetch } = globalThis)`) is an AssignmentPattern, unreached by the visitors above.
         AssignmentPattern(node) {
             if (node.left.type === 'ObjectPattern') {
                 checkDestructure(node.left, node.right);
             }
         },
-        // The mirror image of a rest-destructure — `{ ...globalThis }` copies every ambient global into a new object just as `const { ...x } = globalThis` does.
+        // A for-of binding has no `.init` for the normal alias-chain check to read, so it needs its own handling — scoped to an inline array literal in the loop head, not full data-flow through an intermediate variable. ArrayPattern bindings (`for (const [x] of ...)`) aren't handled, same opacity tier as other unhandled cases.
+        ForOfStatement(node) {
+            if (node.right.type !== 'ArrayExpression') {
+                return;
+            }
+
+            let bindingPattern: ObjectPattern | undefined;
+            let bindingIdentifierVariable: eslintScope.Variable | undefined;
+
+            if (node.left.type === 'VariableDeclaration') {
+                if (node.left.declarations.length !== 1) {
+                    return;
+                }
+                const [declarator] = node.left.declarations;
+                if (declarator.id.type === 'ObjectPattern') {
+                    bindingPattern = declarator.id;
+                } else if (declarator.id.type === 'Identifier' && node.left.kind === 'const') {
+                    bindingIdentifierVariable = findDeclaredVariable(declarator, scopeAnalysis);
+                } else {
+                    // A `let` binding can be reassigned in the loop body, so unlike the ObjectPattern
+                    // case above it isn't provably still the ambient global — same opacity rule as a
+                    // `let` alias chain.
+                    return;
+                }
+            } else if (node.left.type === 'ObjectPattern') {
+                bindingPattern = node.left;
+            } else {
+                // A bare-identifier target (`for (x of ...)`) always reuses an existing, reassignable
+                // binding — never provably const — so it's opaque too.
+                return;
+            }
+
+            const hasAmbientElement = node.right.elements.some(
+                (element) =>
+                    element !== null &&
+                    element.type !== 'SpreadElement' &&
+                    resolvesToAmbientGlobal(element, scopeAnalysis),
+            );
+            if (!hasAmbientElement) {
+                return;
+            }
+
+            if (bindingPattern) {
+                checkDestructuredPattern(bindingPattern);
+            } else if (bindingIdentifierVariable) {
+                forOfAmbientAliases.add(bindingIdentifierVariable);
+            }
+        },
+        // Mirrors a rest-destructure — `{ ...globalThis }` copies every ambient global just as `const { ...x } = globalThis` does.
         ObjectExpression(node: ObjectExpression) {
             for (const property of node.properties) {
                 if (
                     property.type === 'SpreadElement' &&
                     resolvesToAmbientGlobal(property.argument, scopeAnalysis)
                 ) {
-                    handlers.onRestDestructure();
+                    handlers.onBulkCopy();
                 }
+            }
+        },
+        // Built-in statics like `Object.assign({}, globalThis)` reify every property at once — the same threat as a rest-destructure or spread, but with no named-property access for the visitors above to see. Scoped to this known list, not a user-defined equivalent or an aliased `Object`/`Reflect`.
+        CallExpression(node) {
+            if (!matchesBulkCopyCall(node.callee)) {
+                return;
+            }
+            const hasAmbientArgument = node.arguments.some(
+                (arg) =>
+                    arg.type !== 'SpreadElement' && resolvesToAmbientGlobal(arg, scopeAnalysis),
+            );
+            if (hasAmbientArgument) {
+                handlers.onBulkCopy();
             }
         },
     });

--- a/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
@@ -80,19 +80,27 @@ function resolvesToAmbientGlobal(
     if (id.type === 'Identifier') {
         return resolvesToAmbientGlobal(init, scopeAnalysis, visited);
     }
-    // A destructure normally names a property of `y`, not `y` itself — unless the key is a `globalThis`/`global` self-reference (`const { globalThis: g } = globalThis`), since `y.globalThis === y` makes `g` a real alias.
+    // A destructure normally names a property of `y`, not `y` itself — unless every key on the
+    // path down to this binding is a `globalThis`/`global` self-reference (`const { globalThis:
+    // { globalThis: g } } = globalThis`), since `y.globalThis === y` holds at any depth of
+    // repeated self-reference, not just one level.
     if (id.type === 'ObjectPattern') {
-        const selfReferenceProperty = id.properties.find((property) => {
-            if (property.type !== 'Property') {
-                return false;
-            }
-            const propertyName = staticPropertyName(property) ?? '';
-            return (
-                unwrapDefaultValue(property.value) === definition.name &&
-                isAmbientGlobalReceiverName(propertyName)
-            );
-        });
-        if (selfReferenceProperty) {
+        const reachesSelfReference = (pattern: ObjectPattern): boolean =>
+            pattern.properties.some((property) => {
+                if (property.type !== 'Property') {
+                    return false;
+                }
+                const propertyName = staticPropertyName(property) ?? '';
+                if (!isAmbientGlobalReceiverName(propertyName)) {
+                    return false;
+                }
+                const value = unwrapDefaultValue(property.value);
+                return (
+                    value === definition.name ||
+                    (value.type === 'ObjectPattern' && reachesSelfReference(value))
+                );
+            });
+        if (reachesSelfReference(id)) {
             return resolvesToAmbientGlobal(init, scopeAnalysis, visited);
         }
     }
@@ -139,14 +147,18 @@ const BULK_COPY_CALLS: ReadonlyArray<{ readonly object: string; readonly propert
 function matchBulkCopyCall(
     callee: Expression | Super,
 ): { readonly object: string; readonly property: string } | undefined {
-    if (callee.type !== 'MemberExpression' || callee.computed) {
+    if (callee.type !== 'MemberExpression' || callee.object.type !== 'Identifier') {
         return undefined;
     }
-    if (callee.object.type !== 'Identifier' || callee.property.type !== 'Identifier') {
+    // staticMemberName already handles both a plain identifier property (`.assign`) and a
+    // computed access resolving to a static string (`["assign"]`) — reusing it here (instead of
+    // requiring callee.property.type === 'Identifier') closes a gap where `Object["assign"](...)`
+    // evaded detection entirely.
+    const propertyName = staticMemberName(callee);
+    if (!propertyName) {
         return undefined;
     }
     const objectName = callee.object.name;
-    const propertyName = callee.property.name;
     return BULK_COPY_CALLS.find(
         (candidate) => candidate.object === objectName && candidate.property === propertyName,
     );

--- a/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts
@@ -136,16 +136,18 @@ const BULK_COPY_CALLS: ReadonlyArray<{ readonly object: string; readonly propert
     { object: 'Object', property: 'getOwnPropertyDescriptors' },
 ];
 
-function matchesBulkCopyCall(callee: Expression | Super): boolean {
+function matchBulkCopyCall(
+    callee: Expression | Super,
+): { readonly object: string; readonly property: string } | undefined {
     if (callee.type !== 'MemberExpression' || callee.computed) {
-        return false;
+        return undefined;
     }
     if (callee.object.type !== 'Identifier' || callee.property.type !== 'Identifier') {
-        return false;
+        return undefined;
     }
     const objectName = callee.object.name;
     const propertyName = callee.property.name;
-    return BULK_COPY_CALLS.some(
+    return BULK_COPY_CALLS.find(
         (candidate) => candidate.object === objectName && candidate.property === propertyName,
     );
 }
@@ -290,10 +292,15 @@ export function forEachAmbientGlobalAccess(
         },
         // Built-in statics like `Object.assign({}, globalThis)` reify every property at once — the same threat as a rest-destructure or spread, but with no named-property access for the visitors above to see. Scoped to this known list, not a user-defined equivalent or an aliased `Object`/`Reflect`.
         CallExpression(node) {
-            if (!matchesBulkCopyCall(node.callee)) {
+            const match = matchBulkCopyCall(node.callee);
+            if (!match) {
                 return;
             }
-            const hasAmbientArgument = node.arguments.some(
+            // Object.assign's first argument is the write target, not a source — checking it would
+            // reject harmless calls like Object.assign(globalThis, { marker: true }).
+            const sourceArguments =
+                match.property === 'assign' ? node.arguments.slice(1) : node.arguments;
+            const hasAmbientArgument = sourceArguments.some(
                 (arg) =>
                     arg.type !== 'SpreadElement' && resolvesToAmbientGlobal(arg, scopeAnalysis),
             );

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.test.ts
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { rejectNodeBuiltinImports } from '@dd/apps-plugin/backend/ast-parsing/reject-node-builtin-imports';
+import type { ImportDeclaration, Program } from 'estree';
+
+/**
+ * Helper to build a minimal ESTree Program for testing.
+ */
+function program(body: Program['body']): Program {
+    return { type: 'Program', sourceType: 'module', body };
+}
+
+/**
+ * Helper to build a minimal ImportDeclaration node for a given source.
+ */
+function importDecl(source: string, overrides: Partial<ImportDeclaration> = {}): ImportDeclaration {
+    return {
+        type: 'ImportDeclaration',
+        specifiers: [
+            {
+                type: 'ImportDefaultSpecifier',
+                local: { type: 'Identifier', name: 'x' },
+            },
+        ],
+        source: { type: 'Literal', value: source },
+        attributes: [],
+        ...overrides,
+    };
+}
+
+describe('Backend Functions - rejectNodeBuiltinImports', () => {
+    const filePath = '/project/src/math.backend.ts';
+
+    const allowedCases = [
+        {
+            description: 'allow importing a relative module',
+            source: './helpers',
+        },
+        {
+            description: 'allow importing a scoped npm package',
+            source: '@datadog/action-catalog',
+        },
+        {
+            description: 'allow importing an ordinary npm package',
+            source: 'lodash',
+        },
+    ];
+
+    test.each(allowedCases)('Should $description', ({ source }) => {
+        const ast = program([importDecl(source)]);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    const rejectedCases = [
+        {
+            description: 'reject importing "node:fs" via the node: prefix',
+            source: 'node:fs',
+        },
+        {
+            description: 'reject importing the bare built-in "fs"',
+            source: 'fs',
+        },
+        {
+            description: 'reject importing "child_process"',
+            source: 'child_process',
+        },
+        {
+            description: 'reject importing "node:child_process"',
+            source: 'node:child_process',
+        },
+        {
+            description: 'reject importing "net"',
+            source: 'net',
+        },
+        {
+            description: 'reject importing a built-in subpath "fs/promises"',
+            source: 'fs/promises',
+        },
+    ];
+
+    test.each(rejectedCases)('Should $description', ({ source }) => {
+        const ast = program([importDecl(source)]);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(
+            `Importing Node built-in module "${source}" is not supported in .backend.ts files`,
+        );
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(filePath);
+    });
+
+    test('Should allow a type-only import of a Node built-in', () => {
+        // import type { Stats } from 'fs';
+        const ast = program([
+            importDecl('fs', { importKind: 'type' } as Partial<ImportDeclaration>),
+        ]);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    test('Should ignore non-import statements', () => {
+        const ast = program([
+            {
+                type: 'ExpressionStatement',
+                expression: { type: 'Literal', value: 1 },
+            },
+        ]);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+});

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.test.ts
@@ -3,19 +3,25 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { rejectNodeBuiltinImports } from '@dd/apps-plugin/backend/ast-parsing/reject-node-builtin-imports';
-import type { ImportDeclaration, Program } from 'estree';
+import type { TypeScriptImportExportMetadata } from '@dd/apps-plugin/backend/ast-parsing/type-guards';
+import type {
+    ExportNamedDeclaration,
+    ExportSpecifier,
+    ImportDeclaration,
+    ImportSpecifier,
+    Program,
+} from 'estree';
+import { parseAst } from 'rollup/parseAst';
 
-/**
- * Helper to build a minimal ESTree Program for testing.
- */
 function program(body: Program['body']): Program {
     return { type: 'Program', sourceType: 'module', body };
 }
 
-/**
- * Helper to build a minimal ImportDeclaration node for a given source.
- */
-function importDecl(source: string, overrides: Partial<ImportDeclaration> = {}): ImportDeclaration {
+// `overrides` also accepts TypeScript's `importKind`/`exportKind` (not declared by `estree`), so type-only imports can be built without a cast.
+function importDecl(
+    source: string,
+    overrides: Partial<ImportDeclaration> & TypeScriptImportExportMetadata = {},
+): ImportDeclaration {
     return {
         type: 'ImportDeclaration',
         specifiers: [
@@ -26,6 +32,53 @@ function importDecl(source: string, overrides: Partial<ImportDeclaration> = {}):
         ],
         source: { type: 'Literal', value: source },
         attributes: [],
+        ...overrides,
+    };
+}
+
+// Built by hand rather than parsed: `rollup/parseAst` can't parse TypeScript's `export type { ... }` syntax used by the type-only re-export test below.
+function exportNamedDecl(
+    source: string,
+    overrides: Partial<ExportNamedDeclaration> & TypeScriptImportExportMetadata = {},
+): ExportNamedDeclaration {
+    return {
+        type: 'ExportNamedDeclaration',
+        declaration: null,
+        specifiers: [
+            {
+                type: 'ExportSpecifier',
+                local: { type: 'Identifier', name: 'readFile' },
+                exported: { type: 'Identifier', name: 'readFile' },
+            },
+        ],
+        source: { type: 'Literal', value: source },
+        attributes: [],
+        ...overrides,
+    };
+}
+
+// Same technique as `importDecl` above, for TypeScript's inline `importKind`.
+function importSpecifier(
+    name: string,
+    overrides: Partial<ImportSpecifier> & TypeScriptImportExportMetadata = {},
+): ImportSpecifier & TypeScriptImportExportMetadata {
+    return {
+        type: 'ImportSpecifier',
+        imported: { type: 'Identifier', name },
+        local: { type: 'Identifier', name },
+        ...overrides,
+    };
+}
+
+// Same technique as `exportNamedDecl` above, for TypeScript's inline `exportKind`.
+function exportSpecifier(
+    name: string,
+    overrides: Partial<ExportSpecifier> & TypeScriptImportExportMetadata = {},
+): ExportSpecifier & TypeScriptImportExportMetadata {
+    return {
+        type: 'ExportSpecifier',
+        local: { type: 'Identifier', name },
+        exported: { type: 'Identifier', name },
         ...overrides,
     };
 }
@@ -49,7 +102,8 @@ describe('Backend Functions - rejectNodeBuiltinImports', () => {
     ];
 
     test.each(allowedCases)('Should $description', ({ source }) => {
-        const ast = program([importDecl(source)]);
+        const importDeclaration = importDecl(source);
+        const ast = program([importDeclaration]);
         expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
     });
 
@@ -81,19 +135,42 @@ describe('Backend Functions - rejectNodeBuiltinImports', () => {
     ];
 
     test.each(rejectedCases)('Should $description', ({ source }) => {
-        const ast = program([importDecl(source)]);
+        const importDeclaration = importDecl(source);
+        const ast = program([importDeclaration]);
         expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(
-            `Importing Node built-in module "${source}" is not supported in .backend.ts files`,
+            `Importing Node built-in module "${source}" is not supported in backend function code`,
         );
         expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(filePath);
     });
 
     test('Should allow a type-only import of a Node built-in', () => {
         // import type { Stats } from 'fs';
-        const ast = program([
-            importDecl('fs', { importKind: 'type' } as Partial<ImportDeclaration>),
-        ]);
+        const importDeclaration = importDecl('fs', { importKind: 'type' });
+        const ast = program([importDeclaration]);
         expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    test('Should allow an inline type-only named specifier of a Node built-in', () => {
+        // import { type Stats } from 'fs';
+        const importDeclaration = importDecl('fs', {
+            specifiers: [importSpecifier('Stats', { importKind: 'type' })],
+        });
+        const ast = program([importDeclaration]);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    test('Should reject when only one of several named specifiers is inline type-only', () => {
+        // import { type Stats, readFileSync } from 'fs';
+        const importDeclaration = importDecl('fs', {
+            specifiers: [
+                importSpecifier('Stats', { importKind: 'type' }),
+                importSpecifier('readFileSync'),
+            ],
+        });
+        const ast = program([importDeclaration]);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(
+            `Importing Node built-in module "fs" is not supported in backend function code`,
+        );
     });
 
     test('Should ignore non-import statements', () => {
@@ -103,6 +180,95 @@ describe('Backend Functions - rejectNodeBuiltinImports', () => {
                 expression: { type: 'Literal', value: 1 },
             },
         ]);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    const rejectedReExportCases = [
+        {
+            description: 'reject re-exporting "readFile" from "node:fs" under a new name',
+            code: "export { readFile as handler } from 'node:fs';",
+            source: 'node:fs',
+        },
+        {
+            description: 'reject re-exporting the bare built-in "fs" without renaming',
+            code: "export { readFile } from 'fs';",
+            source: 'fs',
+        },
+    ];
+
+    test.each(rejectedReExportCases)('Should $description', ({ code, source }) => {
+        const ast = parseAst(code);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(
+            `Importing Node built-in module "${source}" is not supported in backend function code`,
+        );
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(filePath);
+    });
+
+    test('Should allow re-exporting from a relative module', () => {
+        const ast = parseAst("export { helper } from './helpers';");
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    test('Should allow a type-only re-export of a Node built-in', () => {
+        // export type { Stats } from 'fs';
+        const exportDeclaration = exportNamedDecl('fs', { exportKind: 'type' });
+        const ast = program([exportDeclaration]);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    test('Should allow an inline type-only named re-export specifier of a Node built-in', () => {
+        // export { type Stats } from 'fs';
+        const exportDeclaration = exportNamedDecl('fs', {
+            specifiers: [exportSpecifier('Stats', { exportKind: 'type' })],
+        });
+        const ast = program([exportDeclaration]);
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    test('Should reject "export * from" a Node built-in', () => {
+        const ast = parseAst("export * from 'node:fs';");
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(
+            'Importing Node built-in module "node:fs" is not supported in backend function code',
+        );
+    });
+
+    test('Should reject "export * as ns from" a Node built-in', () => {
+        const ast = parseAst("export * as fs from 'node:fs';");
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(
+            'Importing Node built-in module "node:fs" is not supported in backend function code',
+        );
+    });
+
+    test('Should allow "export * from" a relative module', () => {
+        const ast = parseAst("export * from './helpers';");
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    test('Should allow a named export with no source', () => {
+        const ast = parseAst('const value = 1;\nexport { value };');
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    test('Should reject a literal dynamic import() of a Node built-in', () => {
+        const ast = parseAst(
+            "export async function run() { const fs = await import('node:fs'); return fs.readFileSync('/etc/passwd'); }",
+        );
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).toThrow(
+            'Importing Node built-in module "node:fs" is not supported in backend function code',
+        );
+    });
+
+    test('Should allow a literal dynamic import() of a relative module', () => {
+        const ast = parseAst(
+            "export async function run() { return (await import('./helpers')).helper(); }",
+        );
+        expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
+    });
+
+    test('Should allow a non-literal dynamic import(), which cannot be statically checked', () => {
+        const ast = parseAst(
+            'export async function run(name) { return (await import(name)).default; }',
+        );
         expect(() => rejectNodeBuiltinImports(ast, filePath)).not.toThrow();
     });
 });

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { BaseNode } from 'estree';
+import { builtinModules } from 'node:module';
+
+import { ensureProgram, isTypeOnly } from './type-guards';
+
+const RESTRICTED_MODULES = new Set<string>(builtinModules);
+
+function isRestrictedSource(source: string): boolean {
+    return source.startsWith('node:') || RESTRICTED_MODULES.has(source);
+}
+
+/**
+ * Reject static imports of Node built-in modules in `.backend.ts` files.
+ * Backend functions run in a restricted environment with no direct Node
+ * built-in or network access — everything, including raw HTTP requests,
+ * must go through an Action Platform action ($.Actions or an
+ * @datadog/action-catalog typed wrapper).
+ *
+ * This is a best-effort, defense-in-depth check on static `import` specifiers
+ * only — it doesn't catch `require()` or dynamic `import()` of a computed
+ * specifier. See also `rejectRestrictedGlobals`, which covers bare network
+ * globals like `fetch` that need no import at all.
+ */
+export function rejectNodeBuiltinImports(ast: BaseNode, filePath: string): void {
+    const program = ensureProgram(ast, filePath);
+    for (const node of program.body) {
+        if (node.type !== 'ImportDeclaration' || isTypeOnly(node)) {
+            continue;
+        }
+
+        const source = node.source.value;
+        if (typeof source === 'string' && isRestrictedSource(source)) {
+            throw new Error(
+                `Importing Node built-in module "${source}" is not supported in .backend.ts files. ` +
+                    `Backend functions run in a restricted environment and must use an Action ` +
+                    `Platform action ($.Actions or an @datadog/action-catalog typed wrapper) instead: ${filePath}`,
+            );
+        }
+    }
+}

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts
@@ -19,7 +19,7 @@ function hasRuntimeSpecifier(specifiers: readonly BaseNode[]): boolean {
     return specifiers.length === 0 || specifiers.some((specifier) => !isTypeOnly(specifier));
 }
 
-// Reject static/dynamic imports of Node built-ins in `.backend.ts` files, which run in a restricted environment and must go through an Action Platform action instead; this is best-effort and doesn't catch `require()` or a runtime-computed specifier (see `rejectRestrictedGlobals` for bare network globals like `fetch`).
+// Rejects static/dynamic imports of Node built-ins in `.backend.ts` files, which run in a restricted environment. Best-effort — doesn't catch `require()` or a runtime-computed specifier (see `rejectRestrictedGlobals` for bare network globals like `fetch`).
 export function rejectNodeBuiltinImports(ast: BaseNode, filePath: string): void {
     const program = ensureProgram(ast, filePath);
     for (const node of program.body) {

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts
@@ -2,10 +2,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { BaseNode } from 'estree';
+import type { BaseNode, Expression } from 'estree';
 import { builtinModules } from 'node:module';
 
-import { ensureProgram, isTypeOnly } from './type-guards';
+import { ensureProgram, isTypeOnly, staticStringValue } from './type-guards';
+import { walkAst } from './walk-ast';
 
 const RESTRICTED_MODULES = new Set<string>(builtinModules);
 
@@ -13,32 +14,60 @@ function isRestrictedSource(source: string): boolean {
     return source.startsWith('node:') || RESTRICTED_MODULES.has(source);
 }
 
-/**
- * Reject static imports of Node built-in modules in `.backend.ts` files.
- * Backend functions run in a restricted environment with no direct Node
- * built-in or network access — everything, including raw HTTP requests,
- * must go through an Action Platform action ($.Actions or an
- * @datadog/action-catalog typed wrapper).
- *
- * This is a best-effort, defense-in-depth check on static `import` specifiers
- * only — it doesn't catch `require()` or dynamic `import()` of a computed
- * specifier. See also `rejectRestrictedGlobals`, which covers bare network
- * globals like `fetch` that need no import at all.
- */
+// A declaration with no specifiers still evaluates the module for its side effects, so only a specifier list that's entirely type-only is safe to skip.
+function hasRuntimeSpecifier(specifiers: readonly BaseNode[]): boolean {
+    return specifiers.length === 0 || specifiers.some((specifier) => !isTypeOnly(specifier));
+}
+
+// Reject static/dynamic imports of Node built-ins in `.backend.ts` files, which run in a restricted environment and must go through an Action Platform action instead; this is best-effort and doesn't catch `require()` or a runtime-computed specifier (see `rejectRestrictedGlobals` for bare network globals like `fetch`).
 export function rejectNodeBuiltinImports(ast: BaseNode, filePath: string): void {
     const program = ensureProgram(ast, filePath);
     for (const node of program.body) {
-        if (node.type !== 'ImportDeclaration' || isTypeOnly(node)) {
+        if (
+            node.type === 'ImportDeclaration' &&
+            !isTypeOnly(node) &&
+            hasRuntimeSpecifier(node.specifiers)
+        ) {
+            rejectIfRestrictedSource(node.source, filePath);
             continue;
         }
 
-        const source = node.source.value;
-        if (typeof source === 'string' && isRestrictedSource(source)) {
-            throw new Error(
-                `Importing Node built-in module "${source}" is not supported in .backend.ts files. ` +
-                    `Backend functions run in a restricted environment and must use an Action ` +
-                    `Platform action ($.Actions or an @datadog/action-catalog typed wrapper) instead: ${filePath}`,
-            );
+        // A named re-export from a source loads the built-in module just like a regular import does.
+        if (
+            node.type === 'ExportNamedDeclaration' &&
+            node.source &&
+            !isTypeOnly(node) &&
+            hasRuntimeSpecifier(node.specifiers)
+        ) {
+            rejectIfRestrictedSource(node.source, filePath);
+            continue;
+        }
+
+        // `export * from` is its own Rollup node type, not an ExportNamedDeclaration, so it needs its own check.
+        if (node.type === 'ExportAllDeclaration' && !isTypeOnly(node)) {
+            rejectIfRestrictedSource(node.source, filePath);
         }
     }
+
+    // A dynamic `import()` is an ImportExpression that can appear anywhere in the tree, not just program.body, so it needs its own walk.
+    walkAst(program, null, {
+        ImportExpression(node) {
+            rejectIfRestrictedSource(node.source, filePath);
+        },
+    });
+}
+
+function rejectIfRestrictedSource(source: Expression, filePath: string): void {
+    const value = staticStringValue(source);
+    if (value === undefined || !isRestrictedSource(value)) {
+        return;
+    }
+
+    throw new Error(
+        `Importing Node built-in module "${value}" is not supported in backend function code. ` +
+            `Backend functions run in a restricted environment: for networking, filesystem, or ` +
+            `process access, use an Action Platform action ($.Actions or an @datadog/action-catalog ` +
+            `typed wrapper) instead; for pure utility modules (e.g. path, url, util), use a ` +
+            `runtime-independent package instead: ${filePath}`,
+    );
 }

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { BaseNode } from 'estree';
+import { builtinModules } from 'node:module';
+
+import { ensureProgram, isTypeOnly } from './type-guards';
+
+const RESTRICTED_MODULES = new Set<string>(builtinModules);
+
+function isRestrictedSource(source: string): boolean {
+    return source.startsWith('node:') || RESTRICTED_MODULES.has(source);
+}
+
+/**
+ * Reject static imports of Node built-in modules in `.backend.ts` files.
+ * Backend functions run in a restricted environment (isomorphic/fetch-based
+ * APIs only) so direct Node built-in usage isn't supported.
+ *
+ * This is a best-effort, defense-in-depth check on static `import` specifiers
+ * only — it doesn't catch `require()` or dynamic `import()` of a computed
+ * specifier.
+ */
+export function rejectNodeBuiltinImports(ast: BaseNode, filePath: string): void {
+    const program = ensureProgram(ast, filePath);
+    for (const node of program.body) {
+        if (node.type !== 'ImportDeclaration' || isTypeOnly(node)) {
+            continue;
+        }
+
+        const source = node.source.value;
+        if (typeof source === 'string' && isRestrictedSource(source)) {
+            throw new Error(
+                `Importing Node built-in module "${source}" is not supported in .backend.ts files. ` +
+                    `Backend functions run in a restricted environment and must use fetch-based/isomorphic APIs instead: ${filePath}`,
+            );
+        }
+    }
+}

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { rejectRestrictedGlobals } from '@dd/apps-plugin/backend/ast-parsing/reject-restricted-globals';
+import { parseAst } from 'rollup/parseAst';
+
+describe('Backend Functions - rejectRestrictedGlobals', () => {
+    const filePath = '/project/src/math.backend.ts';
+
+    const rejectedCases = [
+        {
+            description: 'reject a bare fetch() call',
+            code: 'export async function run() { return fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject fetch referenced without calling it',
+            code: 'export function run() { const f = fetch; return f; }',
+        },
+        {
+            description: 'reject new XMLHttpRequest()',
+            code: 'export function run() { return new XMLHttpRequest(); }',
+        },
+        {
+            description: 'reject new WebSocket(...)',
+            code: 'export function run() { return new WebSocket("wss://example.com"); }',
+        },
+        {
+            description: 'reject new EventSource(...)',
+            code: 'export function run() { return new EventSource("/events"); }',
+        },
+    ];
+
+    test.each(rejectedCases)('Should $description', ({ code }) => {
+        const ast = parseAst(code);
+        expect(() => rejectRestrictedGlobals(ast, filePath)).toThrow(
+            'is not supported in .backend.ts files',
+        );
+        expect(() => rejectRestrictedGlobals(ast, filePath)).toThrow(filePath);
+    });
+
+    const allowedCases = [
+        {
+            description: 'allow calling an imported action-catalog function',
+            code: "import { request } from '@datadog/action-catalog/http/http';\nexport async function run() { return request({ inputs: {} }); }",
+        },
+        {
+            description: 'allow a locally-declared function that happens to be named fetch',
+            code: 'function fetch() { return "local"; }\nexport function run() { return fetch(); }',
+        },
+        {
+            description: 'allow a parameter named fetch shadowing the global',
+            code: 'export function run(fetch) { return fetch(); }',
+        },
+        {
+            description: 'allow unrelated code with no restricted-global references',
+            code: 'export function run(a, b) { return a + b; }',
+        },
+    ];
+
+    test.each(allowedCases)('Should $description', ({ code }) => {
+        const ast = parseAst(code);
+        expect(() => rejectRestrictedGlobals(ast, filePath)).not.toThrow();
+    });
+});

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
@@ -93,6 +93,27 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
             code: 'export function run() { const stolen = { ...global }; return stolen.fetch("https://example.com"); }',
         },
         {
+            description: 'reject Object.assign copying every ambient global into a new object',
+            code: 'export function run() { const stolen = Object.assign({}, globalThis); return stolen.fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject Object.assign targeting global, the Node global alias',
+            code: 'export function run() { const stolen = Object.assign({}, global); return stolen.fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject Object.values reading every ambient global value at once',
+            code: 'export function run() { const values = Object.values(globalThis); return values.find((v) => typeof v === "function")(); }',
+        },
+        {
+            description: 'reject Object.entries reading every ambient global at once',
+            code: 'export function run() { const entries = Object.entries(globalThis); return entries[0][1](); }',
+        },
+        {
+            description:
+                'reject Object.getOwnPropertyDescriptors reading every ambient global descriptor at once',
+            code: 'export function run() { const descriptors = Object.getOwnPropertyDescriptors(globalThis); return descriptors.fetch.value(); }',
+        },
+        {
             description:
                 'reject globalThis[`fetch`](...) via a no-substitution template-literal key',
             code: 'export async function run() { return globalThis[`fetch`]("https://example.com"); }',
@@ -147,6 +168,36 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
             description:
                 "reject fetch reached through a const alias bound by a self-referential global destructure key (Node's own alias)",
             code: 'export function run() { const { global: g } = global; return g.fetch("https://example.com"); }',
+        },
+        {
+            description:
+                'reject fetch reached through a const alias bound by a self-referential globalThis destructure key that also carries a default value',
+            code: 'export function run() { const { globalThis: g = {} } = globalThis; return g.fetch("https://example.com"); }',
+        },
+        {
+            description:
+                'reject fetch reached through a nested destructure of the self-referential globalThis.globalThis when the outer key carries a default value',
+            code: 'export function run() { const { globalThis: { fetch } = {} } = globalThis; return fetch("https://example.com"); }',
+        },
+        {
+            description:
+                'reject fetch reached through a for-of destructure whose inline iterable array literal contains globalThis',
+            code: 'export function run() { for (const { fetch } of [globalThis]) { return fetch("https://example.com"); } }',
+        },
+        {
+            description:
+                'reject fetch reached through a for-of destructure whose inline iterable array literal contains a const alias of globalThis',
+            code: 'export function run() { const g = globalThis; for (const { fetch } of [g]) { return fetch("https://example.com"); } }',
+        },
+        {
+            description:
+                'reject fetch reached through a plain (non-destructured) for-of loop variable bound to globalThis via an inline array literal',
+            code: 'export function run() { for (const g of [globalThis]) { return g.fetch("https://example.com"); } }',
+        },
+        {
+            description:
+                'reject fetch reached through a for-of loop using an assignment target (no const/let) destructuring globalThis via an inline array literal',
+            code: 'export function run() { let fetch; for ({ fetch } of [globalThis]) { return fetch("https://example.com"); } }',
         },
     ];
 
@@ -224,6 +275,11 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
             code: 'export function run(g = globalThis) { return g.fetch(); }',
         },
         {
+            description:
+                'allow a "let"-declared for-of loop variable bound to globalThis via an inline array literal, since it could be reassigned to something else before use, same opacity as a "let" alias',
+            code: 'export function run() { for (let g of [globalThis]) { g = safeObj; return g.fetch(); } }',
+        },
+        {
             description: 'allow a computed member access with a template literal that interpolates',
             // eslint-disable-next-line no-template-curly-in-string -- source text for the AST under test, not a real interpolation
             code: 'export function run(name) { return globalThis[`${name}`](); }',
@@ -232,6 +288,26 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
             description:
                 'allow accessing a property on a destructured binding of globalThis, since the binding is a specific property value, not the ambient global object itself',
             code: 'export function run() { const { console: g } = globalThis; return g.fetch; }',
+        },
+        {
+            description:
+                'allow Object.assign copying an unrelated object, since the source is not the ambient global',
+            code: 'export function run() { const merged = Object.assign({}, { a: 1 }); return merged; }',
+        },
+        {
+            description:
+                'allow Object.keys on a parameter named globalThis shadowing the ambient global',
+            code: 'export function run(globalThis) { return Object.keys(globalThis); }',
+        },
+        {
+            description:
+                'allow Object.keys(globalThis), since it returns only property-name strings, never a callable reference',
+            code: 'export function run() { const names = Object.keys(globalThis); return names.length; }',
+        },
+        {
+            description:
+                'allow Reflect.ownKeys(globalThis), since it returns only property-name strings, never a callable reference',
+            code: 'export function run() { const keys = Reflect.ownKeys(globalThis); return keys.length; }',
         },
     ];
 

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
@@ -296,6 +296,11 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
         },
         {
             description:
+                'allow Object.assign(globalThis, ...), since globalThis there is the write target, not a source being copied from',
+            code: 'export function run() { Object.assign(globalThis, { marker: true }); }',
+        },
+        {
+            description:
                 'allow Object.keys on a parameter named globalThis shadowing the ambient global',
             code: 'export function run(globalThis) { return Object.keys(globalThis); }',
         },

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
@@ -101,6 +101,11 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
             code: 'export function run() { const stolen = Object.assign({}, global); return stolen.fetch("https://example.com"); }',
         },
         {
+            description:
+                'reject Object["assign"] copying every ambient global, a computed-property-access form of the same call',
+            code: 'export function run() { const stolen = Object["assign"]({}, globalThis); return stolen.fetch("https://example.com"); }',
+        },
+        {
             description: 'reject Object.values reading every ambient global value at once',
             code: 'export function run() { const values = Object.values(globalThis); return values.find((v) => typeof v === "function")(); }',
         },
@@ -173,6 +178,11 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
             description:
                 'reject fetch reached through a const alias bound by a self-referential globalThis destructure key that also carries a default value',
             code: 'export function run() { const { globalThis: g = {} } = globalThis; return g.fetch("https://example.com"); }',
+        },
+        {
+            description:
+                'reject fetch reached through a const alias bound by two levels of self-referential globalThis destructure keys',
+            code: 'export function run() { const { globalThis: { globalThis: g } } = globalThis; return g.fetch("https://example.com"); }',
         },
         {
             description:

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
@@ -29,12 +29,116 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
             description: 'reject new EventSource(...)',
             code: 'export function run() { return new EventSource("/events"); }',
         },
+        {
+            description: 'reject globalThis.fetch(...)',
+            code: 'export async function run() { return globalThis.fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject globalThis.fetch referenced without calling it',
+            code: 'export function run() { const f = globalThis.fetch; return f; }',
+        },
+        {
+            description: 'reject globalThis["fetch"](...)',
+            code: 'export async function run() { return globalThis["fetch"]("https://example.com"); }',
+        },
+        {
+            description: 'reject destructuring fetch off of globalThis',
+            code: 'export function run() { const { fetch } = globalThis; return fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject destructuring fetch off of globalThis under a local alias',
+            code: 'export function run() { const { fetch: doFetch } = globalThis; return doFetch("https://example.com"); }',
+        },
+        {
+            description:
+                'reject destructuring fetch off of globalThis via a computed string-literal key',
+            code: "export function run() { const { ['fetch']: request } = globalThis; return request('https://example.com'); }",
+        },
+        {
+            description: 'reject global.fetch(...) via the Node global alias',
+            code: 'export async function run() { return global.fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject global["fetch"](...) via the Node global alias',
+            code: 'export async function run() { return global["fetch"]("https://example.com"); }',
+        },
+        {
+            description: 'reject destructuring fetch off of global, the Node global alias',
+            code: 'export function run() { const { fetch } = global; return fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject a destructuring *assignment* (not declaration) off of globalThis',
+            code: 'export function run() { let request; ({ fetch: request } = globalThis); return request("https://example.com"); }',
+        },
+        {
+            description: 'reject a destructuring *assignment* off of global, the Node global alias',
+            code: 'export function run() { let request; ({ fetch: request } = global); return request("https://example.com"); }',
+        },
+        {
+            description:
+                'reject a rest-destructure of globalThis, which copies every ambient global',
+            code: 'export function run() { const { ...globals } = globalThis; return globals.fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject a rest-destructure of global, the Node global alias',
+            code: 'export function run() { const { ...globals } = global; return globals.fetch("https://example.com"); }',
+        },
+        {
+            description:
+                'reject spreading globalThis into a new object, which copies every ambient global',
+            code: 'export function run() { const stolen = { ...globalThis }; return stolen.fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject spreading global into a new object, the Node global alias',
+            code: 'export function run() { const stolen = { ...global }; return stolen.fetch("https://example.com"); }',
+        },
+        {
+            description:
+                'reject globalThis[`fetch`](...) via a no-substitution template-literal key',
+            code: 'export async function run() { return globalThis[`fetch`]("https://example.com"); }',
+        },
+        {
+            description: 'reject destructuring fetch off of globalThis via a template-literal key',
+            code: "export function run() { const { [`fetch`]: request } = globalThis; return request('https://example.com'); }",
+        },
+        {
+            description:
+                'reject destructuring fetch off of globalThis via a quoted (non-computed) string-literal key',
+            code: "export function run() { const { 'fetch': request } = globalThis; return request('https://example.com'); }",
+        },
+        {
+            description:
+                'reject destructuring fetch off of globalThis via a function parameter default value',
+            code: 'export function run({ fetch } = globalThis) { return fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject fetch reached through a single const alias of globalThis',
+            code: 'export function run() { const g = globalThis; return g.fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject a destructure off of a single const alias of globalThis',
+            code: 'export function run() { const g = globalThis; const { fetch } = g; return fetch("https://example.com"); }',
+        },
+        {
+            description: 'reject fetch reached through a chain of const aliases of globalThis',
+            code: 'export function run() { const g1 = globalThis; const g2 = g1; return g2.fetch("https://example.com"); }',
+        },
+        {
+            description:
+                'reject globalThis.globalThis.fetch(...), a self-referential member-expression chain',
+            code: 'export function run() { return globalThis.globalThis.fetch("https://example.com"); }',
+        },
+        {
+            description:
+                "reject global.global.fetch(...), the Node alias's own self-referential chain",
+            code: 'export function run() { return global.global.fetch("https://example.com"); }',
+        },
     ];
 
     test.each(rejectedCases)('Should $description', ({ code }) => {
         const ast = parseAst(code);
         expect(() => rejectRestrictedGlobals(ast, filePath)).toThrow(
-            'is not supported in .backend.ts files',
+            /is not supported in backend function code/,
         );
         expect(() => rejectRestrictedGlobals(ast, filePath)).toThrow(filePath);
     });
@@ -55,6 +159,59 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
         {
             description: 'allow unrelated code with no restricted-global references',
             code: 'export function run(a, b) { return a + b; }',
+        },
+        {
+            description: 'allow accessing an unrestricted globalThis property',
+            code: 'export function run() { return globalThis.console; }',
+        },
+        {
+            description: 'allow destructuring an unrestricted property off of globalThis',
+            code: 'export function run() { const { console } = globalThis; return console; }',
+        },
+        {
+            description:
+                'allow accessing .fetch on a parameter named globalThis shadowing the ambient global',
+            code: 'export function run(globalThis) { return globalThis.fetch(); }',
+        },
+        {
+            description:
+                'allow destructuring fetch off of a parameter named globalThis shadowing the ambient global',
+            code: 'export function run(globalThis) { const { fetch } = globalThis; return fetch(); }',
+        },
+        {
+            description:
+                'allow accessing .fetch on a parameter named global shadowing the Node alias',
+            code: 'export function run(global) { return global.fetch(); }',
+        },
+        {
+            description:
+                'allow a destructuring assignment off of a parameter named globalThis shadowing the ambient global',
+            code: 'export function run(globalThis) { let request; ({ fetch: request } = globalThis); return request(); }',
+        },
+        {
+            description:
+                'allow a rest-destructure of a parameter named globalThis shadowing the ambient global',
+            code: 'export function run(globalThis) { const { ...rest } = globalThis; return rest; }',
+        },
+        {
+            description:
+                'allow a "let" alias of globalThis, since it could be reassigned to something else',
+            code: 'export function run() { let g = globalThis; return g.fetch(); }',
+        },
+        {
+            description:
+                'allow a function-parameter default value aliasing globalThis, same opacity as a "let" alias',
+            code: 'export function run(g = globalThis) { return g.fetch(); }',
+        },
+        {
+            description: 'allow a computed member access with a template literal that interpolates',
+            // eslint-disable-next-line no-template-curly-in-string -- source text for the AST under test, not a real interpolation
+            code: 'export function run(name) { return globalThis[`${name}`](); }',
+        },
+        {
+            description:
+                'allow accessing a property on a destructured binding of globalThis, since the binding is a specific property value, not the ambient global object itself',
+            code: 'export function run() { const { console: g } = globalThis; return g.fetch; }',
         },
     ];
 

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
@@ -133,6 +133,21 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
                 "reject global.global.fetch(...), the Node alias's own self-referential chain",
             code: 'export function run() { return global.global.fetch("https://example.com"); }',
         },
+        {
+            description:
+                'reject fetch reached through a nested destructure of the self-referential globalThis.globalThis',
+            code: 'export function run() { const { globalThis: { fetch } } = globalThis; return fetch("https://example.com"); }',
+        },
+        {
+            description:
+                'reject fetch reached through a const alias bound by a self-referential globalThis destructure key',
+            code: 'export function run() { const { globalThis: g } = globalThis; return g.fetch("https://example.com"); }',
+        },
+        {
+            description:
+                "reject fetch reached through a const alias bound by a self-referential global destructure key (Node's own alias)",
+            code: 'export function run() { const { global: g } = global; return g.fetch("https://example.com"); }',
+        },
     ];
 
     test.each(rejectedCases)('Should $description', ({ code }) => {
@@ -167,6 +182,11 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
         {
             description: 'allow destructuring an unrestricted property off of globalThis',
             code: 'export function run() { const { console } = globalThis; return console; }',
+        },
+        {
+            description:
+                'allow a nested destructure named fetch whose outer key is not itself a globalThis/global self-reference, since the outer key is not provably an alias back to the ambient global',
+            code: 'export function run() { const { myApi: { fetch } } = globalThis; return fetch; }',
         },
         {
             description:

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts
@@ -209,6 +209,21 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
                 'reject fetch reached through a for-of loop using an assignment target (no const/let) destructuring globalThis via an inline array literal',
             code: 'export function run() { let fetch; for ({ fetch } of [globalThis]) { return fetch("https://example.com"); } }',
         },
+        {
+            description:
+                'reject globalThis[f](...) where f is a const alias of a string-literal property name',
+            code: "export function run() { const f = 'fetch'; return globalThis[f]('https://example.com'); }",
+        },
+        {
+            description:
+                'reject destructuring fetch off of globalThis via a computed key that is a const alias of a string-literal property name',
+            code: "export function run() { const key = 'fetch'; const { [key]: r } = globalThis; return r('https://example.com'); }",
+        },
+        {
+            description:
+                'reject fetch reached through a chain of const aliases resolving a computed property name',
+            code: "export function run() { const f1 = 'fetch'; const f2 = f1; return globalThis[f2]('https://example.com'); }",
+        },
     ];
 
     test.each(rejectedCases)('Should $description', ({ code }) => {
@@ -323,6 +338,16 @@ describe('Backend Functions - rejectRestrictedGlobals', () => {
             description:
                 'allow Reflect.ownKeys(globalThis), since it returns only property-name strings, never a callable reference',
             code: 'export function run() { const keys = Reflect.ownKeys(globalThis); return keys.length; }',
+        },
+        {
+            description:
+                'allow a computed property access whose key is a "let" alias of a string literal, same opacity as a "let" alias of globalThis itself',
+            code: "export function run() { let f = 'fetch'; return globalThis[f](); }",
+        },
+        {
+            description:
+                'allow a computed property access whose key is a mutually self-referential const cycle, since the key cannot be statically resolved',
+            code: 'export function run() { const a = b; const b = a; return globalThis[a](); }',
         },
     ];
 

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.ts
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { BaseNode } from 'estree';
+
+import { analyzeModuleScope } from './module-scope';
+import { ensureProgram } from './type-guards';
+
+const RESTRICTED_GLOBALS = new Set(['fetch', 'XMLHttpRequest', 'WebSocket', 'EventSource']);
+
+/**
+ * Reject references to network-capable globals in `.backend.ts` files.
+ * Backend functions have no raw network access under today's v1 runtime —
+ * Deno's `--allow-net` is off — so any outbound call must go through an
+ * Action Platform action (`$.Actions` or an `@datadog/action-catalog` typed
+ * wrapper), never a direct HTTP client. Import-specifier restriction alone
+ * can't catch this: these are bare globals, not imports.
+ *
+ * This is the enforcement layer for a trap that's easy to fall into
+ * otherwise: `fetch` works fine during local dev (nothing stopped it before
+ * this check existed) but fails once the app is actually published, since
+ * production's sandbox blocks it. A separate, complementary effort adds
+ * AI-authoring guidance steering generated code away from `fetch` in the
+ * first place — that reduces how often this gets written at all, but only
+ * this build-time check actually guarantees it never ships, regardless of
+ * whether the code came from an AI, a human, or a copy-pasted snippet.
+ *
+ * Backend functions' planned v2 (Terrapin-based) sandbox will lift this
+ * restriction — legacy (pre-v2) apps are the ones that need it.
+ *
+ * This is a best-effort, defense-in-depth check: it flags any reference to one
+ * of these names that eslint-scope can't resolve to a declaration in this
+ * module (i.e. it falls through to the ambient global instead of a local
+ * variable or import that happens to share the name).
+ */
+export function rejectRestrictedGlobals(ast: BaseNode, filePath: string): void {
+    const program = ensureProgram(ast, filePath);
+    const scopeAnalysis = analyzeModuleScope(program);
+
+    for (const [identifier, reference] of scopeAnalysis.referencesByIdentifier) {
+        if (!RESTRICTED_GLOBALS.has(identifier.name) || reference.resolved) {
+            continue;
+        }
+
+        throw new Error(
+            `Using "${identifier.name}" is not supported in .backend.ts files. ` +
+                `Backend functions cannot make raw network requests in production — ` +
+                `use an Action Platform action ($.Actions or an @datadog/action-catalog ` +
+                `typed wrapper) instead: ${filePath}`,
+        );
+    }
+}

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.ts
@@ -4,50 +4,42 @@
 
 import type { BaseNode } from 'estree';
 
+import { forEachAmbientGlobalAccess } from './ambient-global-access';
 import { analyzeModuleScope } from './module-scope';
+import type { ModuleScopeAnalysis } from './module-scope';
 import { ensureProgram } from './type-guards';
 
 const RESTRICTED_GLOBALS = new Set(['fetch', 'XMLHttpRequest', 'WebSocket', 'EventSource']);
 
-/**
- * Reject references to network-capable globals in `.backend.ts` files.
- * Backend functions have no raw network access under today's v1 runtime —
- * Deno's `--allow-net` is off — so any outbound call must go through an
- * Action Platform action (`$.Actions` or an `@datadog/action-catalog` typed
- * wrapper), never a direct HTTP client. Import-specifier restriction alone
- * can't catch this: these are bare globals, not imports.
- *
- * This is the enforcement layer for a trap that's easy to fall into
- * otherwise: `fetch` works fine during local dev (nothing stopped it before
- * this check existed) but fails once the app is actually published, since
- * production's sandbox blocks it. A separate, complementary effort adds
- * AI-authoring guidance steering generated code away from `fetch` in the
- * first place — that reduces how often this gets written at all, but only
- * this build-time check actually guarantees it never ships, regardless of
- * whether the code came from an AI, a human, or a copy-pasted snippet.
- *
- * Backend functions' planned v2 (Terrapin-based) sandbox will lift this
- * restriction — legacy (pre-v2) apps are the ones that need it.
- *
- * This is a best-effort, defense-in-depth check: it flags any reference to one
- * of these names that eslint-scope can't resolve to a declaration in this
- * module (i.e. it falls through to the ambient global instead of a local
- * variable or import that happens to share the name).
- */
-export function rejectRestrictedGlobals(ast: BaseNode, filePath: string): void {
+// Reject network-capable globals (fetch, etc.) in `.backend.ts` files, since backend functions have no raw network access in production and must go through an Action Platform action instead; only pre-v2 (legacy) apps need this, as the planned Terrapin-based v2 sandbox lifts the restriction.
+export function rejectRestrictedGlobals(
+    ast: BaseNode,
+    filePath: string,
+    precomputedScopeAnalysis?: ModuleScopeAnalysis,
+): void {
     const program = ensureProgram(ast, filePath);
-    const scopeAnalysis = analyzeModuleScope(program);
+    const scopeAnalysis = precomputedScopeAnalysis ?? analyzeModuleScope(program);
 
-    for (const [identifier, reference] of scopeAnalysis.referencesByIdentifier) {
-        if (!RESTRICTED_GLOBALS.has(identifier.name) || reference.resolved) {
-            continue;
-        }
+    forEachAmbientGlobalAccess(program, scopeAnalysis, RESTRICTED_GLOBALS, {
+        onNamedAccess(name) {
+            throwRestrictedGlobalError(name, filePath);
+        },
+        onRestDestructure() {
+            throw new Error(
+                `Destructuring "globalThis"/"global" with a rest pattern is not supported ` +
+                    `in backend function code — it copies every ambient global, including ` +
+                    `network-capable ones (${Array.from(RESTRICTED_GLOBALS).join(', ')}), ` +
+                    `into a plain object: ${filePath}`,
+            );
+        },
+    });
+}
 
-        throw new Error(
-            `Using "${identifier.name}" is not supported in .backend.ts files. ` +
-                `Backend functions cannot make raw network requests in production — ` +
-                `use an Action Platform action ($.Actions or an @datadog/action-catalog ` +
-                `typed wrapper) instead: ${filePath}`,
-        );
-    }
+function throwRestrictedGlobalError(name: string, filePath: string): never {
+    throw new Error(
+        `Using "${name}" is not supported in backend function code. ` +
+            `Backend functions cannot make raw network requests in production — ` +
+            `use an Action Platform action ($.Actions or an @datadog/action-catalog ` +
+            `typed wrapper) instead: ${filePath}`,
+    );
 }

--- a/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.ts
@@ -11,7 +11,7 @@ import { ensureProgram } from './type-guards';
 
 const RESTRICTED_GLOBALS = new Set(['fetch', 'XMLHttpRequest', 'WebSocket', 'EventSource']);
 
-// Reject network-capable globals (fetch, etc.) in `.backend.ts` files, since backend functions have no raw network access in production and must go through an Action Platform action instead; only pre-v2 (legacy) apps need this, as the planned Terrapin-based v2 sandbox lifts the restriction.
+// Rejects network-capable globals (fetch, etc.) in `.backend.ts` files — backend functions have no raw network access in production and must go through an Action Platform action instead. Only pre-v2 (legacy) apps need this; the planned Terrapin-based v2 sandbox lifts the restriction.
 export function rejectRestrictedGlobals(
     ast: BaseNode,
     filePath: string,
@@ -24,11 +24,12 @@ export function rejectRestrictedGlobals(
         onNamedAccess(name) {
             throwRestrictedGlobalError(name, filePath);
         },
-        onRestDestructure() {
+        onBulkCopy() {
             throw new Error(
-                `Destructuring "globalThis"/"global" with a rest pattern is not supported ` +
-                    `in backend function code — it copies every ambient global, including ` +
-                    `network-capable ones (${Array.from(RESTRICTED_GLOBALS).join(', ')}), ` +
+                `Copying every property of "globalThis"/"global" at once (a rest destructure, ` +
+                    `an object spread, or a call like Object.assign/Object.values) is not ` +
+                    `supported in backend function code — it copies every ambient global, ` +
+                    `including network-capable ones (${Array.from(RESTRICTED_GLOBALS).join(', ')}), ` +
                     `into a plain object: ${filePath}`,
             );
         },

--- a/packages/plugins/apps/src/backend/ast-parsing/run-backend-static-checks.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/run-backend-static-checks.ts
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { Logger } from '@dd/core/types';
+import type { BaseNode } from 'estree';
+
+import type { ModuleScopeAnalysis } from './module-scope';
+import { rejectNodeBuiltinImports } from './reject-node-builtin-imports';
+import { rejectRestrictedGlobals } from './reject-restricted-globals';
+import { warnAboutDivergentGlobals } from './warn-divergent-globals';
+
+/** Runs every static check (banned Node built-ins, restricted globals, divergent-global warnings) against a single module; shared by index.ts's entry-file transform and backend-static-checks-plugin.ts's module-graph traversal so the two call sites can't drift on which checks run or in what order. */
+export function runBackendStaticChecks(
+    ast: BaseNode,
+    filePath: string,
+    log: Logger,
+    scopeAnalysis: ModuleScopeAnalysis,
+): void {
+    rejectNodeBuiltinImports(ast, filePath);
+    rejectRestrictedGlobals(ast, filePath, scopeAnalysis);
+    warnAboutDivergentGlobals(ast, filePath, log, scopeAnalysis);
+}

--- a/packages/plugins/apps/src/backend/ast-parsing/run-backend-static-checks.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/run-backend-static-checks.ts
@@ -10,7 +10,7 @@ import { rejectNodeBuiltinImports } from './reject-node-builtin-imports';
 import { rejectRestrictedGlobals } from './reject-restricted-globals';
 import { warnAboutDivergentGlobals } from './warn-divergent-globals';
 
-/** Runs every static check (banned Node built-ins, restricted globals, divergent-global warnings) against a single module; shared by index.ts's entry-file transform and backend-static-checks-plugin.ts's module-graph traversal so the two call sites can't drift on which checks run or in what order. */
+/** Runs every static check (banned Node built-ins, restricted globals, divergent-global warnings) against a single module; shared by index.ts and backend-static-checks-plugin.ts so the two call sites can't drift. */
 export function runBackendStaticChecks(
     ast: BaseNode,
     filePath: string,

--- a/packages/plugins/apps/src/backend/ast-parsing/type-guards.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/type-guards.ts
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { BaseNode, Program, SimpleLiteral, TemplateLiteral } from 'estree';
+import type { BaseNode, Program, SimpleLiteral, TemplateLiteral, VariableDeclarator } from 'estree';
 
 export type StringLiteral = SimpleLiteral & { value: string };
 
@@ -27,25 +27,41 @@ export function isProgramNode(node: BaseNode): node is Program {
 }
 
 export function isStringLiteral(node: unknown): node is StringLiteral {
-    return (
-        typeof node === 'object' &&
-        node !== null &&
-        (node as { type?: string }).type === 'Literal' &&
-        typeof (node as { value?: unknown }).value === 'string'
-    );
+    if (typeof node !== 'object' || node === null || !('type' in node) || !('value' in node)) {
+        return false;
+    }
+    return node.type === 'Literal' && typeof node.value === 'string';
 }
 
 export function isTypeOnly(node: TypeOnlyAwareNode): boolean {
     return node.importKind === 'type' || node.exportKind === 'type';
 }
 
-function isNoSubstitutionTemplateLiteral(node: unknown): node is TemplateLiteral {
+export function isVariableDeclaratorNode(node: unknown): node is VariableDeclarator {
     return (
         typeof node === 'object' &&
         node !== null &&
-        (node as { type?: string }).type === 'TemplateLiteral' &&
-        (node as TemplateLiteral).expressions.length === 0 &&
-        (node as TemplateLiteral).quasis.length === 1
+        'type' in node &&
+        node.type === 'VariableDeclarator'
+    );
+}
+
+function isNoSubstitutionTemplateLiteral(node: unknown): node is TemplateLiteral {
+    if (
+        typeof node !== 'object' ||
+        node === null ||
+        !('type' in node) ||
+        !('expressions' in node) ||
+        !('quasis' in node)
+    ) {
+        return false;
+    }
+    return (
+        node.type === 'TemplateLiteral' &&
+        Array.isArray(node.expressions) &&
+        node.expressions.length === 0 &&
+        Array.isArray(node.quasis) &&
+        node.quasis.length === 1
     );
 }
 

--- a/packages/plugins/apps/src/backend/ast-parsing/type-guards.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/type-guards.ts
@@ -26,11 +26,13 @@ export function isProgramNode(node: BaseNode): node is Program {
     return node.type === 'Program';
 }
 
+// Shared by every guard below: narrows an `unknown` AST value to "a non-null object carrying this specific `type` tag" before any type-specific field is checked.
+function hasNodeType<T extends string>(node: unknown, type: T): node is { type: T } {
+    return typeof node === 'object' && node !== null && 'type' in node && node.type === type;
+}
+
 export function isStringLiteral(node: unknown): node is StringLiteral {
-    if (typeof node !== 'object' || node === null || !('type' in node) || !('value' in node)) {
-        return false;
-    }
-    return node.type === 'Literal' && typeof node.value === 'string';
+    return hasNodeType(node, 'Literal') && 'value' in node && typeof node.value === 'string';
 }
 
 export function isTypeOnly(node: TypeOnlyAwareNode): boolean {
@@ -38,26 +40,14 @@ export function isTypeOnly(node: TypeOnlyAwareNode): boolean {
 }
 
 export function isVariableDeclaratorNode(node: unknown): node is VariableDeclarator {
-    return (
-        typeof node === 'object' &&
-        node !== null &&
-        'type' in node &&
-        node.type === 'VariableDeclarator'
-    );
+    return hasNodeType(node, 'VariableDeclarator');
 }
 
 function isNoSubstitutionTemplateLiteral(node: unknown): node is TemplateLiteral {
-    if (
-        typeof node !== 'object' ||
-        node === null ||
-        !('type' in node) ||
-        !('expressions' in node) ||
-        !('quasis' in node)
-    ) {
+    if (!hasNodeType(node, 'TemplateLiteral') || !('expressions' in node) || !('quasis' in node)) {
         return false;
     }
     return (
-        node.type === 'TemplateLiteral' &&
         Array.isArray(node.expressions) &&
         node.expressions.length === 0 &&
         Array.isArray(node.quasis) &&

--- a/packages/plugins/apps/src/backend/ast-parsing/type-guards.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/type-guards.ts
@@ -2,11 +2,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { BaseNode, Program, SimpleLiteral } from 'estree';
+import type { BaseNode, Program, SimpleLiteral, TemplateLiteral } from 'estree';
 
 export type StringLiteral = SimpleLiteral & { value: string };
 
-interface TypeScriptImportExportMetadata {
+export interface TypeScriptImportExportMetadata {
     importKind?: 'type' | 'value';
     exportKind?: 'type' | 'value';
 }
@@ -37,4 +37,25 @@ export function isStringLiteral(node: unknown): node is StringLiteral {
 
 export function isTypeOnly(node: TypeOnlyAwareNode): boolean {
     return node.importKind === 'type' || node.exportKind === 'type';
+}
+
+function isNoSubstitutionTemplateLiteral(node: unknown): node is TemplateLiteral {
+    return (
+        typeof node === 'object' &&
+        node !== null &&
+        (node as { type?: string }).type === 'TemplateLiteral' &&
+        (node as TemplateLiteral).expressions.length === 0 &&
+        (node as TemplateLiteral).quasis.length === 1
+    );
+}
+
+// Resolves the static string value of a `Literal` or no-substitution template literal — the only two forms knowable without evaluation.
+export function staticStringValue(node: unknown): string | undefined {
+    if (isStringLiteral(node)) {
+        return node.value;
+    }
+    if (isNoSubstitutionTemplateLiteral(node)) {
+        return node.quasis[0].value.cooked ?? undefined;
+    }
+    return undefined;
 }

--- a/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.test.ts
@@ -89,6 +89,18 @@ describe('Backend Functions - warnAboutDivergentGlobals', () => {
             code: 'export function run({ crypto } = globalThis) { return crypto.randomUUID(); }',
             global: 'crypto',
         },
+        {
+            description:
+                'warn on crypto reached through a nested destructure of the self-referential globalThis.globalThis',
+            code: 'export function run() { const { globalThis: { crypto } } = globalThis; return crypto.randomUUID(); }',
+            global: 'crypto',
+        },
+        {
+            description:
+                'warn on crypto reached through a const alias bound by a self-referential globalThis destructure key',
+            code: 'export function run() { const { globalThis: g } = globalThis; return g.crypto.randomUUID(); }',
+            global: 'crypto',
+        },
     ];
 
     test.each(warnedCases)('Should $description', ({ code, global }) => {
@@ -193,6 +205,11 @@ describe('Backend Functions - warnAboutDivergentGlobals', () => {
             description:
                 'not warn on destructuring crypto off of a parameter named globalThis shadowing the ambient global',
             code: 'export function run(globalThis) { const { crypto } = globalThis; return crypto; }',
+        },
+        {
+            description:
+                'not warn on a nested destructure named crypto whose outer key is not itself a globalThis/global self-reference',
+            code: 'export function run() { const { myApi: { crypto } } = globalThis; return crypto; }',
         },
     ];
 

--- a/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.test.ts
@@ -167,6 +167,17 @@ describe('Backend Functions - warnAboutDivergentGlobals', () => {
         expect(mockLogFn).toHaveBeenCalledTimes(2);
     });
 
+    test('Should warn for every divergent global on Object.assign copying every ambient global at once', () => {
+        const code =
+            'export function run() { const stolen = Object.assign({}, globalThis); return stolen; }';
+        const ast = parseAst(code);
+        const logger = getMockLogger();
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('crypto'), 'warn');
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('Intl'), 'warn');
+        expect(mockLogFn).toHaveBeenCalledTimes(2);
+    });
+
     test('Should warn on destructuring crypto off of globalThis via a computed string-literal key', () => {
         const code = "export function run() { const { ['crypto']: c } = globalThis; return c; }";
         const ast = parseAst(code);

--- a/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.test.ts
@@ -1,0 +1,205 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import {
+    resetDivergentGlobalWarnings,
+    warnAboutDivergentGlobals,
+} from '@dd/apps-plugin/backend/ast-parsing/warn-divergent-globals';
+import { getMockLogger, mockLogFn } from '@dd/tests/_jest/helpers/mocks';
+import { parseAst } from 'rollup/parseAst';
+
+describe('Backend Functions - warnAboutDivergentGlobals', () => {
+    const filePath = '/project/src/math.backend.ts';
+
+    // Reset so an earlier test's warning doesn't suppress this test's expected warning via the cross-call dedup cache.
+    beforeEach(() => {
+        resetDivergentGlobalWarnings();
+    });
+
+    const warnedCases = [
+        {
+            description: 'warn on a bare crypto.randomUUID() call',
+            code: 'export function run() { return crypto.randomUUID(); }',
+            global: 'crypto',
+        },
+        {
+            description: 'warn on crypto referenced without calling it',
+            code: 'export function run() { const c = crypto; return c; }',
+            global: 'crypto',
+        },
+        {
+            description: 'warn on a bare new Intl.NumberFormat(...)',
+            code: 'export function run() { return new Intl.NumberFormat("en-US"); }',
+            global: 'Intl',
+        },
+        {
+            description: 'warn on globalThis.crypto',
+            code: 'export function run() { return globalThis.crypto.randomUUID(); }',
+            global: 'crypto',
+        },
+        {
+            description: 'warn on globalThis["Intl"]',
+            code: 'export function run() { return globalThis["Intl"].NumberFormat; }',
+            global: 'Intl',
+        },
+        {
+            description: 'warn on destructuring crypto off of globalThis',
+            code: 'export function run() { const { crypto } = globalThis; return crypto.randomUUID(); }',
+            global: 'crypto',
+        },
+        {
+            description: 'warn on destructuring Intl off of globalThis under a local alias',
+            code: 'export function run() { const { Intl: I } = globalThis; return I.NumberFormat; }',
+            global: 'Intl',
+        },
+        {
+            description: 'warn on global.crypto via the Node global alias',
+            code: 'export function run() { return global.crypto.randomUUID(); }',
+            global: 'crypto',
+        },
+        {
+            description: 'warn on global["Intl"] via the Node global alias',
+            code: 'export function run() { return global["Intl"].NumberFormat; }',
+            global: 'Intl',
+        },
+        {
+            description: 'warn on destructuring crypto off of global, the Node global alias',
+            code: 'export function run() { const { crypto } = global; return crypto.randomUUID(); }',
+            global: 'crypto',
+        },
+        {
+            description: 'warn on a destructuring *assignment* (not declaration) off of globalThis',
+            code: 'export function run() { let c; ({ crypto: c } = globalThis); return c.randomUUID(); }',
+            global: 'crypto',
+        },
+        {
+            description: 'warn on globalThis[`crypto`] via a no-substitution template-literal key',
+            code: 'export function run() { return globalThis[`crypto`].randomUUID(); }',
+            global: 'crypto',
+        },
+        {
+            description: 'warn on crypto reached through a single const alias of globalThis',
+            code: 'export function run() { const g = globalThis; return g.crypto.randomUUID(); }',
+            global: 'crypto',
+        },
+        {
+            description:
+                'warn on destructuring crypto off of globalThis via a function parameter default value',
+            code: 'export function run({ crypto } = globalThis) { return crypto.randomUUID(); }',
+            global: 'crypto',
+        },
+    ];
+
+    test.each(warnedCases)('Should $description', ({ code, global }) => {
+        const ast = parseAst(code);
+        const logger = getMockLogger();
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining(global), 'warn');
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining(filePath), 'warn');
+    });
+
+    test('Should warn only once per distinct global, even if referenced multiple times', () => {
+        const code =
+            'export function run() { crypto.randomUUID(); crypto.randomUUID(); return crypto.randomUUID(); }';
+        const ast = parseAst(code);
+        const logger = getMockLogger();
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        expect(mockLogFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should warn for every distinct global in a multi-property destructure', () => {
+        const code =
+            'export function run() { const { crypto, Intl } = globalThis; return [crypto, Intl]; }';
+        const ast = parseAst(code);
+        const logger = getMockLogger();
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('crypto'), 'warn');
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('Intl'), 'warn');
+        expect(mockLogFn).toHaveBeenCalledTimes(2);
+    });
+
+    // Regression test: a real backend entry file is transformed multiple times with the same filePath, and must still warn only once per distinct global.
+    test('Should warn only once per distinct global across separate calls for the same file path', () => {
+        const code = 'export function run() { return crypto.randomUUID(); }';
+        const ast = parseAst(code);
+        const logger = getMockLogger();
+
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        warnAboutDivergentGlobals(ast, filePath, logger);
+
+        expect(mockLogFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should still warn for a different file path even after another file already warned for the same global', () => {
+        const code = 'export function run() { return crypto.randomUUID(); }';
+        const ast = parseAst(code);
+        const logger = getMockLogger();
+        const otherFilePath = '/project/src/other.backend.ts';
+
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        warnAboutDivergentGlobals(ast, otherFilePath, logger);
+
+        expect(mockLogFn).toHaveBeenCalledTimes(2);
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining(otherFilePath), 'warn');
+    });
+
+    test('Should warn for every divergent global on a rest-destructure of globalThis, which copies every ambient global', () => {
+        const code = 'export function run() { const { ...globals } = globalThis; return globals; }';
+        const ast = parseAst(code);
+        const logger = getMockLogger();
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('crypto'), 'warn');
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('Intl'), 'warn');
+        expect(mockLogFn).toHaveBeenCalledTimes(2);
+    });
+
+    test('Should warn on destructuring crypto off of globalThis via a computed string-literal key', () => {
+        const code = "export function run() { const { ['crypto']: c } = globalThis; return c; }";
+        const ast = parseAst(code);
+        const logger = getMockLogger();
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('crypto'), 'warn');
+    });
+
+    const allowedCases = [
+        {
+            description: 'not warn on an imported action-catalog function',
+            code: "import { request } from '@datadog/action-catalog/http/http';\nexport async function run() { return request({ inputs: {} }); }",
+        },
+        {
+            description: 'not warn on a locally-declared function that happens to be named crypto',
+            code: 'function crypto() { return "local"; }\nexport function run() { return crypto(); }',
+        },
+        {
+            description: 'not warn on a parameter named Intl shadowing the global',
+            code: 'export function run(Intl) { return Intl.NumberFormat; }',
+        },
+        {
+            description: 'not warn on unrelated code with no divergent-global references',
+            code: 'export function run(a, b) { return a + b; }',
+        },
+        {
+            description: 'not warn on accessing an unrelated globalThis property',
+            code: 'export function run() { return globalThis.console; }',
+        },
+        {
+            description:
+                'not warn on accessing .crypto on a parameter named globalThis shadowing the ambient global',
+            code: 'export function run(globalThis) { return globalThis.crypto; }',
+        },
+        {
+            description:
+                'not warn on destructuring crypto off of a parameter named globalThis shadowing the ambient global',
+            code: 'export function run(globalThis) { const { crypto } = globalThis; return crypto; }',
+        },
+    ];
+
+    test.each(allowedCases)('Should $description', ({ code }) => {
+        const ast = parseAst(code);
+        const logger = getMockLogger();
+        warnAboutDivergentGlobals(ast, filePath, logger);
+        expect(mockLogFn).not.toHaveBeenCalled();
+    });
+});

--- a/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.test.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.test.ts
@@ -101,6 +101,12 @@ describe('Backend Functions - warnAboutDivergentGlobals', () => {
             code: 'export function run() { const { globalThis: g } = globalThis; return g.crypto.randomUUID(); }',
             global: 'crypto',
         },
+        {
+            description:
+                'warn on globalThis[key] where key is a const alias of a string-literal property name',
+            code: "export function run() { const key = 'crypto'; return globalThis[key].randomUUID(); }",
+            global: 'crypto',
+        },
     ];
 
     test.each(warnedCases)('Should $description', ({ code, global }) => {

--- a/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.ts
@@ -12,7 +12,7 @@ import { ensureProgram } from './type-guards';
 
 const DIVERGENT_GLOBALS = new Set(['crypto', 'Intl']);
 
-// Cross-call cache (not just within one call) since the same backend entry file is transformed multiple times per build; bounded and cleared wholesale once it grows too large, trading an occasional re-warn for capped memory in long dev-server sessions.
+// Cross-call cache since the same backend entry file is transformed multiple times per build; bounded and cleared wholesale once too large, trading an occasional re-warn for capped memory in long dev-server sessions.
 const MAX_TRACKED_FILES = 500;
 const warnedGlobalsByFile = new Map<string, Set<string>>();
 
@@ -21,7 +21,7 @@ export function resetDivergentGlobalWarnings(): void {
     warnedGlobalsByFile.clear();
 }
 
-// Warn (never reject) on `crypto`/`Intl` references in `.backend.ts` files, since their concrete behavior can differ between local Node execution and production Deno; this is editor-time guidance only — `npm run dev:verify`'s real cloud round trip is the actual parity gate.
+// Warns (never rejects) on `crypto`/`Intl` references in `.backend.ts` files, since their behavior can differ between local Node and production Deno. Editor-time guidance only — `npm run dev:verify`'s real cloud round trip is the actual parity gate.
 export function warnAboutDivergentGlobals(
     ast: BaseNode,
     filePath: string,
@@ -50,7 +50,7 @@ export function warnAboutDivergentGlobals(
 
     forEachAmbientGlobalAccess(program, scopeAnalysis, DIVERGENT_GLOBALS, {
         onNamedAccess: warnOnce,
-        onRestDestructure() {
+        onBulkCopy() {
             // No specific property to point at, so warn about every divergent global rather than staying silent.
             for (const name of DIVERGENT_GLOBALS) {
                 warnOnce(name);

--- a/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.ts
+++ b/packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.ts
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { Logger } from '@dd/core/types';
+import type { BaseNode } from 'estree';
+
+import { forEachAmbientGlobalAccess } from './ambient-global-access';
+import { analyzeModuleScope } from './module-scope';
+import type { ModuleScopeAnalysis } from './module-scope';
+import { ensureProgram } from './type-guards';
+
+const DIVERGENT_GLOBALS = new Set(['crypto', 'Intl']);
+
+// Cross-call cache (not just within one call) since the same backend entry file is transformed multiple times per build; bounded and cleared wholesale once it grows too large, trading an occasional re-warn for capped memory in long dev-server sessions.
+const MAX_TRACKED_FILES = 500;
+const warnedGlobalsByFile = new Map<string, Set<string>>();
+
+// Test-only escape hatch: clears the cross-call dedup cache between test cases that reuse the same file path.
+export function resetDivergentGlobalWarnings(): void {
+    warnedGlobalsByFile.clear();
+}
+
+// Warn (never reject) on `crypto`/`Intl` references in `.backend.ts` files, since their concrete behavior can differ between local Node execution and production Deno; this is editor-time guidance only — `npm run dev:verify`'s real cloud round trip is the actual parity gate.
+export function warnAboutDivergentGlobals(
+    ast: BaseNode,
+    filePath: string,
+    log: Logger,
+    precomputedScopeAnalysis?: ModuleScopeAnalysis,
+): void {
+    const program = ensureProgram(ast, filePath);
+    const scopeAnalysis = precomputedScopeAnalysis ?? analyzeModuleScope(program);
+
+    let warned = warnedGlobalsByFile.get(filePath);
+    if (!warned) {
+        if (warnedGlobalsByFile.size >= MAX_TRACKED_FILES) {
+            warnedGlobalsByFile.clear();
+        }
+        warned = new Set<string>();
+        warnedGlobalsByFile.set(filePath, warned);
+    }
+
+    const warnOnce = (name: string) => {
+        if (warned.has(name)) {
+            return;
+        }
+        warned.add(name);
+        warnDivergentGlobal(name, filePath, log);
+    };
+
+    forEachAmbientGlobalAccess(program, scopeAnalysis, DIVERGENT_GLOBALS, {
+        onNamedAccess: warnOnce,
+        onRestDestructure() {
+            // No specific property to point at, so warn about every divergent global rather than staying silent.
+            for (const name of DIVERGENT_GLOBALS) {
+                warnOnce(name);
+            }
+        },
+    });
+}
+
+function warnDivergentGlobal(name: string, filePath: string, log: Logger): void {
+    log.warn(
+        `"${name}" is used in ${filePath}. Its exact behavior can differ between local ` +
+            `execution (Node) and production (Deno) — verify locale-/implementation-sensitive ` +
+            `results with "npm run dev:verify" before publishing.`,
+    );
+}

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -742,6 +742,140 @@ describe('Apps Plugin - getPlugins', () => {
         ).toEqual([{ allowedConnectionIds: ['conn-helper'] }]);
     });
 
+    test('Should reject a Node builtin import inside a helper module reachable from a backend function', async () => {
+        jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
+            identifier: 'repo:app',
+            name: 'test-app',
+        });
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: '/project/dist/index.js', relativePath: 'dist/index.js' },
+        ]);
+        jest.spyOn(fsHelpers, 'rm').mockResolvedValue(undefined);
+
+        // The entry file alone is clean; only importing a local helper is visible from here.
+        const entryCode = `
+            import { readSecret } from './helpers/fs-helper.js';
+
+            export function greet() {
+                return readSecret();
+            }
+        `;
+        // Only the nested backend build's module graph walk sees this Node builtin import; the outer transform never reaches the helper.
+        const helperCode = `
+            import fs from 'fs';
+
+            export function readSecret() {
+                return fs.readFileSync('/etc/passwd', 'utf8');
+            }
+        `;
+        const helperId = '/project/src/backend/helpers/fs-helper.js';
+        const viteBuild = jest.fn().mockImplementation(async (config) => {
+            emitModuleParsed(config, '/project/src/backend/greet.backend.js', entryCode, [
+                helperId,
+            ]);
+            emitModuleParsed(config, helperId, helperCode);
+            return {
+                output: [
+                    {
+                        type: 'chunk',
+                        isEntry: true,
+                        name: expect.any(String),
+                        fileName: 'unused.greet.js',
+                    },
+                ],
+            };
+        });
+        const args = getArgs();
+        args.bundler = { build: viteBuild };
+        const plugins = getPlugins(args);
+        const transform = extractViteTransform(plugins);
+        const resolveMock = jest.fn(async (specifier: string) =>
+            specifier === './helpers/fs-helper.js' ? { id: helperId } : null,
+        );
+        const loadMock = jest.fn(async () => null);
+        const addWatchFileMock = jest.fn();
+        await transform.call(
+            {
+                parse: parseAst,
+                resolve: resolveMock,
+                load: loadMock,
+                addWatchFile: addWatchFileMock,
+            },
+            entryCode,
+            '/project/src/backend/greet.backend.js',
+        );
+
+        const closeBundleResult = extractCloseBundle(plugins)();
+        await expect(closeBundleResult).rejects.toThrow(
+            'Importing Node built-in module "fs" is not supported in backend function code',
+        );
+    });
+
+    test('Should reject a bare fetch() call inside a helper module reachable from a backend function', async () => {
+        jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
+            identifier: 'repo:app',
+            name: 'test-app',
+        });
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: '/project/dist/index.js', relativePath: 'dist/index.js' },
+        ]);
+        jest.spyOn(fsHelpers, 'rm').mockResolvedValue(undefined);
+
+        const entryCode = `
+            import { getEcho } from './helpers/http-helper.js';
+
+            export function greet() {
+                return getEcho();
+            }
+        `;
+        const helperCode = `
+            export function getEcho() {
+                return fetch('https://example.com');
+            }
+        `;
+        const helperId = '/project/src/backend/helpers/http-helper.js';
+        const viteBuild = jest.fn().mockImplementation(async (config) => {
+            emitModuleParsed(config, '/project/src/backend/greet.backend.js', entryCode, [
+                helperId,
+            ]);
+            emitModuleParsed(config, helperId, helperCode);
+            return {
+                output: [
+                    {
+                        type: 'chunk',
+                        isEntry: true,
+                        name: expect.any(String),
+                        fileName: 'unused.greet.js',
+                    },
+                ],
+            };
+        });
+        const args = getArgs();
+        args.bundler = { build: viteBuild };
+        const plugins = getPlugins(args);
+        const transform = extractViteTransform(plugins);
+        const resolveMock = jest.fn(async (specifier: string) =>
+            specifier === './helpers/http-helper.js' ? { id: helperId } : null,
+        );
+        const loadMock = jest.fn(async () => null);
+        const addWatchFileMock = jest.fn();
+        await transform.call(
+            {
+                parse: parseAst,
+                resolve: resolveMock,
+                load: loadMock,
+                addWatchFile: addWatchFileMock,
+            },
+            entryCode,
+            '/project/src/backend/greet.backend.js',
+        );
+
+        const closeBundleResult = extractCloseBundle(plugins)();
+        await expect(closeBundleResult).rejects.toThrow(
+            'Using "fetch" is not supported in backend function code',
+        );
+    });
+
     test('Should surface upload errors', async () => {
         jest.spyOn(identifier, 'resolveIdentifier').mockReturnValue({
             identifier: 'repo:app',

--- a/packages/plugins/apps/src/vite/backend-connection-id-collector.ts
+++ b/packages/plugins/apps/src/vite/backend-connection-id-collector.ts
@@ -5,12 +5,15 @@
 import type { Plugin } from 'vite';
 
 import { extractConnectionIdsFromModuleGraph } from '../backend/ast-parsing/extract-connection-ids-from-module-graph';
+import type { ParsedModuleRecord } from '../backend/ast-parsing/module-graph';
 
 import { createBackendModuleGraphCollector } from './backend-module-graph-collector';
 
 export interface BackendConnectionIdCollector {
     plugin: Plugin;
     getAllowedConnectionIds: () => string[];
+    /** Exposed so a plugin sharing this build (e.g. the static-checks plugin) can reuse these records instead of re-parsing every module. */
+    getModuleRecords: () => ReadonlyMap<string, ParsedModuleRecord>;
 }
 
 export function createBackendConnectionIdCollector(
@@ -28,5 +31,6 @@ export function createBackendConnectionIdCollector(
                 buildRoot,
             );
         },
+        getModuleRecords: moduleGraphCollector.getModuleRecords,
     };
 }

--- a/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
+++ b/packages/plugins/apps/src/vite/backend-module-graph-collector.ts
@@ -87,7 +87,7 @@ export function createBackendModuleGraphCollector(buildRoot: string): BackendMod
     };
 }
 
-function normalizeViteModuleId(id: string): string {
+export function normalizeViteModuleId(id: string): string {
     return id.split('?')[0];
 }
 
@@ -95,6 +95,6 @@ function getStaticDependencyIds(moduleInfo: ModuleInfo): string[] {
     return moduleInfo.importedIdResolutions?.map(({ id }) => id) ?? [...moduleInfo.importedIds];
 }
 
-function isViteVirtualModuleId(id: string): boolean {
+export function isViteVirtualModuleId(id: string): boolean {
     return VIRTUAL_MODULE_ID_RE.test(id);
 }

--- a/packages/plugins/apps/src/vite/backend-static-checks-plugin.test.ts
+++ b/packages/plugins/apps/src/vite/backend-static-checks-plugin.test.ts
@@ -142,11 +142,8 @@ describe('Backend Functions - backend static checks plugin', () => {
 
     test('Should reuse an already-parsed module record instead of re-parsing', () => {
         const moduleId = '/project/src/backend/helpers/http.js';
-        const record = createParsedModuleRecord(
-            moduleId,
-            '/project',
-            parseAst('export function callIt() { return fetch("https://example.com"); }'),
-        );
+        const ast = parseAst('export function callIt() { return fetch("https://example.com"); }');
+        const record = createParsedModuleRecord(moduleId, '/project', ast);
         if (!record) {
             throw new Error('Expected a module record to be created for this test.');
         }

--- a/packages/plugins/apps/src/vite/backend-static-checks-plugin.test.ts
+++ b/packages/plugins/apps/src/vite/backend-static-checks-plugin.test.ts
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { createParsedModuleRecord } from '@dd/apps-plugin/backend/ast-parsing/module-graph';
+import { getMockLogger, mockLogFn } from '@dd/tests/_jest/helpers/mocks';
+import { parseAst } from 'rollup/parseAst';
+
+import { createBackendStaticChecksPlugin } from './backend-static-checks-plugin';
+
+type FakeModuleInfo = { id: string; code: string | null };
+
+// `parse` defaults to `rollup/parseAst` (matching Rollup's real context); a test asserting no re-parse passes one that throws instead.
+function callModuleParsed(
+    plugin: ReturnType<typeof createBackendStaticChecksPlugin>,
+    moduleInfo: FakeModuleInfo,
+    parse: typeof parseAst = parseAst,
+): void {
+    const hook = plugin.moduleParsed;
+    if (typeof hook !== 'function') {
+        throw new Error('Expected "moduleParsed" to be a function hook.');
+    }
+
+    Reflect.apply(hook, { parse }, [moduleInfo]);
+}
+
+describe('Backend Functions - backend static checks plugin', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('Should reject a module importing a Node built-in', () => {
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map(),
+        );
+
+        expect(() =>
+            callModuleParsed(plugin, {
+                id: '/project/src/backend/helpers/http.js',
+                code: "import fs from 'fs';\nexport function readIt() { return fs.readFileSync('/etc/passwd'); }",
+            }),
+        ).toThrow('Importing Node built-in module "fs" is not supported in backend function code');
+    });
+
+    test('Should reject a module calling a restricted global', () => {
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map(),
+        );
+
+        expect(() =>
+            callModuleParsed(plugin, {
+                id: '/project/src/backend/helpers/http.js',
+                code: 'export function callIt() { return fetch("https://example.com"); }',
+            }),
+        ).toThrow('Using "fetch" is not supported in backend function code');
+    });
+
+    test('Should warn on a module referencing crypto or Intl', () => {
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map(),
+        );
+
+        callModuleParsed(plugin, {
+            id: '/project/src/backend/helpers/id.js',
+            code: 'export function makeId() { return crypto.randomUUID(); }',
+        });
+
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('crypto'), 'warn');
+    });
+
+    test('Should allow a module with no restricted imports or globals', () => {
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map(),
+        );
+
+        expect(() =>
+            callModuleParsed(plugin, {
+                id: '/project/src/backend/helpers/http.js',
+                code: 'export function add(a, b) { return a + b; }',
+            }),
+        ).not.toThrow();
+    });
+
+    test('Should skip modules under node_modules', () => {
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map(),
+        );
+
+        expect(() =>
+            callModuleParsed(plugin, {
+                id: '/project/node_modules/some-package/index.js',
+                code: "import fs from 'fs';\nexport const value = fs;",
+            }),
+        ).not.toThrow();
+    });
+
+    test('Should skip virtual modules', () => {
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map(),
+        );
+
+        expect(() =>
+            callModuleParsed(plugin, {
+                id: '\0dd-backend:hash.greet',
+                code: "import fs from 'fs';\nexport const value = fs;",
+            }),
+        ).not.toThrow();
+        expect(() =>
+            callModuleParsed(plugin, {
+                id: 'virtual:dd-backend-dev:greet.js',
+                code: "import fs from 'fs';\nexport const value = fs;",
+            }),
+        ).not.toThrow();
+    });
+
+    test('Should skip modules with no source (external/synthetic modules)', () => {
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map(),
+        );
+
+        expect(() =>
+            callModuleParsed(plugin, {
+                id: '/project/src/backend/external.js',
+                code: null,
+            }),
+        ).not.toThrow();
+    });
+
+    test('Should reuse an already-parsed module record instead of re-parsing', () => {
+        const moduleId = '/project/src/backend/helpers/http.js';
+        const record = createParsedModuleRecord(
+            moduleId,
+            '/project',
+            parseAst('export function callIt() { return fetch("https://example.com"); }'),
+        );
+        if (!record) {
+            throw new Error('Expected a module record to be created for this test.');
+        }
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map([[moduleId, record]]),
+        );
+        const throwIfParsed: typeof parseAst = () => {
+            throw new Error('Should not re-parse a module that already has a record.');
+        };
+
+        expect(() =>
+            callModuleParsed(
+                plugin,
+                { id: moduleId, code: 'this code is never read when a record already exists' },
+                throwIfParsed,
+            ),
+        ).toThrow('Using "fetch" is not supported in backend function code');
+    });
+
+    test('Should fall back to parsing when no record exists for the module', () => {
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map(),
+        );
+
+        expect(() =>
+            callModuleParsed(plugin, {
+                id: '/project/src/backend/helpers/http.js',
+                code: 'export function callIt() { return fetch("https://example.com"); }',
+            }),
+        ).toThrow('Using "fetch" is not supported in backend function code');
+    });
+});

--- a/packages/plugins/apps/src/vite/backend-static-checks-plugin.test.ts
+++ b/packages/plugins/apps/src/vite/backend-static-checks-plugin.test.ts
@@ -179,4 +179,21 @@ describe('Backend Functions - backend static checks plugin', () => {
             }),
         ).toThrow('Using "fetch" is not supported in backend function code');
     });
+
+    test('Should throw a checks-specific error, not a connection-ID-collector-specific one, when the fallback parse fails', () => {
+        const plugin = createBackendStaticChecksPlugin(
+            '/project',
+            getMockLogger(),
+            () => new Map(),
+        );
+
+        expect(() =>
+            callModuleParsed(plugin, {
+                id: '/project/src/backend/helpers/broken.js',
+                code: 'export function callIt( {',
+            }),
+        ).toThrow(
+            /Unsupported module source .*: unparseable module source .* could hide a Node-builtin import or restricted-global access/,
+        );
+    });
 });

--- a/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
+++ b/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
@@ -58,7 +58,8 @@ export function createBackendStaticChecksPlugin(
                     );
                 }
                 // Shared so rejectRestrictedGlobals/warnAboutDivergentGlobals don't each independently re-walk this fallback-parsed AST to build the same scope graph.
-                scopeAnalysis = analyzeModuleScope(ensureProgram(ast, moduleId));
+                const program = ensureProgram(ast, moduleId);
+                scopeAnalysis = analyzeModuleScope(program);
             }
 
             rejectNodeBuiltinImports(ast, moduleId);

--- a/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
+++ b/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
@@ -13,10 +13,8 @@ import {
     unsupportedModuleGraphDependency,
 } from '../backend/ast-parsing/module-graph';
 import { analyzeModuleScope } from '../backend/ast-parsing/module-scope';
-import { rejectNodeBuiltinImports } from '../backend/ast-parsing/reject-node-builtin-imports';
-import { rejectRestrictedGlobals } from '../backend/ast-parsing/reject-restricted-globals';
+import { runBackendStaticChecks } from '../backend/ast-parsing/run-backend-static-checks';
 import { ensureProgram } from '../backend/ast-parsing/type-guards';
-import { warnAboutDivergentGlobals } from '../backend/ast-parsing/warn-divergent-globals';
 
 import { isViteVirtualModuleId, normalizeViteModuleId } from './backend-module-graph-collector';
 
@@ -57,14 +55,12 @@ export function createBackendStaticChecksPlugin(
                         `unparseable module source (${reason})`,
                     );
                 }
-                // Shared so rejectRestrictedGlobals/warnAboutDivergentGlobals don't each independently re-walk this fallback-parsed AST to build the same scope graph.
+                // Shared so the checks below don't each independently re-walk this fallback-parsed AST to build the same scope graph.
                 const program = ensureProgram(ast, moduleId);
                 scopeAnalysis = analyzeModuleScope(program);
             }
 
-            rejectNodeBuiltinImports(ast, moduleId);
-            rejectRestrictedGlobals(ast, moduleId, scopeAnalysis);
-            warnAboutDivergentGlobals(ast, moduleId, log, scopeAnalysis);
+            runBackendStaticChecks(ast, moduleId, log, scopeAnalysis);
         },
     };
 }

--- a/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
+++ b/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
@@ -10,7 +10,6 @@ import type { Plugin } from 'vite';
 import {
     type ParsedModuleRecord,
     shouldTraverseCollectedModule,
-    unsupportedModuleGraphDependency,
 } from '../backend/ast-parsing/module-graph';
 import { analyzeModuleScope } from '../backend/ast-parsing/module-scope';
 import { runBackendStaticChecks } from '../backend/ast-parsing/run-backend-static-checks';
@@ -18,7 +17,14 @@ import { ensureProgram } from '../backend/ast-parsing/type-guards';
 
 import { isViteVirtualModuleId, normalizeViteModuleId } from './backend-module-graph-collector';
 
-// Re-runs the static checks against every app-local module the nested backend build resolves (not just the `.backend.ts` entry), since a helper module imported by the entry is otherwise never checked; MUST be registered after the connection-ID collector's plugin so `getModuleRecords` is already populated (falls back to parsing locally if a module is missing from it).
+// Distinct from module-graph.ts's `unsupportedModuleGraphDependency` — that message is specific to connection-ID collection, unrelated to this plugin's fallback parse.
+function unsupportedStaticChecksSource(filePath: string, unsupported: string): Error {
+    return new Error(
+        `Unsupported module source for ${filePath}: ${unsupported} could hide a Node-builtin import or restricted-global access.`,
+    );
+}
+
+// Re-runs the static checks against every app-local module the nested backend build resolves, not just the `.backend.ts` entry, so an imported helper module is also checked. MUST be registered after the connection-ID collector's plugin so `getModuleRecords` is populated (falls back to a local parse if a module is missing from it).
 export function createBackendStaticChecksPlugin(
     buildRoot: string,
     log: Logger,
@@ -50,7 +56,7 @@ export function createBackendStaticChecksPlugin(
                     ast = this.parse(moduleInfo.code);
                 } catch (error) {
                     const reason = error instanceof Error ? error.message : String(error);
-                    throw unsupportedModuleGraphDependency(
+                    throw unsupportedStaticChecksSource(
                         moduleId,
                         `unparseable module source (${reason})`,
                     );

--- a/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
+++ b/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
@@ -12,12 +12,13 @@ import {
     shouldTraverseCollectedModule,
     unsupportedModuleGraphDependency,
 } from '../backend/ast-parsing/module-graph';
-import type { ModuleScopeAnalysis } from '../backend/ast-parsing/module-scope';
+import { analyzeModuleScope } from '../backend/ast-parsing/module-scope';
 import { rejectNodeBuiltinImports } from '../backend/ast-parsing/reject-node-builtin-imports';
 import { rejectRestrictedGlobals } from '../backend/ast-parsing/reject-restricted-globals';
+import { ensureProgram } from '../backend/ast-parsing/type-guards';
 import { warnAboutDivergentGlobals } from '../backend/ast-parsing/warn-divergent-globals';
 
-const VIRTUAL_MODULE_ID_RE = /^(?:\0|virtual:)/;
+import { isViteVirtualModuleId, normalizeViteModuleId } from './backend-module-graph-collector';
 
 // Re-runs the static checks against every app-local module the nested backend build resolves (not just the `.backend.ts` entry), since a helper module imported by the entry is otherwise never checked; MUST be registered after the connection-ID collector's plugin so `getModuleRecords` is already populated (falls back to parsing locally if a module is missing from it).
 export function createBackendStaticChecksPlugin(
@@ -38,7 +39,7 @@ export function createBackendStaticChecksPlugin(
 
             const existingRecord = getModuleRecords().get(moduleId);
             let ast: BaseNode;
-            let scopeAnalysis: ModuleScopeAnalysis | undefined;
+            let scopeAnalysis: ReturnType<typeof analyzeModuleScope>;
 
             if (existingRecord) {
                 ast = existingRecord.ast;
@@ -56,6 +57,8 @@ export function createBackendStaticChecksPlugin(
                         `unparseable module source (${reason})`,
                     );
                 }
+                // Shared so rejectRestrictedGlobals/warnAboutDivergentGlobals don't each independently re-walk this fallback-parsed AST to build the same scope graph.
+                scopeAnalysis = analyzeModuleScope(ensureProgram(ast, moduleId));
             }
 
             rejectNodeBuiltinImports(ast, moduleId);
@@ -63,12 +66,4 @@ export function createBackendStaticChecksPlugin(
             warnAboutDivergentGlobals(ast, moduleId, log, scopeAnalysis);
         },
     };
-}
-
-function normalizeViteModuleId(id: string): string {
-    return id.split('?')[0];
-}
-
-function isViteVirtualModuleId(id: string): boolean {
-    return VIRTUAL_MODULE_ID_RE.test(id);
 }

--- a/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
+++ b/packages/plugins/apps/src/vite/backend-static-checks-plugin.ts
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import type { Logger } from '@dd/core/types';
+import type { BaseNode } from 'estree';
+import type { ModuleInfo } from 'rollup';
+import type { Plugin } from 'vite';
+
+import {
+    type ParsedModuleRecord,
+    shouldTraverseCollectedModule,
+    unsupportedModuleGraphDependency,
+} from '../backend/ast-parsing/module-graph';
+import type { ModuleScopeAnalysis } from '../backend/ast-parsing/module-scope';
+import { rejectNodeBuiltinImports } from '../backend/ast-parsing/reject-node-builtin-imports';
+import { rejectRestrictedGlobals } from '../backend/ast-parsing/reject-restricted-globals';
+import { warnAboutDivergentGlobals } from '../backend/ast-parsing/warn-divergent-globals';
+
+const VIRTUAL_MODULE_ID_RE = /^(?:\0|virtual:)/;
+
+// Re-runs the static checks against every app-local module the nested backend build resolves (not just the `.backend.ts` entry), since a helper module imported by the entry is otherwise never checked; MUST be registered after the connection-ID collector's plugin so `getModuleRecords` is already populated (falls back to parsing locally if a module is missing from it).
+export function createBackendStaticChecksPlugin(
+    buildRoot: string,
+    log: Logger,
+    getModuleRecords: () => ReadonlyMap<string, ParsedModuleRecord>,
+): Plugin {
+    return {
+        name: 'dd-backend-static-checks',
+        moduleParsed(moduleInfo: ModuleInfo) {
+            const moduleId = normalizeViteModuleId(moduleInfo.id);
+            if (
+                isViteVirtualModuleId(moduleId) ||
+                !shouldTraverseCollectedModule(moduleId, buildRoot)
+            ) {
+                return;
+            }
+
+            const existingRecord = getModuleRecords().get(moduleId);
+            let ast: BaseNode;
+            let scopeAnalysis: ModuleScopeAnalysis | undefined;
+
+            if (existingRecord) {
+                ast = existingRecord.ast;
+                scopeAnalysis = existingRecord.scopeAnalysis;
+            } else {
+                if (typeof moduleInfo.code !== 'string') {
+                    return;
+                }
+                try {
+                    ast = this.parse(moduleInfo.code);
+                } catch (error) {
+                    const reason = error instanceof Error ? error.message : String(error);
+                    throw unsupportedModuleGraphDependency(
+                        moduleId,
+                        `unparseable module source (${reason})`,
+                    );
+                }
+            }
+
+            rejectNodeBuiltinImports(ast, moduleId);
+            rejectRestrictedGlobals(ast, moduleId, scopeAnalysis);
+            warnAboutDivergentGlobals(ast, moduleId, log, scopeAnalysis);
+        },
+    };
+}
+
+function normalizeViteModuleId(id: string): string {
+    return id.split('?')[0];
+}
+
+function isViteVirtualModuleId(id: string): boolean {
+    return VIRTUAL_MODULE_ID_RE.test(id);
+}

--- a/packages/plugins/apps/src/vite/build-backend-functions.test.ts
+++ b/packages/plugins/apps/src/vite/build-backend-functions.test.ts
@@ -3,10 +3,9 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { buildBackendFunctions } from '@dd/apps-plugin/vite/build-backend-functions';
-import { rm } from '@dd/core/helpers/fs';
+import { existsSync, rm, rmSync } from '@dd/core/helpers/fs';
 import { getMockLogger, mockLogger } from '@dd/tests/_jest/helpers/mocks';
 import { mkdtemp } from 'fs/promises';
-import fs from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import type { build } from 'vite';
@@ -14,6 +13,7 @@ import type { build } from 'vite';
 import type { BackendFunction } from '../backend/types';
 
 jest.mock('@dd/core/helpers/fs', () => ({
+    ...jest.requireActual('@dd/core/helpers/fs'),
     rm: jest.fn(jest.requireActual('@dd/core/helpers/fs').rm),
 }));
 
@@ -58,7 +58,7 @@ describe('buildBackendFunctions', () => {
 
         // outDir is only returned for the caller to clean up on success, so a rejected build must clean up its own temp directory.
         const outDir = await outDirCreatedByLastCall();
-        expect(fs.existsSync(outDir)).toBe(false);
+        expect(existsSync(outDir)).toBe(false);
     });
 
     test('Should still surface the original build failure, not the cleanup failure, when temp-directory cleanup itself throws', async () => {
@@ -83,7 +83,7 @@ describe('buildBackendFunctions', () => {
 
         // The mocked rm() rejected without deleting anything, so this test's own leaked directory needs manual cleanup.
         const outDir = await outDirCreatedByLastCall();
-        fs.rmSync(outDir, { recursive: true, force: true });
+        rmSync(outDir);
     });
 
     test('Should ignore other dd-apps-backend-* temp directories that exist concurrently, e.g. from a sibling test file building its own backend functions in parallel', async () => {
@@ -104,10 +104,10 @@ describe('buildBackendFunctions', () => {
             ).rejects.toThrow('static check rejected a reachable helper module');
 
             const outDir = await outDirCreatedByLastCall();
-            expect(fs.existsSync(outDir)).toBe(false);
-            expect(fs.existsSync(decoyDir)).toBe(true);
+            expect(existsSync(outDir)).toBe(false);
+            expect(existsSync(decoyDir)).toBe(true);
         } finally {
-            fs.rmSync(decoyDir, { recursive: true, force: true });
+            rmSync(decoyDir);
         }
     });
 });

--- a/packages/plugins/apps/src/vite/build-backend-functions.test.ts
+++ b/packages/plugins/apps/src/vite/build-backend-functions.test.ts
@@ -32,7 +32,7 @@ const func: BackendFunction = {
     allowedConnectionIds: [],
 };
 
-// Reads back the exact directory this call created, instead of diffing the OS-wide `dd-apps-backend-*` namespace — Jest runs test files in parallel worker processes that all share the same OS tmpdir(), so a sibling test file building its own backend functions concurrently would otherwise race a namespace-wide diff.
+// Reads back the exact directory this call created, instead of diffing the OS-wide `dd-apps-backend-*` namespace — Jest's parallel worker processes share one OS tmpdir(), so a concurrent sibling test would race a namespace-wide diff.
 async function outDirCreatedByLastCall(): Promise<string> {
     const lastCall = mkdtempMock.mock.results.at(-1);
     if (!lastCall) {

--- a/packages/plugins/apps/src/vite/build-backend-functions.test.ts
+++ b/packages/plugins/apps/src/vite/build-backend-functions.test.ts
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import { buildBackendFunctions } from '@dd/apps-plugin/vite/build-backend-functions';
+import { rm } from '@dd/core/helpers/fs';
+import { getMockLogger, mockLogger } from '@dd/tests/_jest/helpers/mocks';
+import { mkdtemp } from 'fs/promises';
+import fs from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import type { build } from 'vite';
+
+import type { BackendFunction } from '../backend/types';
+
+jest.mock('@dd/core/helpers/fs', () => ({
+    rm: jest.fn(jest.requireActual('@dd/core/helpers/fs').rm),
+}));
+
+jest.mock('fs/promises', () => ({
+    ...jest.requireActual('fs/promises'),
+    mkdtemp: jest.fn(jest.requireActual('fs/promises').mkdtemp),
+}));
+
+const rmMock = jest.mocked(rm);
+const mkdtempMock = jest.mocked(mkdtemp);
+
+const func: BackendFunction = {
+    relativePath: 'src/example',
+    name: 'example',
+    absolutePath: '/src/example.backend.ts',
+    allowedConnectionIds: [],
+};
+
+// Reads back the exact directory this call created, instead of diffing the OS-wide `dd-apps-backend-*` namespace — Jest runs test files in parallel worker processes that all share the same OS tmpdir(), so a sibling test file building its own backend functions concurrently would otherwise race a namespace-wide diff.
+async function outDirCreatedByLastCall(): Promise<string> {
+    const lastCall = mkdtempMock.mock.results.at(-1);
+    if (!lastCall) {
+        throw new Error('mkdtemp was never called');
+    }
+    return lastCall.value;
+}
+
+describe('buildBackendFunctions', () => {
+    test('Should clean up the temp output directory when a per-function vite.build() call throws (e.g. a static check rejects a reachable helper module)', async () => {
+        const failingViteBuild = jest
+            .fn()
+            .mockRejectedValue(new Error('static check rejected a reachable helper module'));
+
+        await expect(
+            buildBackendFunctions(
+                failingViteBuild as unknown as typeof build,
+                [func],
+                '/project',
+                mockLogger,
+            ),
+        ).rejects.toThrow('static check rejected a reachable helper module');
+
+        // outDir is only returned for the caller to clean up on success, so a rejected build must clean up its own temp directory.
+        const outDir = await outDirCreatedByLastCall();
+        expect(fs.existsSync(outDir)).toBe(false);
+    });
+
+    test('Should still surface the original build failure, not the cleanup failure, when temp-directory cleanup itself throws', async () => {
+        rmMock.mockRejectedValueOnce(new Error('EACCES: permission denied'));
+
+        const warnMock = jest.fn();
+        const logger = getMockLogger({ warn: warnMock });
+        const failingViteBuild = jest
+            .fn()
+            .mockRejectedValue(new Error('static check rejected a reachable helper module'));
+
+        await expect(
+            buildBackendFunctions(
+                failingViteBuild as unknown as typeof build,
+                [func],
+                '/project',
+                logger,
+            ),
+        ).rejects.toThrow('static check rejected a reachable helper module');
+
+        expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('EACCES'));
+
+        // The mocked rm() rejected without deleting anything, so this test's own leaked directory needs manual cleanup.
+        const outDir = await outDirCreatedByLastCall();
+        fs.rmSync(outDir, { recursive: true, force: true });
+    });
+
+    test('Should ignore other dd-apps-backend-* temp directories that exist concurrently, e.g. from a sibling test file building its own backend functions in parallel', async () => {
+        const decoyDir = await mkdtemp(path.join(tmpdir(), 'dd-apps-backend-'));
+
+        try {
+            const failingViteBuild = jest
+                .fn()
+                .mockRejectedValue(new Error('static check rejected a reachable helper module'));
+
+            await expect(
+                buildBackendFunctions(
+                    failingViteBuild as unknown as typeof build,
+                    [func],
+                    '/project',
+                    mockLogger,
+                ),
+            ).rejects.toThrow('static check rejected a reachable helper module');
+
+            const outDir = await outDirCreatedByLastCall();
+            expect(fs.existsSync(outDir)).toBe(false);
+            expect(fs.existsSync(decoyDir)).toBe(true);
+        } finally {
+            fs.rmSync(decoyDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/plugins/apps/src/vite/build-backend-functions.ts
+++ b/packages/plugins/apps/src/vite/build-backend-functions.ts
@@ -102,7 +102,7 @@ export async function buildBackendFunctions(
             );
         }
     } catch (error) {
-        // A rejected build throws before outDir is returned, so the caller's success-path cleanup never runs — clean it up here instead of leaking it. Cleanup failure is only logged, not thrown, so it can't mask the actionable build/static-check error that's already in flight.
+        // A rejected build throws before outDir is returned, so the caller's success-path cleanup never runs — clean it up here. Cleanup failure is only logged so it can't mask the real build error.
         try {
             await rm(outDir);
         } catch (cleanupError) {

--- a/packages/plugins/apps/src/vite/build-backend-functions.ts
+++ b/packages/plugins/apps/src/vite/build-backend-functions.ts
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { rm } from '@dd/core/helpers/fs';
 import type { Logger } from '@dd/core/types';
 import { mkdtemp } from 'fs/promises';
 import { tmpdir } from 'os';
@@ -13,6 +14,7 @@ import type { BackendFunction } from '../backend/types';
 import { generateVirtualEntryContent } from '../backend/virtual-entry';
 
 import { createBackendConnectionIdCollector } from './backend-connection-id-collector';
+import { createBackendStaticChecksPlugin } from './backend-static-checks-plugin';
 import { getBaseBackendBuildConfig } from './build-config';
 
 const VIRTUAL_PREFIX = '\0dd-backend:';
@@ -36,57 +38,77 @@ export async function buildBackendFunctions(
 
     log.debug(`Building ${functions.length} backend function(s) via vite.build()`);
 
-    // Build each function individually so that each output is a single
-    // self-contained JS file
-    for (const func of functions) {
-        const bundleName = encodeQueryName(func);
-        const virtualId = `${VIRTUAL_PREFIX}${bundleName}`;
-        const virtualContent = generateVirtualEntryContent(func.name, func.absolutePath, buildRoot);
-        const connectionIdCollector = createBackendConnectionIdCollector(
-            func.absolutePath,
-            buildRoot,
-        );
+    try {
+        // Build each function individually so that each output is a single self-contained JS file.
+        for (const func of functions) {
+            const bundleName = encodeQueryName(func);
+            const virtualId = `${VIRTUAL_PREFIX}${bundleName}`;
+            const virtualContent = generateVirtualEntryContent(
+                func.name,
+                func.absolutePath,
+                buildRoot,
+            );
+            const connectionIdCollector = createBackendConnectionIdCollector(
+                func.absolutePath,
+                buildRoot,
+            );
 
-        const baseConfig = getBaseBackendBuildConfig(buildRoot, { [virtualId]: virtualContent }, [
-            connectionIdCollector.plugin,
-        ]);
+            const staticChecksPlugin = createBackendStaticChecksPlugin(
+                buildRoot,
+                log,
+                connectionIdCollector.getModuleRecords,
+            );
+            const baseConfig = getBaseBackendBuildConfig(
+                buildRoot,
+                { [virtualId]: virtualContent },
+                [connectionIdCollector.plugin, staticChecksPlugin],
+            );
 
-        // eslint-disable-next-line no-await-in-loop
-        const result = await viteBuild({
-            ...baseConfig,
-            build: {
-                ...baseConfig.build,
-                write: true,
-                outDir,
-                emptyOutDir: false,
-                rollupOptions: {
-                    ...baseConfig.build.rollupOptions,
-                    input: { [bundleName]: virtualId },
-                    output: {
-                        ...baseConfig.build.rollupOptions.output,
-                        entryFileNames: '[name].js',
+            // eslint-disable-next-line no-await-in-loop
+            const result = await viteBuild({
+                ...baseConfig,
+                build: {
+                    ...baseConfig.build,
+                    write: true,
+                    outDir,
+                    emptyOutDir: false,
+                    rollupOptions: {
+                        ...baseConfig.build.rollupOptions,
+                        input: { [bundleName]: virtualId },
+                        output: {
+                            ...baseConfig.build.rollupOptions.output,
+                            entryFileNames: '[name].js',
+                        },
                     },
                 },
-            },
-        });
+            });
 
-        const output = Array.isArray(result) ? result[0] : result;
+            const output = Array.isArray(result) ? result[0] : result;
 
-        if ('output' in output) {
-            for (const chunk of output.output) {
-                if (chunk.type !== 'chunk' || !chunk.isEntry) {
-                    continue;
+            if ('output' in output) {
+                for (const chunk of output.output) {
+                    if (chunk.type !== 'chunk' || !chunk.isEntry) {
+                        continue;
+                    }
+                    const absolutePath = path.resolve(outDir, chunk.fileName);
+                    outputs.set(bundleName, absolutePath);
+                    log.debug(`Backend function "${bundleName}" output: ${absolutePath}`);
                 }
-                const absolutePath = path.resolve(outDir, chunk.fileName);
-                outputs.set(bundleName, absolutePath);
-                log.debug(`Backend function "${bundleName}" output: ${absolutePath}`);
             }
-        }
 
-        allowedConnectionIdsByEntryPath.set(
-            func.absolutePath,
-            connectionIdCollector.getAllowedConnectionIds(),
-        );
+            allowedConnectionIdsByEntryPath.set(
+                func.absolutePath,
+                connectionIdCollector.getAllowedConnectionIds(),
+            );
+        }
+    } catch (error) {
+        // A rejected build throws before outDir is returned, so the caller's success-path cleanup never runs — clean it up here instead of leaking it. Cleanup failure is only logged, not thrown, so it can't mask the actionable build/static-check error that's already in flight.
+        try {
+            await rm(outDir);
+        } catch (cleanupError) {
+            log.warn(`Failed to clean up temp output directory "${outDir}": ${cleanupError}`);
+        }
+        throw error;
     }
 
     return {

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -295,6 +295,40 @@ describe('Dev Server Middleware', () => {
             expect(res.getBody()).toContain('export function main($)');
         });
 
+        test('Should reject a bundle whose imported helper module has a restricted import or global', async () => {
+            // Emits moduleParsed for both the entry and a helper module, to prove the static-checks plugin covers the helper too, not just the entry file.
+            mockViteBuild.mockImplementation(async (config) => {
+                emitModuleParsed(
+                    config,
+                    mockFunctions[0].absolutePath,
+                    `export function ${mockFunctions[0].name}() { return null; }`,
+                );
+                emitModuleParsed(
+                    config,
+                    '/project/backend/helpers/secrets.ts',
+                    "import fs from 'fs';\nexport function readSecret() { return fs.readFileSync('/etc/passwd'); }",
+                );
+                return mockBuildResult('// code');
+            });
+
+            const encodedFunctionName = encodeQueryName(mockFunctions[0]);
+            const req = createMockRequest('/__dd/debugBundle', {
+                functionName: encodedFunctionName,
+            });
+            const res = createMockResponse();
+            const next = jest.fn();
+
+            middleware(req, res, next);
+            await res.done;
+
+            expect(res.statusCode).toBe(500);
+            const responseText = res.getBody();
+            const body = JSON.parse(responseText);
+            expect(body.error).toContain(
+                'Importing Node built-in module "fs" is not supported in backend function code',
+            );
+        });
+
         test('Should call vite.build with configFile: false and write: false', async () => {
             mockBuildWithParsedBackend();
 

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -17,6 +17,7 @@ import type { BackendFunction } from '../backend/types';
 import { generateDevVirtualEntryContent } from '../backend/virtual-entry';
 
 import { createBackendConnectionIdCollector } from './backend-connection-id-collector';
+import { createBackendStaticChecksPlugin } from './backend-static-checks-plugin';
 import { getBaseBackendBuildConfig } from './build-config';
 
 interface BundleResult {
@@ -86,8 +87,14 @@ async function bundleBackendFunction(
 
     log.debug(`Bundling backend function "${displayName}" from ${func.absolutePath}`);
 
+    const staticChecksPlugin = createBackendStaticChecksPlugin(
+        projectRoot,
+        log,
+        connectionIdCollector.getModuleRecords,
+    );
     const baseConfig = getBaseBackendBuildConfig(projectRoot, { [virtualId]: virtualContent }, [
         connectionIdCollector.plugin,
+        staticChecksPlugin,
     ]);
 
     // Dev: build a single function in-memory per request so we can send the

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -7,11 +7,32 @@ import * as identifier from '@dd/apps-plugin/identifier';
 import { getVitePlugin } from '@dd/apps-plugin/vite/index';
 import type { ViteBundler } from '@dd/apps-plugin/vite/index';
 import { InjectPosition } from '@dd/core/types';
-import { getContextMock, getRepositoryDataMock } from '@dd/tests/_jest/helpers/mocks';
+import { getContextMock, getRepositoryDataMock, mockLogFn } from '@dd/tests/_jest/helpers/mocks';
 import { parseAst } from 'rollup/parseAst';
 
 import { encodeQueryName } from '../backend/encodeQueryName';
 import type { BackendFunction } from '../backend/types';
+
+type TransformHandler = (code: string, id: string) => unknown;
+
+// Narrows `plugin.transform` to the object-hook form via a runtime check, then wraps `handler` in `Reflect.apply` to match `TransformHandler` without casting its wider real signature.
+function getTransformHandler(plugin: ReturnType<typeof getVitePlugin>): TransformHandler {
+    const { transform } = plugin ?? {};
+    if (
+        typeof transform !== 'object' ||
+        transform === null ||
+        typeof transform.handler !== 'function'
+    ) {
+        throw new Error(
+            'Expected plugin.transform to be the object-hook form with a handler function',
+        );
+    }
+
+    const handler = transform.handler;
+    return function callTransformHandler(this: unknown, code: string, id: string): unknown {
+        return Reflect.apply(handler, this, [code, id]);
+    };
+}
 
 const functions: BackendFunction[] = [
     {
@@ -135,11 +156,9 @@ describe('Backend Functions - getVitePlugin', () => {
 
     test('Should build backend functions and then upload in closeBundle', async () => {
         const plugin = getVitePlugin(defaultOptions);
-        const transform = plugin!.transform as {
-            handler: (code: string, id: string) => unknown;
-        };
+        const handler = getTransformHandler(plugin);
 
-        await transform.handler.call(
+        await handler.call(
             {
                 parse: parseAst,
                 resolve: jest.fn(async () => null),
@@ -162,17 +181,18 @@ describe('Backend Functions - getVitePlugin', () => {
 
     test('Should reject a backend file importing a Node built-in module', () => {
         const plugin = getVitePlugin(defaultOptions);
-        const transform = plugin!.transform as {
-            handler: (code: string, id: string) => unknown;
-        };
+        const handler = getTransformHandler(plugin);
+        const resolveMock = jest.fn(async () => null);
+        const loadMock = jest.fn(async () => null);
+        const addWatchFileMock = jest.fn();
 
         expect(() =>
-            transform.handler.call(
+            handler.call(
                 {
                     parse: parseAst,
-                    resolve: jest.fn(async () => null),
-                    load: jest.fn(async () => null),
-                    addWatchFile: jest.fn(),
+                    resolve: resolveMock,
+                    load: loadMock,
+                    addWatchFile: addWatchFileMock,
                 },
                 `
                     import fs from 'node:fs';
@@ -182,7 +202,37 @@ describe('Backend Functions - getVitePlugin', () => {
                 `,
                 '/build/src/backend/myHandler.backend.ts',
             ),
-        ).toThrow('Importing Node built-in module "node:fs" is not supported in .backend.ts files');
+        ).toThrow(
+            'Importing Node built-in module "node:fs" is not supported in backend function code',
+        );
+    });
+
+    test('Should warn, but not reject, a backend file referencing crypto or Intl', () => {
+        const plugin = getVitePlugin(defaultOptions);
+        const handler = getTransformHandler(plugin);
+        const resolveMock = jest.fn(async () => null);
+        const loadMock = jest.fn(async () => null);
+        const addWatchFileMock = jest.fn();
+
+        expect(() =>
+            handler.call(
+                {
+                    parse: parseAst,
+                    resolve: resolveMock,
+                    load: loadMock,
+                    addWatchFile: addWatchFileMock,
+                },
+                `
+                    export function myHandler() {
+                        return crypto.randomUUID() + new Intl.NumberFormat('en-US').format(1);
+                    }
+                `,
+                '/build/src/backend/myHandler.backend.ts',
+            ),
+        ).not.toThrow();
+
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('crypto'), 'warn');
+        expect(mockLogFn).toHaveBeenCalledWith(expect.stringContaining('Intl'), 'warn');
     });
 
     test('Should inject the apps runtime', () => {

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -160,6 +160,31 @@ describe('Backend Functions - getVitePlugin', () => {
         expect(assets.collectAssets).toHaveBeenCalledWith(['dist/**/*'], '/build');
     });
 
+    test('Should reject a backend file importing a Node built-in module', () => {
+        const plugin = getVitePlugin(defaultOptions);
+        const transform = plugin!.transform as {
+            handler: (code: string, id: string) => unknown;
+        };
+
+        expect(() =>
+            transform.handler.call(
+                {
+                    parse: parseAst,
+                    resolve: jest.fn(async () => null),
+                    load: jest.fn(async () => null),
+                    addWatchFile: jest.fn(),
+                },
+                `
+                    import fs from 'node:fs';
+                    export function myHandler() {
+                        return fs.readFileSync('/etc/passwd', 'utf8');
+                    }
+                `,
+                '/build/src/backend/myHandler.backend.ts',
+            ),
+        ).toThrow('Importing Node built-in module "node:fs" is not supported in .backend.ts files');
+    });
+
     test('Should inject the apps runtime', () => {
         getVitePlugin(defaultOptions);
 

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -15,10 +15,8 @@ import {
 } from '../auth';
 import { extractExportedFunctions } from '../backend/ast-parsing/extract-backend-functions';
 import { analyzeModuleScope } from '../backend/ast-parsing/module-scope';
-import { rejectNodeBuiltinImports } from '../backend/ast-parsing/reject-node-builtin-imports';
-import { rejectRestrictedGlobals } from '../backend/ast-parsing/reject-restricted-globals';
+import { runBackendStaticChecks } from '../backend/ast-parsing/run-backend-static-checks';
 import { ensureProgram } from '../backend/ast-parsing/type-guards';
-import { warnAboutDivergentGlobals } from '../backend/ast-parsing/warn-divergent-globals';
 import { encodeQueryName } from '../backend/encodeQueryName';
 import { generateProxyModule } from '../backend/proxy-codegen';
 import type { BackendFunction } from '../backend/types';
@@ -136,12 +134,10 @@ export const getVitePlugin = ({
             handler(code, id) {
                 const ast = this.parse(code);
                 const program = ensureProgram(ast, id);
-                // Shared so rejectRestrictedGlobals/warnAboutDivergentGlobals don't each independently re-walk the same AST to build the same scope graph.
+                // Shared so the checks below don't each independently re-walk the same AST to build the same scope graph.
                 const scopeAnalysis = analyzeModuleScope(program);
                 // Runs even for a file with zero exports, to catch a banned import/global as soon as it's written.
-                rejectNodeBuiltinImports(ast, id);
-                rejectRestrictedGlobals(ast, id, scopeAnalysis);
-                warnAboutDivergentGlobals(ast, id, log, scopeAnalysis);
+                runBackendStaticChecks(ast, id, log, scopeAnalysis);
                 const exportNames = extractExportedFunctions(ast, id);
                 if (exportNames.length === 0) {
                     log.warn(

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -14,6 +14,7 @@ import {
     type DoAuthenticatedRequest,
 } from '../auth';
 import { extractExportedFunctions } from '../backend/ast-parsing/extract-backend-functions';
+import { rejectNodeBuiltinImports } from '../backend/ast-parsing/reject-node-builtin-imports';
 import { encodeQueryName } from '../backend/encodeQueryName';
 import { generateProxyModule } from '../backend/proxy-codegen';
 import type { BackendFunction } from '../backend/types';
@@ -130,6 +131,7 @@ export const getVitePlugin = ({
             // frontend proxy that calls executeBackendFunction at runtime.
             handler(code, id) {
                 const ast = this.parse(code);
+                rejectNodeBuiltinImports(ast, id);
                 const exportNames = extractExportedFunctions(ast, id);
                 if (exportNames.length === 0) {
                     log.warn(

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -16,6 +16,7 @@ import {
 import { extractExportedFunctions } from '../backend/ast-parsing/extract-backend-functions';
 import { rejectNodeBuiltinImports } from '../backend/ast-parsing/reject-node-builtin-imports';
 import { rejectRestrictedGlobals } from '../backend/ast-parsing/reject-restricted-globals';
+import { warnAboutDivergentGlobals } from '../backend/ast-parsing/warn-divergent-globals';
 import { encodeQueryName } from '../backend/encodeQueryName';
 import { generateProxyModule } from '../backend/proxy-codegen';
 import type { BackendFunction } from '../backend/types';
@@ -132,8 +133,10 @@ export const getVitePlugin = ({
             // frontend proxy that calls executeBackendFunction at runtime.
             handler(code, id) {
                 const ast = this.parse(code);
+                // Runs even for a file with zero exports, to catch a banned import/global as soon as it's written.
                 rejectNodeBuiltinImports(ast, id);
                 rejectRestrictedGlobals(ast, id);
+                warnAboutDivergentGlobals(ast, id, log);
                 const exportNames = extractExportedFunctions(ast, id);
                 if (exportNames.length === 0) {
                     log.warn(

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -14,6 +14,8 @@ import {
     type DoAuthenticatedRequest,
 } from '../auth';
 import { extractExportedFunctions } from '../backend/ast-parsing/extract-backend-functions';
+import { rejectNodeBuiltinImports } from '../backend/ast-parsing/reject-node-builtin-imports';
+import { rejectRestrictedGlobals } from '../backend/ast-parsing/reject-restricted-globals';
 import { encodeQueryName } from '../backend/encodeQueryName';
 import { generateProxyModule } from '../backend/proxy-codegen';
 import type { BackendFunction } from '../backend/types';
@@ -130,6 +132,8 @@ export const getVitePlugin = ({
             // frontend proxy that calls executeBackendFunction at runtime.
             handler(code, id) {
                 const ast = this.parse(code);
+                rejectNodeBuiltinImports(ast, id);
+                rejectRestrictedGlobals(ast, id);
                 const exportNames = extractExportedFunctions(ast, id);
                 if (exportNames.length === 0) {
                     log.warn(

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -14,8 +14,10 @@ import {
     type DoAuthenticatedRequest,
 } from '../auth';
 import { extractExportedFunctions } from '../backend/ast-parsing/extract-backend-functions';
+import { analyzeModuleScope } from '../backend/ast-parsing/module-scope';
 import { rejectNodeBuiltinImports } from '../backend/ast-parsing/reject-node-builtin-imports';
 import { rejectRestrictedGlobals } from '../backend/ast-parsing/reject-restricted-globals';
+import { ensureProgram } from '../backend/ast-parsing/type-guards';
 import { warnAboutDivergentGlobals } from '../backend/ast-parsing/warn-divergent-globals';
 import { encodeQueryName } from '../backend/encodeQueryName';
 import { generateProxyModule } from '../backend/proxy-codegen';
@@ -133,10 +135,12 @@ export const getVitePlugin = ({
             // frontend proxy that calls executeBackendFunction at runtime.
             handler(code, id) {
                 const ast = this.parse(code);
+                // Shared so rejectRestrictedGlobals/warnAboutDivergentGlobals don't each independently re-walk the same AST to build the same scope graph.
+                const scopeAnalysis = analyzeModuleScope(ensureProgram(ast, id));
                 // Runs even for a file with zero exports, to catch a banned import/global as soon as it's written.
                 rejectNodeBuiltinImports(ast, id);
-                rejectRestrictedGlobals(ast, id);
-                warnAboutDivergentGlobals(ast, id, log);
+                rejectRestrictedGlobals(ast, id, scopeAnalysis);
+                warnAboutDivergentGlobals(ast, id, log, scopeAnalysis);
                 const exportNames = extractExportedFunctions(ast, id);
                 if (exportNames.length === 0) {
                     log.warn(

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -135,8 +135,9 @@ export const getVitePlugin = ({
             // frontend proxy that calls executeBackendFunction at runtime.
             handler(code, id) {
                 const ast = this.parse(code);
+                const program = ensureProgram(ast, id);
                 // Shared so rejectRestrictedGlobals/warnAboutDivergentGlobals don't each independently re-walk the same AST to build the same scope graph.
-                const scopeAnalysis = analyzeModuleScope(ensureProgram(ast, id));
+                const scopeAnalysis = analyzeModuleScope(program);
                 // Runs even for a file with zero exports, to catch a banned import/global as soon as it's written.
                 rejectNodeBuiltinImports(ast, id);
                 rejectRestrictedGlobals(ast, id, scopeAnalysis);


### PR DESCRIPTION
## Motivation

- Part of [APPS-2792](https://datadoghq.atlassian.net/browse/APPS-2792) — local Node execution for App Builder backend functions. Under today's v1 runtime, backend functions get no raw network access at all (not even `fetch`) — everything must go through an Action Platform action (`$.Actions` or an `@datadog/action-catalog` typed wrapper).
- Static imports of Node built-ins (`fs`, `child_process`, `net`, etc.) in `.backend.ts` files are now rejected at build time, so an author gets immediate feedback instead of code that silently breaks once local Node execution lands.
- Network-capable globals (`fetch`, `XMLHttpRequest`, `WebSocket`, `EventSource`) need a separate check, since they're bare globals rather than imports.
  - Closes a real trap: `fetch` works fine during local dev today but fails once published, since production's sandbox blocks it. Node's own `global` alias reaches the same globals and is treated identically.
- `crypto`/`Intl` behave identically enough to work in both runtimes, but aren't *guaranteed* identical (RNG implementation, bundled ICU data) — part of the RFC's prod-parity divergence list.
  - These only warn, pointing authors at `npm run dev:verify`'s real cloud round trip as the actual parity gate.
- A complementary effort ([web-ui#340206](https://github.com/DataDog/web-ui/pull/340206)) steers AI-generated code away from `fetch` in the first place. That reduces how often it's written, but only this build-time check guarantees it never ships — both layers exist for a reason.
- v1-specific: backend functions' planned v2 (Terrapin-based) sandbox will lift this restriction. Only legacy (pre-v2) apps need it.
- These are the design doc's two "Layer 2" static defenses; the companion item (ambient TypeScript globals for `$` that omit Node-specific types) is deferred — see Out of Scope.

## Architecture

Three checks run in the Vite transform hook right after `this.parse(code)`; two of them (the reject-style checks for restricted globals) share one AST traversal so a bypass fix lands once, not twice. A nested plugin re-runs all three against the whole backend module graph, not just the entry file.

```
.backend.ts (or an app-local module it imports)
     │
     ▼
this.parse(code) → AST
     │
     ├──▶ rejectNodeBuiltinImports     throws on a Node built-in
     │                                 (static or dynamic import)
     │
     ├──▶ rejectRestrictedGlobals ──┐  throws on an unshadowed
     │                              │  fetch/XHR/WebSocket/EventSource
     │                              ▼
     │                       forEachAmbientGlobalAccess
     │                       (bare ref, globalThis/global-qualified,
     │                        destructure, const-alias chains,
     │                        template-literal computed keys)
     │                              ▲
     └──▶ warnAboutDivergentGlobals ┘  warns (never throws) on
                                       crypto/Intl, same traversal

createBackendStaticChecksPlugin (nested Vite plugin)
  re-runs all three checks against every app-local module the
  backend build resolves — not just the .backend.ts entry the
  outer transform hook sees — reusing the connection-ID collector's
  already-parsed AST/scope analysis instead of re-parsing.
```

## Changes

| What changed | File |
|---|---|
| Added `rejectNodeBuiltinImports`, which walks a `.backend.ts` file's static `ImportDeclaration`s and throws if any source is a Node built-in (via `node:` prefix or Node's own `builtinModules` list). | [reject-node-builtin-imports.ts](packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts) |
| Also rejects a literal dynamic `import('node:fs')`, which Rollup represents as an `ImportExpression` rather than a top-level `ImportDeclaration`. | [reject-node-builtin-imports.ts](packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts) |
| Corrected its doc comment and error message, which previously pointed to fetch-based/isomorphic APIs as the allowed escape hatch — no longer accurate now that `fetch` itself is blocked too. | [reject-node-builtin-imports.ts](packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.ts) |
| Added `rejectRestrictedGlobals`, an eslint-scope-based check that throws on any unshadowed reference to `fetch`/`XMLHttpRequest`/`WebSocket`/`EventSource` — i.e. one that doesn't resolve to a local declaration or import of the same name, so it falls through to the real ambient global. | [reject-restricted-globals.ts](packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.ts) |
| It also treats Node's `global` alias the same as `globalThis`, in both qualified-access forms (`global.fetch`, destructuring off `global`). | [reject-restricted-globals.ts](packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.ts) |
| Added `warnAboutDivergentGlobals`, which warns (never rejects) on `crypto`/`Intl` references — bare, `globalThis`-qualified, or destructured — deduped once per distinct global per file. | [warn-divergent-globals.ts](packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.ts) |
| It also fires on a destructuring *assignment* (not just a declaration) and on a rest-destructure, matching coverage `rejectRestrictedGlobals` already had; its per-file dedup cache is now bounded so a long dev-server session can't grow it forever. | [warn-divergent-globals.ts](packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.ts) |
| Extracted `forEachAmbientGlobalAccess`, a shared traversal for every syntactic form that reaches `globalThis`/`global` (bare reference, qualified member access, destructuring), used by both reject/warn checks so a bypass fix lands once instead of drifting between two hand-mirrored copies. | [ambient-global-access.ts](packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts) |
| It now also resolves a computed member/destructure key written as a no-substitution template literal (`` globalThis[\`fetch\`] ``). | [ambient-global-access.ts](packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts) |
| It now also follows a `const` alias of `globalThis`/`global`, including a chain of aliases (e.g. `const x = globalThis; const y = x;`), so the ambient-global identity is still recognized after being reassigned to a new name. | [ambient-global-access.ts](packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts) |
| Wired all checks into the Vite transform hook, right after `this.parse(code)` and before export extraction. | [vite/index.ts](packages/plugins/apps/src/vite/index.ts) |
| Added `createBackendStaticChecksPlugin`, a nested Vite plugin that re-runs all three static checks against every app-local module the backend build resolves — not just the `.backend.ts` entry — so an imported helper can't ship an undetected violation. | [backend-static-checks-plugin.ts](packages/plugins/apps/src/vite/backend-static-checks-plugin.ts) |
| Wired into both the production build and the dev server's own bundling path, and now reuses the connection-ID collector's already-parsed AST/scope analysis instead of parsing a module a second time. | [backend-static-checks-plugin.ts](packages/plugins/apps/src/vite/backend-static-checks-plugin.ts), [backend-connection-id-collector.ts](packages/plugins/apps/src/vite/backend-connection-id-collector.ts) |
| Added unit tests covering allowed imports (relative, scoped, ordinary npm packages), rejected imports (`node:fs`, bare `fs`, `child_process`, `net`, `fs/promises`), and edge cases (type-only imports, non-import statements). | [reject-node-builtin-imports.test.ts](packages/plugins/apps/src/backend/ast-parsing/reject-node-builtin-imports.test.ts) |
| Added unit tests covering rejected global references (bare `fetch()` calls, referencing `fetch` without calling it, `new XMLHttpRequest()`/`WebSocket()`/`EventSource()`) and allowed cases (an imported action-catalog function, a locally-declared function/parameter named `fetch` — shadowing-safe). | [reject-restricted-globals.test.ts](packages/plugins/apps/src/backend/ast-parsing/reject-restricted-globals.test.ts) |
| Added an end-to-end test that runs a real `.backend.ts` file with a `node:fs` import through the actual transform handler (using rollup's real `parseAst`, not a hand-built AST) to confirm the rejection fires through the genuine pipeline. | [vite/index.test.ts](packages/plugins/apps/src/vite/index.test.ts) |
| Added a regression test for the nested self-referential destructure case (`const { globalThis: { crypto } } = globalThis`) to the warn path, mirroring the coverage `rejectRestrictedGlobals` already had — both checks share the same traversal, so a gap in one check's coverage is a gap in the other's too. | [warn-divergent-globals.test.ts](packages/plugins/apps/src/backend/ast-parsing/warn-divergent-globals.test.ts) |
| `forEachAmbientGlobalAccess` now also recognizes a for-of loop bound to an inline array literal containing `globalThis`/`global` (`for (const g of [globalThis]) { return g.fetch(...) }`), for both a destructured and a plain-identifier binding — only when provably `const`, since a `let`-declared or bare-assignment-target binding can be reassigned inside the loop body and is treated as opaque, the same rule the file's ordinary const-alias chains already follow. | [ambient-global-access.ts](packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts) |
| It also recognizes `Object.assign`/`Object.values`/`Object.entries`/`Object.getOwnPropertyDescriptors` called with `globalThis`/`global` as an argument — each reifies every own enumerable property value at once, the same threat as a rest-destructure or object-spread. The shared handler is renamed `onRestDestructure` → `onBulkCopy` to cover all forms uniformly. `Object.keys`/`Reflect.ownKeys` are deliberately excluded: they return only property-name strings, never a callable reference. | [ambient-global-access.ts](packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts) |
| `Object.assign`'s check now skips its first argument (the write target) rather than scanning every argument — `Object.assign(globalThis, { marker: true })` writes into `globalThis`, it doesn't copy properties out of it, so it was being incorrectly rejected. | [ambient-global-access.ts](packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts) |
| The bulk-copy call matcher now reuses `staticMemberName` instead of requiring a plain identifier property, so a computed form of the same call (`Object["assign"](...)`) is recognized too. | [ambient-global-access.ts](packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts) |
| The destructured-alias self-reference check now recurses through nested `globalThis`/`global` keys at any depth, not just one level, so `const { globalThis: { globalThis: g } } = globalThis` is recognized as a real alias. | [ambient-global-access.ts](packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts) |
| A computed member or destructure key that is itself bound through a `const` string alias (`const f = 'fetch'; globalThis[f](...)`, `const { [key]: r } = globalThis`) is now resolved the same way an aliased receiver object already was — via a new `resolveStaticPropertyName` alias-chain walk on the key side. | [ambient-global-access.ts](packages/plugins/apps/src/backend/ast-parsing/ambient-global-access.ts) |

## QA Instructions

Build the plugin and link it into a scratch Vite project, then exercise every syntactic form these checks recognize — both what they must reject and what they must still let through unaffected — against a single running dev server.

```bash
# 1. Build and link the plugin from this branch
cd ~/dd/build-plugins/packages/published/vite-plugin
rm -rf dist && yarn build
npm link

# 2. Scaffold a throwaway consumer project
mkdir -p ~/import-restriction-qa/src && cd ~/import-restriction-qa
cat > package.json <<'EOF'
{ "name": "import-restriction-qa", "private": true, "type": "module", "devDependencies": { "vite": "^5.0.0" } }
EOF
cat > vite.config.ts <<'EOF'
import { datadogVitePlugin } from '@datadog/vite-plugin/dist/src';
import { defineConfig } from 'vite';
export default defineConfig({
    plugins: [datadogVitePlugin({ apps: { identifier: 'qa-app-id', name: 'import-restriction-qa', dryRun: true } })],
});
EOF

# Positive cases — each of these must be REJECTED.
cat > src/badImport.backend.ts <<'EOF'
import fs from 'node:fs';
export function readSecret() { return fs.readFileSync('/etc/passwd', 'utf8'); }
EOF
cat > src/badFetch.backend.ts <<'EOF'
export async function callExternal() { return fetch('https://example.com'); }
EOF
cat > src/aliasedFetch.backend.ts <<'EOF'
export async function callExternal() { const g = globalThis; return g.fetch('https://example.com'); }
EOF
cat > src/bulkCopyFetch.backend.ts <<'EOF'
export async function callExternal() { const stolen = Object.assign({}, globalThis); return stolen.fetch('https://example.com'); }
EOF
cat > src/computedBulkCopy.backend.ts <<'EOF'
export async function callExternal() { const stolen = Object["assign"]({}, globalThis); return stolen.fetch('https://example.com'); }
EOF
cat > src/nestedSelfRefDestructure.backend.ts <<'EOF'
export async function callExternal() {
    const { globalThis: { globalThis: g } } = globalThis as any;
    return g.fetch('https://example.com');
}
EOF
cat > src/constAliasedComputedKey.backend.ts <<'EOF'
export async function callExternal() {
    const f = 'fetch';
    return (globalThis as any)[f]('https://example.com');
}
EOF
cat > src/destructureConstAliasKey.backend.ts <<'EOF'
export async function callExternal() {
    const key = 'fetch';
    const { [key]: r } = globalThis as any;
    return r('https://example.com');
}
EOF

# Negative cases — each of these must NOT be rejected (things we assume shouldn't be affected).
cat > src/goodImport.backend.ts <<'EOF'
export function doubleNumber(input: number) { return input * 2; }
EOF
cat > src/writeTargetAssign.backend.ts <<'EOF'
export function markGlobal() {
    Object.assign(globalThis, { marker: true });
    return 'ok';
}
EOF
cat > src/shadowedFetch.backend.ts <<'EOF'
export function run(fetch: (url: string) => string) {
    return fetch('https://example.com');
}
EOF
cat > src/letAliasNotFlagged.backend.ts <<'EOF'
export async function callExternal() {
    let g = globalThis;
    g = globalThis;
    return (g as any).fetch('https://example.com');
}
EOF

# Warn-only case — must transform successfully AND log a warning, not reject.
cat > src/divergentGlobalsWarn.backend.ts <<'EOF'
export function generateId() {
    return crypto.randomUUID();
}
EOF

npm install && npm link @datadog/vite-plugin

# 3. Start one dev server and exercise all 13 files against it
npx vite --port 5210 --strictPort > /tmp/qa476-server.log 2>&1 &
sleep 3

for f in badImport badFetch aliasedFetch bulkCopyFetch computedBulkCopy nestedSelfRefDestructure constAliasedComputedKey destructureConstAliasKey goodImport writeTargetAssign shadowedFetch letAliasNotFlagged divergentGlobalsWarn; do
  echo "=== $f ==="
  curl -s "http://localhost:5210/src/${f}.backend.ts" | head -c 300
  echo
done
grep -i "crypto" /tmp/qa476-server.log
kill %1
```

**Expected results** (all ✅ VERIFIED against this branch's current tip):
| File | Expectation | Result |
|---|---|---|
| `badImport` | Rejected: `Importing Node built-in module "node:fs" is not supported...` | ✅ |
| `badFetch` | Rejected: `Using "fetch" is not supported...` | ✅ |
| `aliasedFetch` (`const g = globalThis; g.fetch(...)`) | Rejected: same fetch message, via const-alias resolution | ✅ |
| `bulkCopyFetch` (`Object.assign({}, globalThis)`) | Rejected: `Copying every property of "globalThis"/"global" at once...` | ✅ |
| `computedBulkCopy` (`Object["assign"](...)`) | Rejected: same bulk-copy message, via computed-member resolution | ✅ |
| `nestedSelfRefDestructure` (`const { globalThis: { globalThis: g } } = globalThis`) | Rejected: fetch message, via nested self-reference resolution | ✅ |
| `constAliasedComputedKey` (`const f = 'fetch'; globalThis[f](...)`) | Rejected: fetch message, via const-aliased computed key resolution | ✅ |
| `destructureConstAliasKey` (`const key = 'fetch'; const { [key]: r } = globalThis`) | Rejected: fetch message, via the same key-alias resolution | ✅ |
| `goodImport` (plain function, no restricted access) | Transforms into a working `DD_APPS_RUNTIME.executeBackendFunction` proxy | ✅ |
| `writeTargetAssign` (`Object.assign(globalThis, {...})`) | NOT rejected — `globalThis` as a write target, not copied from | ✅ |
| `shadowedFetch` (a parameter literally named `fetch`) | NOT rejected — local shadowing resolves before the ambient global | ✅ |
| `letAliasNotFlagged` (`let g = globalThis`) | NOT rejected — a reassignable `let` binding is treated as opaque | ✅ |
| `divergentGlobalsWarn` (`crypto.randomUUID()`) | Transforms successfully AND logs `[warn\|vite\|apps] "crypto" is used in .../divergentGlobalsWarn.backend.ts...` | ✅ |

```bash
# Automated pass
yarn test:unit packages/plugins/apps
# Expected: Test Suites: 28 passed, 28 total / Tests: 433 passed, 433 total ✅ VERIFIED
yarn workspace @dd/apps-plugin run typecheck
# Expected: no output, exit 0 ✅ VERIFIED
```

## Blast Radius

- Scoped to `.backend.ts` files and the local helper modules they import. No feature flag — production's real sandbox already blocks both restricted patterns, so these are new build-time errors for code that wasn't usable in production anyway; `crypto`/`Intl` only ever warn, never fail a build.
- Best-effort, defense-in-depth, not exhaustive:
  - The import check catches static `import` specifiers and a dynamic `import()` with a string/template-literal specifier — not `require()` or a runtime-computed specifier.
  - The global-reference checks resolve a bare reference, a `globalThis`/`global`-qualified access (including a `const` alias chain), and destructuring — not a reference reached through a reassignable (`let`) binding or a fully dynamic computed key.
- Risk: low. No behavior change for any file that doesn't import a Node built-in or reference one of the four restricted globals. Files referencing `crypto`/`Intl` get an additional warn-level log line only.
- The checks run before the existing zero-exports check, intentionally: a no-export `.backend.ts` file that also imports a banned module now hard-fails instead of being silently warned-and-stripped — catching the banned pattern as soon as it's written.

## Out of Scope / Follow-ups

| Item | Status | Next step |
|---|---|---|
| Ship `backend-function-globals.d.ts` (ambient TypeScript type for `$` that omits `Deno`/`process`/Node-builtin globals) | Deferred | Editor-only DX polish, not an enforced guarantee — this PR's checks already enforce the restriction regardless of what types an author's editor shows. Getting a hand-written `.d.ts` into the published `dist/` tarball requires new build-tooling wiring in `packages/tools/src/rollupConfig.mjs` (shared by all 5 published bundler plugins), which is disproportionate scope for this PR. Revisit once a scaffold tool exists to actually wire the type into a consumer's `tsconfig.json`. |
| Revisit/remove both checks once backend-functions v2 ships | Deferred | v2's Terrapin-based sandbox will allow `fetch`; not blocking today's v1 rollout |
| `rejectNodeBuiltinImports`'s dynamic-import detection only registers a visitor for the `ImportExpression` AST shape, not the alternate `CallExpression` (`callee.type === 'Import'`) shape a different parser could emit for the same `import(...)` syntax | Deferred | Currently unobservable — `rollup/parseAst` (acorn) always emits `ImportExpression`, confirmed empirically. Revisit if Vite 8's Rolldown-based parser is adopted, since `module-graph.ts`'s own AST walk already anticipates both shapes for the same reason |
| `warnAboutDivergentGlobals`'s cross-call dedup cache is keyed only by file path, not content — a warning fires at most once per file for the lifetime of the dev-server process, even after a developer removes then re-adds a divergent-global reference in a later edit | Deferred | Would need a content hash threaded from the transform hook's own `code` argument into this function's cache key, a larger change than this finding's severity warrants — it's WARN-only editor guidance; `npm run dev:verify`'s real cloud round trip is the actual parity gate, per this function's own doc comment |

## Documentation

- RFC: [Confluence page 7012712651](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651)
- Kickoff doc: [Confluence page 7025394455](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455)
- QA guide: [Confluence page 7100498075](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7100498075) — exact local/staging QA commands for this repo
- Related: [web-ui#340206](https://github.com/DataDog/web-ui/pull/340206) — the complementary AI-authoring guidance change


[APPS-2792]: https://datadoghq.atlassian.net/browse/APPS-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ














