### PR TITLE
docs(apps): require HTTP action for external requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@datadog/build-plugins",
     "private": true,
-    "version": "3.2.12",
+    "version": "3.2.13",
     "license": "MIT",
     "author": "Datadog",
     "description": "Root of Datadog's Build Plugins monorepo",

--- a/packages/plugins/apps/README.md
+++ b/packages/plugins/apps/README.md
@@ -15,6 +15,7 @@ A plugin to upload assets to Datadog's storage
 <!-- #toc -->
 -   [Configuration](#configuration)
 -   [Assets Upload](#assets-upload)
+    -   [External HTTP requests](#external-http-requests)
     -   [apps.dryRun](#appsdryrun)
     -   [apps.enable](#appsenable)
     -   [apps.include](#appsinclude)
@@ -57,6 +58,28 @@ Upload built assets to Datadog storage as a compressed archive.
 > [!NOTE]
 > You can override the domain used in the request with the `DATADOG_SITE` environment variable or the `auth.site` options (eg. `datadoghq.eu`).
 > You can override the full intake URL by setting the `DATADOG_APPS_INTAKE_URL` environment variable (eg. `https://apps-intake.datadoghq.com/api/v1/apps`).
+
+### External HTTP requests
+
+External HTTP requests from an app must use the generic HTTP action from the Action Catalog in a backend function. Do not call `fetch` or use Node.js networking APIs to access an external service directly.
+
+```ts
+import { request } from '@datadog/action-catalog/http/http';
+
+export async function getExternalData() {
+    return request({
+        connectionId: '<YOUR_HTTP_CONNECTION_ID>',
+        inputs: {
+            verb: 'GET',
+            url: 'https://api.example.com/data',
+            responseParsing: 'json',
+            errorOnStatus: ['400-599'],
+        },
+    });
+}
+```
+
+Use an HTTP connection configured in your Datadog organization so credentials and access to the external service are managed through the Action Catalog. Frontend code should call the backend function rather than contacting the external service directly.
 
 ### apps.dryRun
 

--- a/packages/plugins/apps/README.md
+++ b/packages/plugins/apps/README.md
@@ -68,7 +68,6 @@ import { request } from '@datadog/action-catalog/http/http';
 
 export async function getExternalData() {
     return request({
-        connectionId: '<YOUR_HTTP_CONNECTION_ID>',
         inputs: {
             verb: 'GET',
             url: 'https://api.example.com/data',
@@ -79,7 +78,9 @@ export async function getExternalData() {
 }
 ```
 
-Use an HTTP connection configured in your Datadog organization so credentials and access to the external service are managed through the Action Catalog. Frontend code should call the backend function rather than contacting the external service directly.
+An HTTP connection is not required. Omit `connectionId` unless an HTTP connection already exists in the user's Datadog organization and contains authentication information the request needs. Connections must be created manually in the Datadog UI and their IDs copied into the app, so most external requests will not use one. When a suitable connection does exist, pass its ID as `connectionId` alongside `inputs`.
+
+Frontend code should call the backend function rather than contacting the external service directly.
 
 ### apps.dryRun
 

--- a/packages/published/esbuild-plugin/package.json
+++ b/packages/published/esbuild-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@datadog/esbuild-plugin",
     "packageManager": "yarn@4.0.2",
-    "version": "3.2.12",
+    "version": "3.2.13",
     "license": "MIT",
     "author": "Datadog",
     "description": "Datadog ESBuild Plugin",

--- a/packages/published/rollup-plugin/package.json
+++ b/packages/published/rollup-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@datadog/rollup-plugin",
     "packageManager": "yarn@4.0.2",
-    "version": "3.2.12",
+    "version": "3.2.13",
     "license": "MIT",
     "author": "Datadog",
     "description": "Datadog Rollup Plugin",

--- a/packages/published/rspack-plugin/package.json
+++ b/packages/published/rspack-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@datadog/rspack-plugin",
     "packageManager": "yarn@4.0.2",
-    "version": "3.2.12",
+    "version": "3.2.13",
     "license": "MIT",
     "author": "Datadog",
     "description": "Datadog Rspack Plugin",

--- a/packages/published/vite-plugin/package.json
+++ b/packages/published/vite-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@datadog/vite-plugin",
     "packageManager": "yarn@4.0.2",
-    "version": "3.2.12",
+    "version": "3.2.13",
     "license": "MIT",
     "author": "Datadog",
     "description": "Datadog Vite Plugin",

--- a/packages/published/webpack-plugin/package.json
+++ b/packages/published/webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@datadog/webpack-plugin",
     "packageManager": "yarn@4.0.2",
-    "version": "3.2.12",
+    "version": "3.2.13",
     "license": "MIT",
     "author": "Datadog",
     "description": "Datadog Webpack Plugin",


### PR DESCRIPTION
## What changed

- Document that apps must route external HTTP requests through a backend function and the generic HTTP action from `@datadog/action-catalog/http/http`.
- Explicitly discourage direct `fetch` and Node.js networking calls, and provide a copyable example that does not require a connection.
- Clarify that `connectionId` is optional and should only be supplied when an existing HTTP connection contains authentication information the request needs.
- Bump the build plugin packages from `3.2.12` to `3.2.13` so the guidance is included in the next published version.

## Why

Agents creating Datadog apps need an explicit networking boundary without being told to require configuration most users will not have. External calls should use the HTTP action, but that action works without a connection. HTTP connections are created manually in the Datadog UI, so apps should only reference one when it already exists and provides required authentication.

## Validation

- `yarn cli integrity`
- `git diff --check`
