### PR TITLE
[APPS-2792] Add: dev:verify mode-aware routing for local execution (build-plugins half)

### DIFF
--- a/packages/plugins/apps/src/constants.ts
+++ b/packages/plugins/apps/src/constants.ts
@@ -16,6 +16,10 @@ export const LOCAL_EXECUTION_LOAD_SUFFIX = '?dd-local-exec';
 export const BACKEND_FILE_WITH_QUERY_RE = new RegExp(
     `${BACKEND_FILE_RE.source.slice(0, -1)}(\\?.*)?$`,
 );
+
+/** Vite's `--mode` for `npm run dev:verify`; read via `server.config.mode` since `import.meta.env.MODE` breaks Jest's CommonJS transform. */
+export const DEV_VERIFY_MODE = 'dev-verify';
+
 export const BACKEND_CODE_EXTENSIONS = [
     '.ts',
     '.tsx',

--- a/packages/plugins/apps/src/vite/dev-server.integration.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.integration.test.ts
@@ -197,6 +197,7 @@ describe('Dev Server Middleware — real end-to-end local execution', () => {
             mockLongPolling,
             FIXTURE_ROOT,
             getMockLogger(),
+            'development',
         );
 
         const req = createMockRequest('/__dd/executeAction', {
@@ -239,6 +240,7 @@ describe('Dev Server Middleware — real end-to-end local execution', () => {
             mockLongPolling,
             FIXTURE_ROOT,
             getMockLogger(),
+            'development',
         );
 
         const req = createMockRequest('/__dd/executeAction', {
@@ -275,6 +277,7 @@ describe('Dev Server Middleware — real end-to-end local execution', () => {
             mockLongPolling,
             FIXTURE_ROOT,
             getMockLogger(),
+            'development',
         );
 
         const req = createMockRequest('/__dd/executeAction', {
@@ -345,6 +348,7 @@ describe('Dev Server Middleware — real end-to-end local execution', () => {
             mockLongPolling,
             FIXTURE_ROOT,
             getMockLogger(),
+            'development',
         );
 
         const req = createMockRequest('/__dd/executeAction', {
@@ -389,6 +393,7 @@ describe('Dev Server Middleware — real end-to-end local execution', () => {
             mockLongPolling,
             FIXTURE_ROOT,
             getMockLogger(),
+            'development',
         );
 
         // The connection-ID collector is under test here, not the preview-async round trip
@@ -442,6 +447,7 @@ describe('Dev Server Middleware — real end-to-end local execution', () => {
             mockLongPolling,
             FIXTURE_ROOT,
             getMockLogger(),
+            'development',
         );
 
         const apiScope = nock('https://api.datadoghq.com')

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -21,7 +21,7 @@ import { parseAst } from 'rollup/parseAst';
 
 import { encodeQueryName } from '../backend/encodeQueryName';
 import type { BackendFunction } from '../backend/types';
-import { LOCAL_EXECUTION_LOAD_SUFFIX } from '../constants';
+import { DEV_VERIFY_MODE, LOCAL_EXECUTION_LOAD_SUFFIX } from '../constants';
 import type { AppsOptionsWithDefaults } from '../types';
 
 /** Shape of the `$.Actions` dynamic proxy — a nested property path (e.g. `$.Actions.slack.chat.postMessage`) callable at any depth; types `globalThis.$` in tests without an `any` cast. */
@@ -283,6 +283,39 @@ function makeImmediateRuntimeContextRequest() {
         });
 }
 
+type CreateDevServerMiddlewareArgs = Parameters<typeof createDevServerMiddleware>;
+
+/** Builds a middleware with the common test defaults, so each test only names the argument(s) it's actually varying. `doAuthenticatedRequest` distinguishes "omitted" from "explicitly undefined" (the no-auth tests) via `in`, since `?? testAuthenticatedRequest` couldn't tell them apart. */
+function createTestMiddleware(
+    overrides: {
+        viteBuild?: CreateDevServerMiddlewareArgs[0];
+        loadModule?: CreateDevServerMiddlewareArgs[1];
+        getBackendFunctions?: CreateDevServerMiddlewareArgs[2];
+        getAllowedConnectionIds?: CreateDevServerMiddlewareArgs[3];
+        auth?: CreateDevServerMiddlewareArgs[4];
+        doAuthenticatedRequest?: CreateDevServerMiddlewareArgs[5];
+        longPolling?: CreateDevServerMiddlewareArgs[6];
+        projectRoot?: CreateDevServerMiddlewareArgs[7];
+        log?: CreateDevServerMiddlewareArgs[8];
+        mode?: CreateDevServerMiddlewareArgs[9];
+    } = {},
+): ReturnType<typeof createDevServerMiddleware> {
+    return createDevServerMiddleware(
+        overrides.viteBuild ?? mockViteBuild,
+        overrides.loadModule ?? mockLoadModule,
+        overrides.getBackendFunctions ?? (() => mockFunctions),
+        overrides.getAllowedConnectionIds ?? (async () => []),
+        overrides.auth ?? mockAuth,
+        'doAuthenticatedRequest' in overrides
+            ? overrides.doAuthenticatedRequest
+            : testAuthenticatedRequest,
+        overrides.longPolling ?? mockLongPolling,
+        overrides.projectRoot ?? '/project',
+        overrides.log ?? mockLog,
+        overrides.mode ?? 'development',
+    );
+}
+
 describe('Dev Server Middleware', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -295,17 +328,7 @@ describe('Dev Server Middleware', () => {
     });
 
     describe('createDevServerMiddleware routing', () => {
-        const middleware = createDevServerMiddleware(
-            mockViteBuild,
-            mockLoadModule,
-            () => mockFunctions,
-            async () => [],
-            mockAuth,
-            testAuthenticatedRequest,
-            mockLongPolling,
-            '/project',
-            mockLog,
-        );
+        const middleware = createTestMiddleware();
 
         test('Should call next() for non-POST requests', () => {
             const req = { method: 'GET', url: '/__dd/debugBundle' } as unknown as IncomingMessage;
@@ -405,20 +428,48 @@ describe('Dev Server Middleware', () => {
             expect(body.result).toEqual({ data: { result: 'hello' } });
             expect(apiScope.isDone()).toBe(true);
         });
+
+        test('Should route /__dd/executeAction to the cloud path when the dev server was started in dev-verify mode', async () => {
+            const verifyModeMiddleware = createTestMiddleware({ mode: DEV_VERIFY_MODE });
+
+            mockBuildWithParsedBackend();
+
+            const apiScope = nock(DD_API_ORIGIN)
+                .post('/api/v2/app-builder/queries/preview-async')
+                .reply(200, { data: { id: 'receipt-456' } })
+                .get('/api/v2/app-builder/queries/execution-long-polling/receipt-456')
+                .reply(200, {
+                    data: {
+                        attributes: {
+                            done: true,
+                            outputs: { data: { result: 'via cloud' } },
+                        },
+                    },
+                });
+
+            const req = createMockRequest('/__dd/executeAction', {
+                functionName: encodeQueryName(mockFunctions[0]),
+                args: ['world'],
+            });
+            const res = createMockResponse();
+            const next = jest.fn();
+
+            verifyModeMiddleware(req, res, next);
+            expect(next).not.toHaveBeenCalled();
+
+            await res.done;
+
+            expect(res.statusCode).toBe(200);
+            const body = JSON.parse(res.getBody());
+            expect(body.success).toBe(true);
+            expect(body.result).toEqual({ data: { result: 'via cloud' } });
+            expect(apiScope.isDone()).toBe(true);
+            expect(mockLoadModule).not.toHaveBeenCalled();
+        });
     });
 
     describe('debugBundle handler', () => {
-        const middleware = createDevServerMiddleware(
-            mockViteBuild,
-            mockLoadModule,
-            () => mockFunctions,
-            async () => [],
-            mockAuth,
-            testAuthenticatedRequest,
-            mockLongPolling,
-            '/project',
-            mockLog,
-        );
+        const middleware = createTestMiddleware();
 
         test('Should return 400 for missing functionRef', async () => {
             const req = createMockRequest('/__dd/debugBundle', {});
@@ -521,17 +572,7 @@ describe('Dev Server Middleware', () => {
     });
 
     describe('executeActionViaCloud handler', () => {
-        const middleware = createDevServerMiddleware(
-            mockViteBuild,
-            mockLoadModule,
-            () => mockFunctions,
-            async () => [],
-            mockAuth,
-            testAuthenticatedRequest,
-            mockLongPolling,
-            '/project',
-            mockLog,
-        );
+        const middleware = createTestMiddleware();
 
         test('Should return 400 for missing functionRef', async () => {
             const req = createMockRequest('/__dd/executeActionViaCloud', {});
@@ -556,17 +597,7 @@ describe('Dev Server Middleware', () => {
         });
 
         test('Should reject a request with no auth configured upfront, matching the /__dd/executeAction gate', async () => {
-            const noAuthMiddleware = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => mockFunctions,
-                async () => [],
-                mockAuth,
-                undefined,
-                mockLongPolling,
-                '/project',
-                mockLog,
-            );
+            const noAuthMiddleware = createTestMiddleware({ doAuthenticatedRequest: undefined });
 
             const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
@@ -679,17 +710,9 @@ describe('Dev Server Middleware', () => {
             // token must be set in the test body for this live construction.
             process.env.DD_OAUTH_ACCESS_TOKEN = TEST_OAUTH_TOKEN;
 
-            const bearerMiddleware = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => mockFunctions,
-                async () => [],
-                mockAuth,
-                getAuthenticatedRequest(),
-                mockLongPolling,
-                '/project',
-                mockLog,
-            );
+            const bearerMiddleware = createTestMiddleware({
+                doAuthenticatedRequest: getAuthenticatedRequest(),
+            });
 
             const apiScope = nock(DD_API_ORIGIN, {
                 reqheaders: {
@@ -721,17 +744,7 @@ describe('Dev Server Middleware', () => {
         });
 
         test('Should return 400 with auth guidance when the access token is missing', async () => {
-            const noKeyMiddleware = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => mockFunctions,
-                async () => [],
-                mockAuth,
-                undefined,
-                mockLongPolling,
-                '/project',
-                mockLog,
-            );
+            const noKeyMiddleware = createTestMiddleware({ doAuthenticatedRequest: undefined });
 
             const req = createMockRequest('/__dd/executeActionViaCloud', {
                 functionName: encodeQueryName(mockFunctions[0]),
@@ -810,17 +823,9 @@ describe('Dev Server Middleware', () => {
                     allowedConnectionIds: ['conn-1', 'conn-2'],
                 },
             ];
-            const middlewareWithAllowlist = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => functionsWithAllowlist,
-                async () => [],
-                mockAuth,
-                testAuthenticatedRequest,
-                mockLongPolling,
-                '/project',
-                mockLog,
-            );
+            const middlewareWithAllowlist = createTestMiddleware({
+                getBackendFunctions: () => functionsWithAllowlist,
+            });
 
             type PreviewAsyncBody = {
                 data: {
@@ -974,17 +979,9 @@ describe('Dev Server Middleware', () => {
         test('Should not retry when maxRetries is 1 (long-polling disabled)', async () => {
             mockBuildWithParsedBackend();
 
-            const singleAttemptMiddleware = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => mockFunctions,
-                async () => [],
-                mockAuth,
-                testAuthenticatedRequest,
-                { ...mockLongPolling, maxRetries: 1 },
-                '/project',
-                mockLog,
-            );
+            const singleAttemptMiddleware = createTestMiddleware({
+                longPolling: { ...mockLongPolling, maxRetries: 1 },
+            });
 
             const apiScope = nock(DD_API_ORIGIN)
                 .post('/api/v2/app-builder/queries/preview-async')
@@ -1013,17 +1010,9 @@ describe('Dev Server Middleware', () => {
 
             // A stalled connection must be abandoned and re-polled, not surfaced
             // as a failed action: the receipt stays valid across attempts.
-            const stallingMiddleware = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => mockFunctions,
-                async () => [],
-                mockAuth,
-                testAuthenticatedRequest,
-                { ...mockLongPolling, timeoutMs: 100 },
-                '/project',
-                mockLog,
-            );
+            const stallingMiddleware = createTestMiddleware({
+                longPolling: { ...mockLongPolling, timeoutMs: 100 },
+            });
 
             const apiScope = nock(DD_API_ORIGIN)
                 .post('/api/v2/app-builder/queries/preview-async')
@@ -1084,17 +1073,7 @@ describe('Dev Server Middleware', () => {
             mockRuntimeContextHydration();
         });
 
-        const middleware = createDevServerMiddleware(
-            mockViteBuild,
-            mockLoadModule,
-            () => mockFunctions,
-            async () => [],
-            mockAuth,
-            testAuthenticatedRequest,
-            mockLongPolling,
-            '/project',
-            mockLog,
-        );
+        const middleware = createTestMiddleware();
 
         test('Should return 400 for missing functionRef', async () => {
             const req = createMockRequest('/__dd/executeAction', {});
@@ -1213,6 +1192,7 @@ describe('Dev Server Middleware', () => {
                     mockLongPolling,
                     '/project',
                     mockLog,
+                    'development',
                 );
 
                 const req = createMockRequest('/__dd/executeAction', {
@@ -1244,6 +1224,7 @@ describe('Dev Server Middleware', () => {
                     mockLongPolling,
                     '/project',
                     mockLog,
+                    'development',
                 );
                 mockLoadModuleReturning(mockFunctions[0], () => 'recovered');
                 const recoveringReq = createMockRequest('/__dd/executeAction', {
@@ -1267,17 +1248,7 @@ describe('Dev Server Middleware', () => {
         });
 
         test('Should reject a request with no auth configured upfront, even for a function that never calls $.Actions — matching production, which authenticates before any backend code runs', async () => {
-            const noAuthMiddleware = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => mockFunctions,
-                async () => [],
-                mockAuth,
-                undefined,
-                mockLongPolling,
-                '/project',
-                mockLog,
-            );
+            const noAuthMiddleware = createTestMiddleware({ doAuthenticatedRequest: undefined });
             mockLoadModuleReturning(mockFunctions[0], () => 'pure result, no $.Actions call');
 
             const req = createMockRequest('/__dd/executeAction', {
@@ -1300,18 +1271,11 @@ describe('Dev Server Middleware', () => {
                 ...mockFunctions[0],
                 allowedConnectionIds: ['conn-1'],
             };
-            const middlewareWithConnection = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => [funcWithConnection, mockFunctions[1]],
-                async (entryId: string) =>
+            const middlewareWithConnection = createTestMiddleware({
+                getBackendFunctions: () => [funcWithConnection, mockFunctions[1]],
+                getAllowedConnectionIds: async (entryId: string) =>
                     entryId === funcWithConnection.absolutePath ? ['conn-1'] : [],
-                mockAuth,
-                testAuthenticatedRequest,
-                mockLongPolling,
-                '/project',
-                mockLog,
-            );
+            });
             mockLoadModuleReturning(funcWithConnection, () =>
                 testDollarActions().slack.chat.postMessage({
                     inputs: { text: 'hi' },
@@ -1378,18 +1342,11 @@ describe('Dev Server Middleware', () => {
                 ...mockFunctions[0],
                 allowedConnectionIds: [''],
             };
-            const middlewareWithEmptyConnection = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => [funcWithEmptyConnection, mockFunctions[1]],
-                async (entryId: string) =>
+            const middlewareWithEmptyConnection = createTestMiddleware({
+                getBackendFunctions: () => [funcWithEmptyConnection, mockFunctions[1]],
+                getAllowedConnectionIds: async (entryId: string) =>
                     entryId === funcWithEmptyConnection.absolutePath ? [''] : [],
-                mockAuth,
-                testAuthenticatedRequest,
-                mockLongPolling,
-                '/project',
-                mockLog,
-            );
+            });
             mockLoadModuleReturning(funcWithEmptyConnection, () =>
                 testDollarActions().slack.chat.postMessage({
                     inputs: { text: 'hi' },
@@ -1541,6 +1498,7 @@ describe('Dev Server Middleware', () => {
                     mockLongPolling,
                     '/project',
                     mockLog,
+                    'development',
                 );
                 mockLoadModule.mockImplementation(
                     // Never settles.
@@ -1639,19 +1597,11 @@ describe('Dev Server Middleware', () => {
                 primingCalls.push(specifier);
                 return { [mockFunctions[0].name]: () => 'done' };
             });
-            const rejectingMiddleware = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => mockFunctions,
-                async () => {
+            const rejectingMiddleware = createTestMiddleware({
+                getAllowedConnectionIds: async () => {
                     throw new Error('Importing Node built-in module "fs" is not supported');
                 },
-                mockAuth,
-                testAuthenticatedRequest,
-                mockLongPolling,
-                '/project',
-                mockLog,
-            );
+            });
 
             const req = createMockRequest('/__dd/executeAction', {
                 functionName: encodeQueryName(mockFunctions[0]),
@@ -1674,18 +1624,11 @@ describe('Dev Server Middleware', () => {
             try {
                 mockLoadModuleReturning(mockFunctions[0], () => 'done');
                 const immediateRuntimeContextRequest = makeImmediateRuntimeContextRequest();
-                const hangingMiddleware = createDevServerMiddleware(
-                    mockViteBuild,
-                    mockLoadModule,
-                    () => mockFunctions,
+                const hangingMiddleware = createTestMiddleware({
                     // Never settles.
-                    () => new Promise(() => {}),
-                    mockAuth,
-                    immediateRuntimeContextRequest,
-                    mockLongPolling,
-                    '/project',
-                    mockLog,
-                );
+                    getAllowedConnectionIds: () => new Promise(() => {}),
+                    doAuthenticatedRequest: immediateRuntimeContextRequest,
+                });
 
                 const req = createMockRequest('/__dd/executeAction', {
                     functionName: encodeQueryName(mockFunctions[0]),
@@ -1712,17 +1655,9 @@ describe('Dev Server Middleware', () => {
     describe('dynamic discovery', () => {
         test('Should not find stale function after re-transform (HMR)', async () => {
             let currentFunctions: BackendFunction[] = [...mockFunctions];
-            const middleware = createDevServerMiddleware(
-                mockViteBuild,
-                mockLoadModule,
-                () => currentFunctions,
-                async () => [],
-                mockAuth,
-                testAuthenticatedRequest,
-                mockLongPolling,
-                '/project',
-                mockLog,
-            );
+            const middleware = createTestMiddleware({
+                getBackendFunctions: () => currentFunctions,
+            });
 
             // Simulate HMR: greet is renamed to greetV2 in the same file.
             currentFunctions = [

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -15,6 +15,7 @@ import { encodeQueryName } from '../backend/encodeQueryName';
 import type { ExecuteActionRequest, ExecuteActionResponse } from '../backend/protocol';
 import type { BackendFunction, BackendOutputs } from '../backend/types';
 import { generateDevVirtualEntryContent } from '../backend/virtual-entry';
+import { DEV_VERIFY_MODE } from '../constants';
 import type { LongPollingOptions } from '../types';
 
 import { createBackendConnectionIdCollector } from './backend-connection-id-collector';
@@ -605,11 +606,7 @@ async function handleExecuteAction(
     }
 }
 
-/**
- * Handles POST /__dd/executeActionViaCloud — bundles a backend function and executes it via
- * the production round trip (queue + Deno subprocess), kept as its own endpoint
- * (`npm run dev:verify`) for pre-publish parity checks rather than a mode flag.
- */
+/** Handle POST /__dd/executeActionViaCloud: bundle and execute via the production round trip (queue + Deno subprocess). */
 async function handleExecuteActionViaCloud(
     req: IncomingMessage,
     res: ServerResponse,
@@ -638,8 +635,34 @@ async function handleExecuteActionViaCloud(
 
         sendSuccess(res, result);
     } catch (error: unknown) {
-        handleHttpError(res, error, log, 'executeActionViaCloud');
+        // Labeled by the actual URL hit, not a fixed name, since dev-verify mode also reaches this via /__dd/executeAction.
+        handleHttpError(res, error, log, req.url ?? 'executeActionViaCloud');
     }
+}
+
+/** Shared by both routes that reach the cloud round trip, so a fix to auth-checking or error handling can't drift between them. */
+function routeToCloudHandler(
+    req: IncomingMessage,
+    res: ServerResponse,
+    functionsByName: Map<string, BackendFunction>,
+    bundle: BundleFn,
+    auth: AuthConfig,
+    doAuthenticatedRequest: DoAuthenticatedRequest | undefined,
+    longPolling: LongPollingConfig,
+    log: Logger,
+): void {
+    guardAuthenticated(res, doAuthenticatedRequest, (authedRequest) =>
+        handleExecuteActionViaCloud(
+            req,
+            res,
+            functionsByName,
+            bundle,
+            auth,
+            authedRequest,
+            longPolling,
+            log,
+        ),
+    );
 }
 
 /**
@@ -664,9 +687,11 @@ export function createDevServerMiddleware(
     longPolling: LongPollingConfig,
     projectRoot: string,
     log: Logger,
+    mode: string,
 ): (req: IncomingMessage, res: ServerResponse, next: () => void) => void {
     const bundle = (func: BackendFunction) =>
         bundleBackendFunction(viteBuild, func, projectRoot, log);
+    const isDevVerifyMode = mode === DEV_VERIFY_MODE;
 
     const initialFunctions = getBackendFunctions();
     if (initialFunctions.length > 0) {
@@ -687,6 +712,21 @@ export function createDevServerMiddleware(
             handleDebugBundle(req, res, functionsByName, bundle).catch(() => {
                 sendError(res, 500, 'Unexpected error');
             });
+        } else if (
+            req.url === '/__dd/executeActionViaCloud' ||
+            (req.url === '/__dd/executeAction' && isDevVerifyMode)
+        ) {
+            // The client always POSTs to /__dd/executeAction regardless of mode, so dev-verify is routed here server-side instead.
+            routeToCloudHandler(
+                req,
+                res,
+                functionsByName,
+                bundle,
+                auth,
+                doAuthenticatedRequest,
+                longPolling,
+                log,
+            );
         } else if (req.url === '/__dd/executeAction') {
             guardAuthenticated(res, doAuthenticatedRequest, (authedRequest) =>
                 handleExecuteAction(
@@ -699,19 +739,6 @@ export function createDevServerMiddleware(
                     loadModule,
                     getAllowedConnectionIds,
                     projectRoot,
-                    log,
-                ),
-            );
-        } else if (req.url === '/__dd/executeActionViaCloud') {
-            guardAuthenticated(res, doAuthenticatedRequest, (authedRequest) =>
-                handleExecuteActionViaCloud(
-                    req,
-                    res,
-                    functionsByName,
-                    bundle,
-                    auth,
-                    authedRequest,
-                    longPolling,
                     log,
                 ),
             );

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -6,7 +6,16 @@ import { getVitePlugin } from '@dd/apps-plugin/vite/index';
 import type { ViteBundler } from '@dd/apps-plugin/vite/index';
 import { localExecutionResolutionContext } from '@dd/apps-plugin/vite/local-execution';
 import { InjectPosition } from '@dd/core/types';
-import { getContextMock, getRepositoryDataMock, mockLogFn } from '@dd/tests/_jest/helpers/mocks';
+import { cleanEnv } from '@dd/tests/_jest/helpers/env';
+import {
+    createMockRequest,
+    createMockResponse,
+    getContextMock,
+    getRepositoryDataMock,
+    mockLogFn,
+} from '@dd/tests/_jest/helpers/mocks';
+import type { IncomingMessage, ServerResponse } from 'http';
+import nock from 'nock';
 import { parseAst } from 'rollup/parseAst';
 import type { PluginContext } from 'rollup';
 import type { ViteDevServer } from 'vite';
@@ -14,7 +23,7 @@ import type { ViteDevServer } from 'vite';
 import * as auth from '../auth';
 import { encodeQueryName } from '../backend/encodeQueryName';
 import type { BackendFunction } from '../backend/types';
-import { LOCAL_EXECUTION_LOAD_SUFFIX } from '../constants';
+import { DEV_VERIFY_MODE, LOCAL_EXECUTION_LOAD_SUFFIX } from '../constants';
 
 import * as buildPackage from './build-package';
 
@@ -56,6 +65,34 @@ function extractTransformedCode(result: unknown): string | undefined {
         typeof result.code === 'string'
         ? result.code
         : undefined;
+}
+
+type DevServerMiddleware = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
+
+// The subset of Vite's real `ViteDevServer` this test's fake server object provides.
+type FakeViteDevServer = {
+    middlewares: { use: (fn: DevServerMiddleware) => void };
+    ssrLoadModule: (id: string) => Promise<unknown>;
+    config: { mode: string };
+};
+
+// Narrows `plugin.configureServer` to its plain-function hook form via a runtime check, then wraps
+// it in a signature scoped to the fake server this test passes, since the real hook's `ViteDevServer`
+// parameter is far wider than what these tests construct — mirrors `getTransformHandler` above.
+function getConfigureServer(
+    plugin: ReturnType<typeof getVitePlugin>,
+): (server: FakeViteDevServer) => void {
+    const { configureServer } = plugin ?? {};
+    if (typeof configureServer !== 'function') {
+        throw new Error('Expected plugin.configureServer to be the plain function-hook form');
+    }
+    return function callConfigureServer(server: FakeViteDevServer): void {
+        Reflect.apply(configureServer, undefined, [server]);
+    };
+}
+
+function isDevServerMiddleware(value: unknown): value is DevServerMiddleware {
+    return typeof value === 'function';
 }
 
 const functions: BackendFunction[] = [
@@ -141,6 +178,8 @@ function mockBuildWithParsedBackend() {
     });
 }
 
+const DD_API_ORIGIN = 'https://api.datadoghq.com';
+
 const defaultOptions = {
     bundler: mockVite,
     context: getContextMock({
@@ -172,6 +211,10 @@ describe('Backend Functions - getVitePlugin', () => {
         jest.clearAllMocks();
         mockBuildWithParsedBackend();
         jest.spyOn(buildPackage, 'buildAppPackage').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
     });
 
     test('Should return a vite plugin object with closeBundle', () => {
@@ -228,6 +271,7 @@ describe('Backend Functions - getVitePlugin', () => {
         const server = {
             middlewares: { use: jest.fn() },
             ssrLoadModule: jest.fn(),
+            config: { mode: 'development' },
         } as unknown as ViteDevServer;
         // The hooks are typed with Rollup's `this: PluginContext`, but the
         // plugin closures never read `this`, so a stand-in satisfies the call.
@@ -256,6 +300,7 @@ describe('Backend Functions - getVitePlugin', () => {
         const server = {
             middlewares: { use: jest.fn() },
             ssrLoadModule: jest.fn(),
+            config: { mode: 'development' },
         } as unknown as ViteDevServer;
 
         plugin.configureServer(server);
@@ -283,6 +328,7 @@ describe('Backend Functions - getVitePlugin', () => {
         const server = {
             middlewares: { use: jest.fn() },
             ssrLoadModule: jest.fn(),
+            config: { mode: 'development' },
         } as unknown as ViteDevServer;
 
         plugin.configureServer(server);
@@ -638,5 +684,88 @@ describe('Backend Functions - getVitePlugin', () => {
                 noExternal: ['@datadog/apps-backend', '@datadog/action-catalog'],
             },
         });
+    });
+
+    // Uses the real configureServer hook, not createDevServerMiddleware directly, to catch mode-forwarding regressions.
+    test('Should route /__dd/executeAction to the cloud path when configureServer sees a dev-verify server.config.mode', async () => {
+        const plugin = getVitePlugin(defaultOptions);
+        const transformHandler = getTransformHandler(plugin);
+
+        await transformHandler.call(
+            {
+                parse: parseAst,
+                resolve: jest.fn(async () => null),
+                load: jest.fn(async () => null),
+                addWatchFile: jest.fn(),
+            },
+            `
+                export function myHandler() {}
+                export function otherFunc() {}
+            `,
+            '/build/src/backend/myHandler.backend.ts',
+        );
+
+        // Unlike closeBundle's default mock (chunk metadata only), the cloud path bundles first and logs code.length, so this needs a real chunk `code`.
+        mockViteBuild.mockImplementation(async (config) => {
+            emitModuleParsed(
+                config,
+                '/build/src/backend/myHandler.backend.ts',
+                'export function myHandler() {} export function otherFunc() {}',
+            );
+            return {
+                output: [{ type: 'chunk', isEntry: true, name: bundleName1, code: '// bundled' }],
+            };
+        });
+
+        const use = jest.fn();
+        const ssrLoadModule = jest.fn();
+        const configureServer = getConfigureServer(plugin);
+        // configureServer resolves auth from the environment; restored immediately after use.
+        const restoreEnv = cleanEnv();
+        process.env.DD_API_KEY = 'test-api-key';
+        process.env.DD_APP_KEY = 'test-app-key';
+        configureServer({
+            middlewares: { use },
+            ssrLoadModule,
+            config: { mode: DEV_VERIFY_MODE },
+        });
+        restoreEnv();
+
+        expect(use).toHaveBeenCalledTimes(1);
+        const [registeredMiddleware] = use.mock.calls[0];
+        if (!isDevServerMiddleware(registeredMiddleware)) {
+            throw new Error(
+                'Expected middlewares.use to have been called with a middleware function',
+            );
+        }
+        const middleware = registeredMiddleware;
+
+        const apiScope = nock(DD_API_ORIGIN)
+            .post('/api/v2/app-builder/queries/preview-async')
+            .reply(200, { data: { id: 'receipt-dev-verify' } })
+            .get('/api/v2/app-builder/queries/execution-long-polling/receipt-dev-verify')
+            .reply(200, {
+                data: {
+                    attributes: {
+                        done: true,
+                        outputs: { data: { result: 'via cloud' } },
+                    },
+                },
+            });
+
+        const req = createMockRequest('/__dd/executeAction', {
+            functionName: bundleName1,
+            args: ['world'],
+        });
+        const res = createMockResponse();
+
+        middleware(req, res, jest.fn());
+        await res.done;
+
+        expect(res.statusCode).toBe(200);
+        const body = JSON.parse(res.getBody());
+        expect(body.result).toEqual({ data: { result: 'via cloud' } });
+        expect(apiScope.isDone()).toBe(true);
+        expect(ssrLoadModule).not.toHaveBeenCalled();
     });
 });

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -325,6 +325,7 @@ export const getVitePlugin = ({
                 options.longPolling,
                 context.buildRoot,
                 log,
+                server.config.mode,
             );
             server.middlewares.use(middleware);
         },


### PR DESCRIPTION
## Motivation

- Part of [APPS-2792](https://datadoghq.atlassian.net/browse/APPS-2792) — local Node execution for App Builder backend functions, the `npm run dev:verify` CLI milestone described in the [Kickoff doc](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455).
- Gap this PR closes:
  - `npm run dev:verify` doesn't exist yet — pre-publish parity checking against the real cloud round trip currently requires manually curling `/__dd/executeActionViaCloud`.
  - This PR makes the dev server mode-aware so `dev:verify` (added to the scaffold template in a separate web-ui PR) can route through the same `/__dd/executeAction` URL the frontend already calls, without the frontend needing to know which mode it's in.
- Rejected alternative: making the client-side transport (`dev-server-transport.ts`) mode-aware via `import.meta.env.MODE`.
  - Rejected because this repo's Jest setup (`ts-jest`) has no CommonJS equivalent for `import.meta` — introducing it breaks the transform for any file that imports it.
  - Routing server-side, keyed off Vite's own resolved `--mode`, avoids this and keeps the client transport unchanged.

## Architecture

```
npm run dev              (--mode development, default)     npm run dev:verify        (--mode dev-verify)
         │                                                            │
         └──────────────────────┬─────────────────────────────────────┘
                                 ▼
                  Browser: executeBackendFunction()
                  → devServerTransport → POST /__dd/executeAction
                  (unchanged either way — the client never knows the mode)
                                 │
                                 ▼
                  createDevServerMiddleware's /__dd/executeAction branch
                  checks `mode` (threaded from `server.config.mode`,
                  Vite's own resolved --mode, read in configureServer)
                                 │
                  ┌──────────────┴───────────────┐
                  ▼ mode !== 'dev-verify'          ▼ mode === 'dev-verify'
          handleExecuteAction                handleExecuteActionViaCloud
          (local, in-process, no bundling)    (bundle + real preview-async
                                                round trip — unchanged)
```

- `/__dd/executeActionViaCloud` remains directly reachable — this only adds a second way to reach the same cloud behavior, gated by mode, at the URL the client already calls by default.

## Changes

<details>
<summary>9 changes across 6 files</summary>

| What changed | File |
|---|---|
| New `DEV_VERIFY_MODE` constant (`'dev-verify'`), the Vite `--mode` value `dev:verify` will use. | [constants.ts](packages/plugins/apps/src/constants.ts) |
| `createDevServerMiddleware` takes a new required `mode: string` parameter (no default — `index.ts` always passes `server.config.mode`), computing `isDevVerifyMode` once above the returned request handler instead of re-comparing `mode` on every request. | [dev-server.ts](packages/plugins/apps/src/vite/dev-server.ts) |
| Extracted `routeToCloudHandler` so both cloud-bound routes share one auth/error path. | [dev-server.ts](packages/plugins/apps/src/vite/dev-server.ts) |
| When `req.url === '/__dd/executeAction'` and `mode === DEV_VERIFY_MODE`, delegates to the same cloud-execution logic `/__dd/executeActionViaCloud` uses (including the existing "auth not configured" 400 guard) instead of running locally. | [dev-server.ts](packages/plugins/apps/src/vite/dev-server.ts) |
| `configureServer(server)` passes `server.config.mode` (Vite's own resolved mode, read via the plugin API — no `import.meta.env` involved) through to `createDevServerMiddleware`. | [vite/index.ts](packages/plugins/apps/src/vite/index.ts) |
| New test: `mode: DEV_VERIFY_MODE` routes `/__dd/executeAction` through the real `preview-async` round trip (via `nock`) and never calls `loadModule`. | [dev-server.test.ts](packages/plugins/apps/src/vite/dev-server.test.ts) |
| New `configureServer`-level test: confirms the cloud path is taken through the real plugin wiring, not just the middleware in isolation, when `config.mode` is `DEV_VERIFY_MODE`. | [index.test.ts](packages/plugins/apps/src/vite/index.test.ts) |
| Collapsed 17 near-identical `createDevServerMiddleware(...)` call sites into one `createTestMiddleware()` factory taking only the overrides each test actually varies. | [dev-server.test.ts](packages/plugins/apps/src/vite/dev-server.test.ts) |
| The 6 real-end-to-end `createDevServerMiddleware` call sites now pass an explicit `'development'` mode, since it's the one test file that exercises the plugin through real Vite build config rather than the `createTestMiddleware` factory above. | [dev-server.integration.test.ts](packages/plugins/apps/src/vite/dev-server.integration.test.ts) |

</details>

## QA Instructions

```bash
yarn install
```

```bash
yarn test:unit packages/plugins/apps/src/vite/dev-server.test.ts
# Expected: Test Suites: 1 passed / Tests: 48 passed ✅ VERIFIED
```

```bash
yarn test:unit
# Expected: Test Suites: 88 passed / Tests: 2163 passed, 2 skipped ✅ VERIFIED
```

```bash
yarn workspace @dd/apps-plugin run typecheck
# Expected: no output, clean exit ✅ VERIFIED
```

```bash
npx eslint 'packages/plugins/apps/**/*.ts' --quiet
# Expected: no output, clean exit ✅ VERIFIED
```

Manual QA against a real scaffolded app (invoking `vite dev --mode dev-verify` directly, ahead of the web-ui half's `dev:verify` script landing), per the [Testing and QA Guide](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7100498075):
```bash
npx vite dev --mode dev-verify --port 5185 --strictPort
# VITE v7.3.6  dev-verify  ready in 185 ms ✅ VERIFIED (mode banner confirms it's active)
curl -X POST http://localhost:5185/__dd/executeAction -d '{"functionName":"...example","args":[99]}'
# {"success":true,"result":{"data":{"doubled":198,"tripled":297}}} ✅ VERIFIED
```
Confirmed it's genuinely routing to the cloud, not local in-process execution:
- The customer function's own `console.log` did **not** print in the local terminal (unlike the same call under default `npm run dev`, where it does).
- The server log shows the real round trip:
  - `Bundling backend function...`
  - `Executing action via cloud...`
  - `Calling Datadog API: https://api.datad0g.com/api/v2/app-builder/queries/preview-async`
  - `Query execution started with receipt: ...`
  - `Long-poll attempt 1/10...`
  - `Long-poll response, done: true`

## Blast Radius

- No behavior change for `npm run dev` (default mode) — `mode` is required with no code-level default, but `index.ts` always passes `server.config.mode`, Vite's own resolved mode, which itself defaults to `'development'` when Vite doesn't otherwise set it. Either way it never equals `DEV_VERIFY_MODE`, so the existing local-execution branch is unchanged.
- `/__dd/executeActionViaCloud` is untouched.
- Risk: low.
  - Purely additive branch in the middleware.
  - No new dependency, no client-side change.
  - No new config surface exposed to customers — the mode comes from Vite's own `--mode` flag, which the web-ui template's `dev:verify` script will set.

## Out of Scope / Follow-ups

<details>
<summary>3 items deferred</summary>

| Item | Status | Next step |
|---|---|---|
| web-ui: add the `dev:verify` script (`vite dev --mode dev-verify`) and a minimal example backend function to the create-apps template | In progress | [ddoghq/web-ui#4501](https://github.com/ddoghq/web-ui/pull/4501) |
| Update onboarding docs to reference the real `dev:verify` command | Not started | After both halves land |
| Nudge/enforce `dev:verify` in the publish flow before `datadog-apps publish` | Not started | Separate follow-up, likely in the `datadog-apps` CLI |

</details>

## Documentation

- RFC: [Confluence page 7012712651](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651)
- Kickoff doc: [Confluence page 7025394455](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455) — npm run dev:verify CLI
- QA guide: [Confluence page 7100498075](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7100498075) — exact local/staging QA commands for this repo


[APPS-2792]: https://datadoghq.atlassian.net/browse/APPS-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




