### PR TITLE
[APPS][WIP] Prototype direct action execution in local dev server

### DIFF
--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -4,6 +4,7 @@
 
 /* eslint-disable no-await-in-loop */
 
+import { setExecuteActionImplementation } from '@datadog/action-catalog';
 import type { AuthOptionsWithDefaults, Logger } from '@dd/core/types';
 import { randomUUID } from 'crypto';
 import type { IncomingMessage, ServerResponse } from 'http';
@@ -124,6 +125,65 @@ async function bundleBackendFunction(
     return { func: enrichedFunc, code };
 }
 
+function executeAction({
+    func,
+    auth,
+    fqn,
+    input,
+    doAuthenticatedRequest,
+}: {
+    func: BackendFunction;
+    auth: AuthConfig;
+    fqn: string;
+    inputs: unknown;
+    doAuthenticatedRequest: DoAuthenticatedRequest;
+}) {
+    const endpoint = `https://api.${auth.site}/api/v2/app-builder/queries/preview-async`;
+    const displayName = formatRef(func);
+
+    log.debug(`Calling Datadog API: ${endpoint}`);
+
+    const body = JSON.stringify({
+        data: {
+            type: 'queries',
+            attributes: {
+                query: {
+                    id: randomUUID(),
+                    name: displayName,
+                    type: 'action',
+                    properties: {
+                        spec: {
+                            fqn,
+                            inputs,
+                        },
+                        onlyTriggerManually: true,
+                    },
+                },
+                template_params: {},
+            },
+        },
+    });
+
+    const initialResult = await doAuthenticatedRequest<{ data?: { id?: string } }>({
+        url: endpoint,
+        method: 'POST',
+        type: 'json',
+        getData: () => ({
+            data: body,
+            headers: { 'Content-Type': 'application/json' },
+        }),
+    });
+
+    const receiptId = initialResult.data?.id;
+
+    if (!receiptId) {
+        throw new Error('No receipt ID returned from Datadog API');
+    }
+
+    log.debug(`Query execution started with receipt: ${receiptId}`);
+
+    return pollQueryExecution(receiptId, auth, doAuthenticatedRequest, log);
+}
 /**
  * Execute a script via Datadog's app-builder queries API.
  */
@@ -320,19 +380,24 @@ async function handleExecuteAction(
     log: Logger,
 ): Promise<void> {
     try {
-        const { func, code, args } = await validateAndBundle(req, functionsByName, bundle);
+        const { functionName, args = [] } = await parseRequestBody(req);
+        const func = functionsByName.get(functionName);
+
+        setExecuteActionImplementation(async (actionId, { inputs, connectionId }) => {
+            return executeAction({
+                fqn: actionId,
+                inputs,
+                connectionId,
+            });
+        });
+        // Loading the module todos.backend.ts
+        const functions = await import(func?.absolutePath);
+        // Execute the addTodo()
+        const result = await functions[func?.name](...args);
+
         const displayName = formatRef(func);
 
         log.debug(`Executing action: ${displayName} with args`);
-
-        const result = await executeScriptViaDatadog(
-            code,
-            func,
-            args,
-            auth,
-            doAuthenticatedRequest,
-            log,
-        );
 
         res.statusCode = 200;
         res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
## Motivation

Explore executing Apps backend functions directly in the local Vite dev server while routing action-catalog calls through Datadog's App Builder query execution API. This draft is intended to make the prototype concrete enough for design feedback before the implementation is completed.

## Changes

The local `__dd/executeAction` handler now imports the requested backend module and invokes its exported function with the request arguments. Before invoking it, the handler installs an action-catalog execution adapter so calls made by the backend function can be forwarded to the App Builder `preview-async` API and resolved through the existing long-polling flow.

The adapter builds an action query from the action FQN and inputs, starts the query, validates the returned receipt ID, and reuses the current polling implementation to return the action output.

This is intentionally a WIP prototype. The action-catalog dependency and callback wiring are incomplete, and the Apps plugin does not currently typecheck with these changes.

## QA Instructions

No manual QA yet because the prototype wiring is incomplete. For this draft, review the proposed execution flow and where the action-catalog adapter is installed in the local dev-server request lifecycle.

## Blast Radius

The change is limited to the Apps plugin's local Vite development server and its backend-function execution endpoint. It is not production-ready and has no released customer impact unless completed and merged.

## Documentation

-   [How to reliably make frontend production changes](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/2286781319/Frontend+Production+Changesp)
-   [PR Description Guidelines](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/3120334387/PR+Checklist+and+Guidelines+for+Web+UI)
-   [Deploy steps](https://datadoghq.atlassian.net/wiki/spaces/FRON/pages/1457750032/)
