### PR TITLE
Remove OAuth from the dev server and use DD_OAUTH_ACCESS_TOKEN passed by the apps CLI

### DIFF
--- a/packages/core/src/helpers/env.ts
+++ b/packages/core/src/helpers/env.ts
@@ -22,8 +22,8 @@ const yellow = chalk.bold.yellow;
 //   - DATADOG_APPS_IDENTIFIER
 //   - DD_APPS_NAME
 //   - DATADOG_APPS_NAME
-//   - DD_APPS_AUTH_METHOD
-//   - DATADOG_APPS_AUTH_METHOD
+//   - DD_OAUTH_ACCESS_TOKEN
+//   - DATADOG_OAUTH_ACCESS_TOKEN
 //   - DD_SITE
 //   - DATADOG_SITE
 export const OVERRIDE_VARIABLES = [
@@ -33,7 +33,7 @@ export const OVERRIDE_VARIABLES = [
     'APPS_PACKAGE_DIR',
     'APPS_IDENTIFIER',
     'APPS_NAME',
-    'APPS_AUTH_METHOD',
+    'OAUTH_ACCESS_TOKEN',
     'SITE',
 ] as const;
 type ENV_KEY = (typeof OVERRIDE_VARIABLES)[number];

--- a/packages/plugins/apps/README.md
+++ b/packages/plugins/apps/README.md
@@ -9,6 +9,7 @@ A Vite plugin that builds a deployable Datadog Apps package. Publishing is owned
 
 <!-- #toc -->
 -   [Configuration](#configuration)
+-   [Development server authentication](#development-server-authentication)
 -   [Package output](#package-output)
     -   [apps.enable](#appsenable)
     -   [apps.include](#appsinclude)
@@ -33,11 +34,20 @@ apps?: {
         protectionLevel?: 'direct_publish' | 'approval_required';
         runAs?: string;
     };
-    authOverrides?: {
-        method?: 'apiKey' | 'oauth';
-    };
 }
 ```
+
+## Development server authentication
+
+Backend function execution authenticates in this order:
+
+1. `DD_API_KEY`/`DATADOG_API_KEY` + `DD_APP_KEY`/`DATADOG_APP_KEY` (API-key auth)
+2. `DD_OAUTH_ACCESS_TOKEN` (or `DATADOG_OAUTH_ACCESS_TOKEN`)
+
+`datadog-apps dev` resolves and refreshes an OAuth token for your org, then
+passes it to the dev server via `DD_OAUTH_ACCESS_TOKEN`. When no credentials are
+configured, backend function execution is unavailable and the dev server tells
+you to start it with `datadog-apps dev`.
 
 ## Package output
 
@@ -45,7 +55,7 @@ A production `vite build` writes `datadog-apps-assets.zip` and `datadog-apps-bui
 
 Set `DATADOG_APPS_PACKAGE_DIR` (or `DD_APPS_PACKAGE_DIR`) to write both files to a different directory. `DATADOG_APPS_IDENTIFIER`/`DD_APPS_IDENTIFIER` and `DATADOG_APPS_NAME`/`DD_APPS_NAME` override the resolved identity for a CLI child build.
 
-Use `datadog-apps build` to package locally, `datadog-apps upload` to create a draft, and `datadog-apps deploy` to upload and publish. Production packaging makes no Datadog API requests. Development-server backend functions retain their existing authentication behavior.
+Use `datadog-apps build` to package locally, `datadog-apps upload` to create a draft, and `datadog-apps deploy` to upload and publish. Production packaging makes no Datadog API requests. Development-server authentication is described above.
 
 ### apps.enable
 

--- a/packages/plugins/apps/src/auth.test.ts
+++ b/packages/plugins/apps/src/auth.test.ts
@@ -3,60 +3,35 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { getAuthenticatedRequest, MissingAuthenticationError } from '@dd/apps-plugin/auth';
-import { doOAuthRequest } from '@dd/core/helpers/oauth-request';
 import { doRequest } from '@dd/core/helpers/request';
-import { getMockLogger } from '@dd/tests/_jest/helpers/mocks';
-
-jest.mock('@dd/core/helpers/oauth-request', () => ({
-    doOAuthRequest: jest.fn(),
-}));
+import { cleanEnv } from '@dd/tests/_jest/helpers/env';
 
 jest.mock('@dd/core/helpers/request', () => ({
     doRequest: jest.fn(),
 }));
 
-const doOAuthRequestMock = jest.mocked(doOAuthRequest);
 const doRequestMock = jest.mocked(doRequest);
 
 describe('Apps Plugin - auth', () => {
+    let restoreEnv: () => void;
+
+    beforeEach(() => {
+        restoreEnv = cleanEnv();
+    });
+
     afterEach(() => {
+        restoreEnv();
         jest.clearAllMocks();
     });
 
-    test('Should build an OAuth request function', async () => {
-        doOAuthRequestMock.mockResolvedValue('ok');
-        const log = getMockLogger();
-        const doAuthenticatedRequest = getAuthenticatedRequest(
-            'oauth',
-            { site: 'datadoghq.com' },
-            log,
-        );
-
-        await expect(
-            doAuthenticatedRequest({ url: 'https://api.datadoghq.com/test' }),
-        ).resolves.toBe('ok');
-        expect(doOAuthRequestMock).toHaveBeenCalledWith({
-            url: 'https://api.datadoghq.com/test',
-            auth: { site: 'datadoghq.com' },
-            log,
-        });
-    });
-
-    test('Should build an API-key request function when both keys are available', async () => {
+    test('Should prefer API-key auth when both keys are set', async () => {
+        process.env.DD_API_KEY = 'api-key';
+        process.env.DD_APP_KEY = 'app-key';
+        process.env.DD_OAUTH_ACCESS_TOKEN = 'oauth-token';
         doRequestMock.mockResolvedValue('ok');
-        const log = getMockLogger();
-        const doAuthenticatedRequest = getAuthenticatedRequest(
-            'apiKey',
-            {
-                apiKey: 'api-key',
-                appKey: 'app-key',
-                site: 'datadoghq.com',
-            },
-            log,
-        );
 
         await expect(
-            doAuthenticatedRequest({ url: 'https://api.datadoghq.com/test' }),
+            getAuthenticatedRequest()({ url: 'https://api.datadoghq.com/test' }),
         ).resolves.toBe('ok');
         expect(doRequestMock).toHaveBeenCalledWith({
             url: 'https://api.datadoghq.com/test',
@@ -67,13 +42,38 @@ describe('Apps Plugin - auth', () => {
         });
     });
 
-    test('Should throw when API-key credentials are incomplete', () => {
-        expect(() =>
-            getAuthenticatedRequest(
-                'apiKey',
-                { apiKey: 'api-key', site: 'datadoghq.com' },
-                getMockLogger(),
-            ),
-        ).toThrow(MissingAuthenticationError);
+    test('Should fall back to the OAuth access token when API keys are absent', async () => {
+        process.env.DD_OAUTH_ACCESS_TOKEN = 'oauth-token';
+        doRequestMock.mockResolvedValue('ok');
+
+        await expect(
+            getAuthenticatedRequest()({ url: 'https://api.datadoghq.com/test' }),
+        ).resolves.toBe('ok');
+        expect(doRequestMock).toHaveBeenCalledWith({
+            url: 'https://api.datadoghq.com/test',
+            auth: {
+                accessToken: 'oauth-token',
+            },
+        });
+    });
+
+    test('Should not use API-key auth when only one key is set', async () => {
+        process.env.DD_API_KEY = 'api-key';
+        process.env.DD_OAUTH_ACCESS_TOKEN = 'oauth-token';
+        doRequestMock.mockResolvedValue('ok');
+
+        await expect(
+            getAuthenticatedRequest()({ url: 'https://api.datadoghq.com/test' }),
+        ).resolves.toBe('ok');
+        expect(doRequestMock).toHaveBeenCalledWith({
+            url: 'https://api.datadoghq.com/test',
+            auth: {
+                accessToken: 'oauth-token',
+            },
+        });
+    });
+
+    test('Should throw when no credentials are configured', () => {
+        expect(() => getAuthenticatedRequest()).toThrow(MissingAuthenticationError);
     });
 });

--- a/packages/plugins/apps/src/auth.ts
+++ b/packages/plugins/apps/src/auth.ts
@@ -2,15 +2,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import { doOAuthRequest } from '@dd/core/helpers/oauth-request';
+import { getDDEnvValue } from '@dd/core/helpers/env';
 import { doRequest } from '@dd/core/helpers/request';
-import type { AuthOptionsWithDefaults, Logger, RequestOpts } from '@dd/core/types';
-
-import type { AuthMethod } from './types';
+import type { RequestOpts } from '@dd/core/types';
 
 export const AUTH_GUIDANCE =
-    'Set apps.authOverrides.method: "oauth" or DD_APPS_AUTH_METHOD=oauth to use OAuth, ' +
-    'or set DD_API_KEY and DD_APP_KEY to use API/App key auth.';
+    'Set DD_API_KEY and DD_APP_KEY for API-key auth, or set DD_OAUTH_ACCESS_TOKEN ' +
+    '(or DATADOG_OAUTH_ACCESS_TOKEN) — e.g. by starting the dev server with `datadog-apps dev`.';
 
 export type DoAuthenticatedRequest = <T>(opts: Omit<RequestOpts, 'auth'>) => Promise<T>;
 
@@ -23,23 +21,30 @@ export class MissingAuthenticationError extends Error {
     }
 }
 
-// Build the authenticated request function from the resolved method + base credentials.
-export const getAuthenticatedRequest = (
-    method: AuthMethod,
-    auth: AuthOptionsWithDefaults,
-    log: Logger,
-): DoAuthenticatedRequest => {
-    if (method === 'oauth') {
-        return (opts) => doOAuthRequest({ ...opts, auth, log });
-    }
-
-    if (auth.apiKey && auth.appKey) {
+// Build the dev-server request authenticator. API-key auth (DD_API_KEY +
+// DD_APP_KEY) takes precedence; otherwise the OAuth access token that
+// @datadog/apps-cli passes via DD_OAUTH_ACCESS_TOKEN is used.
+export const getAuthenticatedRequest = (): DoAuthenticatedRequest => {
+    const apiKey = getDDEnvValue('API_KEY');
+    const appKey = getDDEnvValue('APP_KEY');
+    if (apiKey && appKey) {
         return (opts) =>
             doRequest({
                 ...opts,
                 auth: {
-                    apiKey: auth.apiKey,
-                    appKey: auth.appKey,
+                    apiKey,
+                    appKey,
+                },
+            });
+    }
+
+    const accessToken = getDDEnvValue('OAUTH_ACCESS_TOKEN');
+    if (accessToken) {
+        return (opts) =>
+            doRequest({
+                ...opts,
+                auth: {
+                    accessToken,
                 },
             });
     }

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -65,7 +65,6 @@ describe('Apps Plugin - package output', () => {
             }),
             options: {
                 include: [],
-                authOverrides: { method: 'oauth' as const },
                 ...overrides.options,
             },
         };

--- a/packages/plugins/apps/src/types.ts
+++ b/packages/plugins/apps/src/types.ts
@@ -2,9 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import type { Assign, WithRequired } from '@dd/core/types';
-
-export type AuthMethod = 'apiKey' | 'oauth';
+import type { WithRequired } from '@dd/core/types';
 
 export type AppsProtectionLevel = 'direct_publish' | 'approval_required';
 
@@ -32,11 +30,6 @@ export type AppsOptions = {
          */
         runAs?: string;
     };
-    // Per-app auth overrides. `method` is scoped here rather than on the shared
-    // `auth` config because not every product endpoint supports OAuth.
-    authOverrides?: {
-        method?: AuthMethod;
-    };
 };
 
 export type AppsManifest = {
@@ -61,14 +54,4 @@ export type AppsManifest = {
 };
 
 // We don't enforce identifier, as it needs to be dynamically computed if absent.
-export type AppsOptionsWithDefaults = Omit<
-    Assign<
-        WithRequired<AppsOptions, 'include'>,
-        {
-            authOverrides: {
-                method: AuthMethod;
-            };
-        }
-    >,
-    'enable'
->;
+export type AppsOptionsWithDefaults = WithRequired<AppsOptions, 'include'>;

--- a/packages/plugins/apps/src/validate.test.ts
+++ b/packages/plugins/apps/src/validate.test.ts
@@ -17,67 +17,12 @@ describe('Apps Plugin - validateOptions', () => {
         restoreEnv();
     });
 
-    test('uses package-only defaults and OAuth when credentials are absent', () => {
+    test('uses package-only defaults when credentials are absent', () => {
         expect(validateOptions({ apps: {} })).toEqual({
             include: [],
             identifier: undefined,
             name: undefined,
-            authOverrides: { method: 'oauth' },
         });
-    });
-
-    test('uses API-key auth when both keys are configured via auth option', () => {
-        const result = validateOptions({
-            auth: { apiKey: 'api-key', appKey: 'app-key' },
-        });
-        expect(result.authOverrides.method).toBe('apiKey');
-    });
-
-    test('uses API-key auth only when both keys are available', () => {
-        process.env.DATADOG_API_KEY = 'api-key';
-        process.env.DATADOG_APP_KEY = 'app-key';
-
-        expect(validateOptions({ apps: {} }).authOverrides.method).toBe('apiKey');
-    });
-
-    test('defaults to OAuth when API-key auth is incomplete', () => {
-        const result = validateOptions({
-            auth: { apiKey: 'api-key' },
-        });
-        expect(result.authOverrides.method).toBe('oauth');
-    });
-
-    test('respects explicit OAuth method over available API/App keys', () => {
-        const result = validateOptions({
-            auth: { apiKey: 'api-key', appKey: 'app-key' },
-            apps: { authOverrides: { method: 'oauth' } },
-        });
-        expect(result.authOverrides.method).toBe('oauth');
-    });
-
-    test('respects explicit apiKey method when no keys are configured', () => {
-        const result = validateOptions({
-            apps: { authOverrides: { method: 'apiKey' } },
-        });
-        expect(result.authOverrides.method).toBe('apiKey');
-    });
-
-    test('allows env var to override auth method to OAuth', () => {
-        process.env.DATADOG_APPS_AUTH_METHOD = 'oauth';
-
-        expect(validateOptions({ apps: {} }).authOverrides.method).toBe('oauth');
-    });
-
-    test('allows env var to override auth method to apiKey', () => {
-        process.env.DATADOG_APPS_AUTH_METHOD = 'apiKey';
-
-        expect(validateOptions({ apps: {} }).authOverrides.method).toBe('apiKey');
-    });
-
-    test('throws on invalid auth method', () => {
-        expect(() =>
-            validateOptions({ apps: { authOverrides: { method: 'invalid' as never } } }),
-        ).toThrow('apps.authOverrides.method must be one of: apiKey, oauth');
     });
 
     test('uses environment identity overrides before plugin configuration', () => {

--- a/packages/plugins/apps/src/validate.ts
+++ b/packages/plugins/apps/src/validate.ts
@@ -6,34 +6,10 @@ import { getDDEnvValue } from '@dd/core/helpers/env';
 import type { Options } from '@dd/core/types';
 
 import { CONFIG_KEY } from './constants';
-import type { AppsOptions, AppsOptionsWithDefaults, AuthMethod } from './types';
-
-const AUTH_METHODS: AuthMethod[] = ['apiKey', 'oauth'];
-
-const resolveAuthMethod = (value: string | undefined): AuthMethod | undefined => {
-    if (value === undefined) {
-        return undefined;
-    }
-
-    if (AUTH_METHODS.includes(value as AuthMethod)) {
-        return value as AuthMethod;
-    }
-
-    throw new Error(`apps.authOverrides.method must be one of: ${AUTH_METHODS.join(', ')}`);
-};
-
-const hasApiKeyAuth = (options: Options): boolean =>
-    Boolean(
-        (getDDEnvValue('API_KEY') || options.auth?.apiKey) &&
-            (getDDEnvValue('APP_KEY') || options.auth?.appKey),
-    );
+import type { AppsOptions, AppsOptionsWithDefaults } from './types';
 
 export const validateOptions = (options: Options): AppsOptionsWithDefaults => {
     const resolvedOptions = (options[CONFIG_KEY] || {}) as AppsOptions;
-    const method =
-        resolveAuthMethod(
-            getDDEnvValue('APPS_AUTH_METHOD') || resolvedOptions.authOverrides?.method,
-        ) || (hasApiKeyAuth(options) ? 'apiKey' : 'oauth');
 
     // Only spread optional app-property fields when explicitly configured — omitting
     // them entirely (rather than setting them to undefined) keeps the returned object
@@ -49,8 +25,5 @@ export const validateOptions = (options: Options): AppsOptionsWithDefaults => {
         ...(resolvedOptions.description != null && { description: resolvedOptions.description }),
         ...(resolvedOptions.selfService != null && { selfService: resolvedOptions.selfService }),
         ...(resolvedOptions.permissions != null && { permissions: resolvedOptions.permissions }),
-        authOverrides: {
-            method,
-        },
     };
 };

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -5,6 +5,7 @@
 import { getAuthenticatedRequest } from '@dd/apps-plugin/auth';
 import { createDevServerMiddleware } from '@dd/apps-plugin/vite/dev-server';
 import type { AuthOptionsWithDefaults } from '@dd/core/types';
+import { cleanEnv } from '@dd/tests/_jest/helpers/env';
 import { getMockLogger } from '@dd/tests/_jest/helpers/mocks';
 import { EventEmitter } from 'events';
 import type { IncomingMessage, ServerResponse } from 'http';
@@ -13,18 +14,6 @@ import { parseAst } from 'rollup/parseAst';
 
 import { encodeQueryName } from '../backend/encodeQueryName';
 import type { BackendFunction } from '../backend/types';
-
-jest.mock('@dd/core/helpers/oauth-request', () => ({
-    doOAuthRequest: jest.fn(async (opts) => {
-        const { doRequest } = await import('@dd/core/helpers/request');
-        return doRequest({
-            ...opts,
-            auth: {
-                accessToken: 'test-oauth-token',
-            },
-        });
-    }),
-}));
 
 const mockViteBuild = jest.fn();
 
@@ -46,19 +35,24 @@ const mockFunctions: BackendFunction[] = [
 ];
 
 const mockAuth: AuthOptionsWithDefaults = {
-    apiKey: 'test-api-key',
-    appKey: 'test-app-key',
-    site: 'datadoghq.com',
-};
-
-const mockOauthOnlyAuth: AuthOptionsWithDefaults = {
     site: 'datadoghq.com',
 };
 
 const mockLog = getMockLogger();
+// getAuthenticatedRequest reads the OAuth token from the environment. Jest's
+// setupAfterEnv cleanEnv strips env vars after collection, so the authenticated
+// request is captured once at collection time — describe bodies and test
+// bodies both reuse it. The bearer test pins the token itself to exercise a
+// live construction. Developer-provided API keys are stripped so the bearer
+// path is deterministic.
+const TEST_OAUTH_TOKEN = 'test-oauth-token';
+const restoreModuleEnv = cleanEnv();
+process.env.DD_OAUTH_ACCESS_TOKEN = TEST_OAUTH_TOKEN;
+const testAuthenticatedRequest = getAuthenticatedRequest();
 
-const getApiKeyRequest = () => getAuthenticatedRequest('apiKey', mockAuth, mockLog);
-const getOAuthRequest = () => getAuthenticatedRequest('oauth', mockOauthOnlyAuth, mockLog);
+afterAll(() => {
+    restoreModuleEnv();
+});
 
 /**
  * Create a mock IncomingMessage with a JSON body.
@@ -162,7 +156,7 @@ describe('Dev Server Middleware', () => {
             mockViteBuild,
             () => mockFunctions,
             mockAuth,
-            getApiKeyRequest(),
+            testAuthenticatedRequest,
             '/project',
             mockLog,
         );
@@ -250,7 +244,7 @@ describe('Dev Server Middleware', () => {
             mockViteBuild,
             () => mockFunctions,
             mockAuth,
-            getApiKeyRequest(),
+            testAuthenticatedRequest,
             '/project',
             mockLog,
         );
@@ -326,7 +320,7 @@ describe('Dev Server Middleware', () => {
             mockViteBuild,
             () => mockFunctions,
             mockAuth,
-            getApiKeyRequest(),
+            testAuthenticatedRequest,
             '/project',
             mockLog,
         );
@@ -407,8 +401,7 @@ describe('Dev Server Middleware', () => {
             let capturedBody: PreviewAsyncBody | undefined;
             const apiScope = nock(DD_API_ORIGIN, {
                 reqheaders: {
-                    'DD-API-KEY': 'test-api-key',
-                    'DD-APPLICATION-KEY': 'test-app-key',
+                    Authorization: 'Bearer test-oauth-token',
                 },
             })
                 .post('/api/v2/app-builder/queries/preview-async', (body) => {
@@ -444,14 +437,17 @@ describe('Dev Server Middleware', () => {
             expect(capturedBody?.data.attributes.template_params).toEqual({});
         });
 
-        test('Should call Datadog API with OAuth when configured without API/App keys', async () => {
+        test('Should call Datadog API with bearer auth and no API/App key headers', async () => {
             mockBuildWithParsedBackend();
+            // setupAfterEnv's cleanEnv strips env vars after collection, so the
+            // token must be set in the test body for this live construction.
+            process.env.DD_OAUTH_ACCESS_TOKEN = TEST_OAUTH_TOKEN;
 
-            const oauthMiddleware = createDevServerMiddleware(
+            const bearerMiddleware = createDevServerMiddleware(
                 mockViteBuild,
                 () => mockFunctions,
-                mockOauthOnlyAuth,
-                getOAuthRequest(),
+                mockAuth,
+                getAuthenticatedRequest(),
                 '/project',
                 mockLog,
             );
@@ -475,7 +471,7 @@ describe('Dev Server Middleware', () => {
             });
             const res = createMockResponse();
 
-            oauthMiddleware(req, res, jest.fn());
+            bearerMiddleware(req, res, jest.fn());
             await res.done;
 
             expect(res.statusCode).toBe(200);
@@ -485,11 +481,11 @@ describe('Dev Server Middleware', () => {
             expect(apiScope.isDone()).toBe(true);
         });
 
-        test('Should return 400 with auth guidance when explicit API-key auth is missing keys', async () => {
+        test('Should return 400 with auth guidance when the access token is missing', async () => {
             const noKeyMiddleware = createDevServerMiddleware(
                 mockViteBuild,
                 () => mockFunctions,
-                mockOauthOnlyAuth,
+                mockAuth,
                 undefined,
                 '/project',
                 mockLog,
@@ -506,9 +502,8 @@ describe('Dev Server Middleware', () => {
 
             expect(res.statusCode).toBe(400);
             const body = JSON.parse(res.getBody());
-            expect(body.error).toContain('DD_APPS_AUTH_METHOD=oauth');
-            expect(body.error).toContain('DD_API_KEY');
-            expect(body.error).toContain('DD_APP_KEY');
+            expect(body.error).toContain('DD_OAUTH_ACCESS_TOKEN');
+            expect(body.error).toContain('datadog-apps dev');
             expect(mockViteBuild).not.toHaveBeenCalled();
         });
 
@@ -577,7 +572,7 @@ describe('Dev Server Middleware', () => {
                 mockViteBuild,
                 () => functionsWithAllowlist,
                 mockAuth,
-                getApiKeyRequest(),
+                testAuthenticatedRequest,
                 '/project',
                 mockLog,
             );
@@ -739,7 +734,7 @@ describe('Dev Server Middleware', () => {
                 mockViteBuild,
                 () => currentFunctions,
                 mockAuth,
-                getApiKeyRequest(),
+                testAuthenticatedRequest,
                 '/project',
                 mockLog,
             );

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -378,12 +378,6 @@ export function createDevServerMiddleware(
         );
     }
 
-    if (!doAuthenticatedRequest) {
-        log.warn(
-            `Auth credentials not configured. The /__dd/executeAction endpoint will be unavailable. ${AUTH_GUIDANCE}`,
-        );
-    }
-
     return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
         if (req.method !== 'POST') {
             next();

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -98,19 +98,7 @@ const defaultOptions = {
     }),
     options: {
         enable: true,
-        authOverrides: {
-            method: 'apiKey' as const,
-        },
         include: [],
-        oauth: {
-            authorizationUrl: 'https://api.datadoghq.com/oauth2/v1/authorize',
-            cacheTokens: true,
-            clientId: 'client-id',
-            openBrowser: false,
-            redirectUri: 'http://localhost:8060',
-            timeoutMs: 1000,
-            tokenUrl: 'https://api.datadoghq.com/oauth2/v1/token',
-        },
     },
 };
 

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import type { build } from 'vite';
 
 import {
+    AUTH_GUIDANCE,
     getAuthenticatedRequest,
     MissingAuthenticationError,
     type DoAuthenticatedRequest,
@@ -180,15 +181,14 @@ export const getVitePlugin = ({
         configureServer(server) {
             let doAuthenticatedRequest: DoAuthenticatedRequest | undefined;
             try {
-                doAuthenticatedRequest = getAuthenticatedRequest(
-                    options.authOverrides.method,
-                    auth,
-                    log,
-                );
+                doAuthenticatedRequest = getAuthenticatedRequest();
             } catch (error) {
                 if (!(error instanceof MissingAuthenticationError)) {
                     throw error;
                 }
+                log.warn(
+                    `No authentication configured. The /__dd/executeAction endpoint will be unavailable. ${AUTH_GUIDANCE}`,
+                );
             }
 
             server.middlewares.use(


### PR DESCRIPTION
## Summary

Implements the dev-server section of the RFC "OAuth multi org credential management in apps CLI" (Confluence: RFC OAuth multi org credential management in apps CLI → *Integration with the Vite build plugin's dev server*).

`@datadog/apps-cli` now owns the OAuth flow: login, token storage, org selection, and refresh. The CLI passes the access token to the dev server via `DD_OAUTH_ACCESS_TOKEN` when it spawns it through `datadog-apps dev`. The plugin no longer duplicates any OAuth/session logic.

## Changes

**Authentication precedence** (`auth.ts`): `getAuthenticatedRequest()` reads credentials from the environment in this order:

1. `DD_API_KEY`/`DATADOG_API_KEY` + `DD_APP_KEY`/`DATADOG_APP_KEY` → API-key auth
2. `DD_OAUTH_ACCESS_TOKEN`/`DATADOG_OAUTH_ACCESS_TOKEN` → Bearer auth
3. Otherwise: throw `MissingAuthenticationError` with guidance to start the dev server with `datadog-apps dev`

**Removed:**

- `apps.authOverrides` option, the `AuthMethod` type, and auth-method resolution in `validate.ts`.
- `DD_APPS_AUTH_METHOD` / `DATADOG_APPS_AUTH_METHOD` env vars.
- The `doOAuthRequest` dependency from the dev-server path (browser auth, keychain storage, token refresh all live in the CLI now).

**Added:**

- `OAUTH_ACCESS_TOKEN` to the core `OVERRIDE_VARIABLES` registry (both `DD_` and `DATADOG_` prefixes).
- README section "Development server authentication" that documents the precedence and the `datadog-apps dev` flow.

## Notes for reviewers

- The dev server warns once at startup when no credentials are configured; individual `/__dd/executeAction` requests return 400 with the same guidance.
- Test isolation: Jest's `setupAfterEnv` runs `cleanEnv()` after collection, so `dev-server.test.ts` captures the authenticated request at collection time and the bearer test pins its token in the test body. All tests pass individually and in any order.

## Verification

- All apps plugin unit suites pass (22 suites / 235 tests), including each affected test in isolation.
- Apps plugin typecheck and lint pass.
- Repo-wide search shows no remaining references to `authOverrides`, `AuthMethod`, or `APPS_AUTH_METHOD`.
