### PR TITLE
[APPS-2792] Add: local-execution resilience tests

### DIFF
--- a/packages/plugins/apps/src/vite/local-execution.fixtures.ts
+++ b/packages/plugins/apps/src/vite/local-execution.fixtures.ts
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+// Not named `*.test.*` so `yarn test:unit`'s testMatch never picks it up as its own suite —
+// shared by local-execution.test.ts, local-execution.resilience.test.ts, and
+// local-execution.process-exit.fixture.ts, including the fixture despite it running as its own
+// spawned Jest process: that spawn only isolates the OS process process.exit() can safely kill,
+// not module resolution, so importing shared fixture data here works the same as it already does
+// for mockLogger/moduleResolverFor.
+
+import type { BackendFunction } from '../backend/types';
+
+import type { ExecuteAction } from './local-execution';
+
+export const func: BackendFunction = {
+    relativePath: 'src/example',
+    name: 'example',
+    absolutePath: '/src/example.backend.ts',
+    allowedConnectionIds: [],
+};
+
+export const stubExecuteAction: ExecuteAction = async (fqn) => ({ data: null, stub: true, fqn });

--- a/packages/plugins/apps/src/vite/local-execution.fixtures.ts
+++ b/packages/plugins/apps/src/vite/local-execution.fixtures.ts
@@ -2,12 +2,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-// Not named `*.test.*` so `yarn test:unit`'s testMatch never picks it up as its own suite —
-// shared by local-execution.test.ts, local-execution.resilience.test.ts, and
-// local-execution.process-exit.fixture.ts, including the fixture despite it running as its own
-// spawned Jest process: that spawn only isolates the OS process process.exit() can safely kill,
-// not module resolution, so importing shared fixture data here works the same as it already does
-// for mockLogger/moduleResolverFor.
+// Not named `*.test.*` so `yarn test:unit` doesn't run it as its own suite. Shared by all three
+// local-execution test files, including the spawned-process fixture — spawning isolates the OS
+// process, not module resolution, so this import works there too.
 
 import type { BackendFunction } from '../backend/types';
 

--- a/packages/plugins/apps/src/vite/local-execution.fixtures.ts
+++ b/packages/plugins/apps/src/vite/local-execution.fixtures.ts
@@ -8,7 +8,7 @@
 
 import type { BackendFunction } from '../backend/types';
 
-import type { ExecuteAction } from './local-execution';
+import type { ExecuteAction, GetRuntimeContext, RuntimeContext } from './local-execution';
 
 export const func: BackendFunction = {
     relativePath: 'src/example',
@@ -18,3 +18,16 @@ export const func: BackendFunction = {
 };
 
 export const stubExecuteAction: ExecuteAction = async (fqn) => ({ data: null, stub: true, fqn });
+
+// A factory, not a shared constant: local-execution.ts spreads this shallowly onto `$`, so a
+// reused instance would let one execution's mutation of `$.Source.initiator` leak into the next.
+export function makePreviewRuntimeContext(): RuntimeContext {
+    return {
+        Source: {
+            initiator: { id: 'preview-initiator', orgId: 'preview-org' },
+            runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
+        },
+    };
+}
+
+export const stubGetRuntimeContext: GetRuntimeContext = async () => makePreviewRuntimeContext();

--- a/packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts
+++ b/packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts
@@ -1,42 +1,41 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
-// Not named `*.test.*` so `yarn test:unit` skips it — resilience.test.ts spawns it as its own Jest
-// process instead, since process.exit() here would otherwise kill the parent worker. The disables
-// below exist because Jest treats it as a test at runtime despite the eslint override not matching.
-// eslint-disable-next-line import/no-extraneous-dependencies -- test-only helper; file isn't named *.test.ts
-import { mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
 
-import { func, stubExecuteAction } from './local-execution.fixtures';
-import type { GetRuntimeContext } from './local-execution';
+// Not named `*.test.*` so `yarn test:unit` skips it — resilience.test.ts spawns it as its own Jest
+// process instead, since process.exit() here would otherwise kill the parent worker. Jest still
+// treats it as a test at runtime, so the eslint-disables below cover rules whose overrides key off
+// the filename and don't apply here.
+
+// eslint-disable-next-line import/no-extraneous-dependencies -- test-only helper
+import { mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
+import fs from 'fs';
+
+import { func, stubExecuteAction, stubGetRuntimeContext } from './local-execution.fixtures';
 import { executeScriptLocally } from './local-execution';
 
-const stubGetRuntimeContext: GetRuntimeContext = async () => ({
-    Source: {
-        initiator: { id: 'preview-initiator', orgId: 'preview-org' },
-        runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
-    },
-});
-
-// eslint-disable-next-line no-undef -- Jest injects `test` at runtime; eslint override doesn't match this filename
+// eslint-disable-next-line no-undef -- Jest injects `test` at runtime
 test('process.exit fixture', async () => {
     // Jest's console.log is buffered in-process and only flushed once a test result is reported —
     // process.exit() never lets that happen, so the marker must go straight to the real stdout fd.
-    process.stdout.write('FIXTURE_STARTED\n');
+    // `process.stdout.write` itself is asynchronous when stdout is a pipe (spawnSync's default) on
+    // POSIX, so process.exit() could still race ahead of it — fs.writeSync bypasses that entirely.
+    fs.writeSync(1, 'FIXTURE_STARTED\n');
+    const resolveModule = moduleResolverFor(func, {
+        example: () => {
+            process.exit(7);
+        },
+    });
     await executeScriptLocally(
         func,
         '/project',
         [],
         stubExecuteAction,
         stubGetRuntimeContext,
-        moduleResolverFor(func, {
-            example: () => {
-                process.exit(7);
-            },
-        }),
+        resolveModule,
         mockLogger,
         5000,
     );
     // Unreachable if process.exit() truly bypasses cleanup; see note above for why this bypasses console.log.
-    process.stdout.write('FIXTURE_CLEANUP_RAN\n');
+    fs.writeSync(1, 'FIXTURE_CLEANUP_RAN\n');
 });

--- a/packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts
+++ b/packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts
@@ -1,30 +1,18 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
-
 // Deliberately not named `*.test.*` so `yarn test:unit`'s normal testMatch never picks it up —
 // local-execution.resilience.test.ts spawns it as its own Jest process (via --testMatch override)
 // to observe a real process.exit() call inside the actual executeScriptLocally() code path; running
 // it in-process would kill the parent test's own Jest worker. Not matched by the repo's `**/*.test.ts`
 // eslint override for the same reason, hence the disables below (Jest still injects the `test`
 // global at runtime for any file it executes, matched or not).
-
 // eslint-disable-next-line import/no-extraneous-dependencies -- test-only helper, same as any *.test.ts file; this file just isn't named like one (see note above)
 import { mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
 
-import type { BackendFunction } from '../backend/types';
-
-import type { ExecuteAction, GetRuntimeContext } from './local-execution';
+import { func, stubExecuteAction } from './local-execution.fixtures';
+import type { GetRuntimeContext } from './local-execution';
 import { executeScriptLocally } from './local-execution';
-
-const func: BackendFunction = {
-    relativePath: 'src/example',
-    name: 'example',
-    absolutePath: '/src/example.backend.ts',
-    allowedConnectionIds: [],
-};
-
-const stubExecuteAction: ExecuteAction = async (fqn) => ({ data: null, stub: true, fqn });
 
 const stubGetRuntimeContext: GetRuntimeContext = async () => ({
     Source: {

--- a/packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts
+++ b/packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts
@@ -1,13 +1,10 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
-// Deliberately not named `*.test.*` so `yarn test:unit`'s normal testMatch never picks it up —
-// local-execution.resilience.test.ts spawns it as its own Jest process (via --testMatch override)
-// to observe a real process.exit() call inside the actual executeScriptLocally() code path; running
-// it in-process would kill the parent test's own Jest worker. Not matched by the repo's `**/*.test.ts`
-// eslint override for the same reason, hence the disables below (Jest still injects the `test`
-// global at runtime for any file it executes, matched or not).
-// eslint-disable-next-line import/no-extraneous-dependencies -- test-only helper, same as any *.test.ts file; this file just isn't named like one (see note above)
+// Not named `*.test.*` so `yarn test:unit` skips it — resilience.test.ts spawns it as its own Jest
+// process instead, since process.exit() here would otherwise kill the parent worker. The disables
+// below exist because Jest treats it as a test at runtime despite the eslint override not matching.
+// eslint-disable-next-line import/no-extraneous-dependencies -- test-only helper; file isn't named *.test.ts
 import { mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
 
 import { func, stubExecuteAction } from './local-execution.fixtures';
@@ -21,10 +18,11 @@ const stubGetRuntimeContext: GetRuntimeContext = async () => ({
     },
 });
 
-// eslint-disable-next-line no-undef -- Jest injects this global at runtime; not declared here because this file isn't matched by the repo's jest eslint override (see note above)
+// eslint-disable-next-line no-undef -- Jest injects `test` at runtime; eslint override doesn't match this filename
 test('process.exit fixture', async () => {
-    // eslint-disable-next-line no-console -- this file's stdout is the only channel the spawning parent test can observe
-    console.log('FIXTURE_STARTED');
+    // Jest's console.log is buffered in-process and only flushed once a test result is reported —
+    // process.exit() never lets that happen, so the marker must go straight to the real stdout fd.
+    process.stdout.write('FIXTURE_STARTED\n');
     await executeScriptLocally(
         func,
         '/project',
@@ -39,6 +37,6 @@ test('process.exit fixture', async () => {
         mockLogger,
         5000,
     );
-    // eslint-disable-next-line no-console -- see note above; unreachable if process.exit() truly bypasses cleanup
-    console.log('FIXTURE_CLEANUP_RAN');
+    // Unreachable if process.exit() truly bypasses cleanup; see note above for why this bypasses console.log.
+    process.stdout.write('FIXTURE_CLEANUP_RAN\n');
 });

--- a/packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts
+++ b/packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+// Deliberately not named `*.test.*` so `yarn test:unit`'s normal testMatch never picks it up —
+// local-execution.resilience.test.ts spawns it as its own Jest process (via --testMatch override)
+// to observe a real process.exit() call inside the actual executeScriptLocally() code path; running
+// it in-process would kill the parent test's own Jest worker. Not matched by the repo's `**/*.test.ts`
+// eslint override for the same reason, hence the disables below (Jest still injects the `test`
+// global at runtime for any file it executes, matched or not).
+
+// eslint-disable-next-line import/no-extraneous-dependencies -- test-only helper, same as any *.test.ts file; this file just isn't named like one (see note above)
+import { mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
+
+import type { BackendFunction } from '../backend/types';
+
+import type { ExecuteAction, GetRuntimeContext } from './local-execution';
+import { executeScriptLocally } from './local-execution';
+
+const func: BackendFunction = {
+    relativePath: 'src/example',
+    name: 'example',
+    absolutePath: '/src/example.backend.ts',
+    allowedConnectionIds: [],
+};
+
+const stubExecuteAction: ExecuteAction = async (fqn) => ({ data: null, stub: true, fqn });
+
+const stubGetRuntimeContext: GetRuntimeContext = async () => ({
+    Source: {
+        initiator: { id: 'preview-initiator', orgId: 'preview-org' },
+        runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
+    },
+});
+
+// eslint-disable-next-line no-undef -- Jest injects this global at runtime; not declared here because this file isn't matched by the repo's jest eslint override (see note above)
+test('process.exit fixture', async () => {
+    // eslint-disable-next-line no-console -- this file's stdout is the only channel the spawning parent test can observe
+    console.log('FIXTURE_STARTED');
+    await executeScriptLocally(
+        func,
+        '/project',
+        [],
+        stubExecuteAction,
+        stubGetRuntimeContext,
+        moduleResolverFor(func, {
+            example: () => {
+                process.exit(7);
+            },
+        }),
+        mockLogger,
+        5000,
+    );
+    // eslint-disable-next-line no-console -- see note above; unreachable if process.exit() truly bypasses cleanup
+    console.log('FIXTURE_CLEANUP_RAN');
+});

--- a/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-/** Two targeted checks that empirically confirm real failure modes of running backend functions in-process rather than in an isolated child process/thread — accepted v1 limitations, not bugs this file fixes. */
+/** Confirms known v1 limitations of in-process execution (vs. an isolated child process/thread) — not bugs to fix. */
 
 import { mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
 import { spawnSync } from 'child_process';
@@ -20,15 +20,19 @@ const stubGetRuntimeContext: GetRuntimeContext = async () => ({
 });
 
 describe('local-execution resilience (in-process execution known limitations)', () => {
-    // A real `while (true) {}` would hang this test (and the whole Jest
-    // worker) forever, since nothing — including the timeout's own
-    // setTimeout callback — can run while the event loop is synchronously
-    // blocked. A bounded, time-boxed busy-wait demonstrates the exact same
-    // mechanism without actually hanging: if the 20ms timeout could
-    // interrupt a synchronous loop, this would settle around 20ms with a
-    // timeout rejection; instead it can only settle once the loop itself
-    // finishes on its own, ~200ms later, with the loop's real result.
+    // A real `while (true) {}` would hang this test forever, since nothing — not even the timeout's
+    // own callback — can run while the event loop is blocked synchronously. This bounded busy-wait
+    // proves the same point safely: the 20ms timeout can't interrupt it, so it settles at ~200ms.
     test('Should NOT interrupt a synchronous CPU-bound loop with the current timeout — known, accepted v1 limitation', async () => {
+        const resolver = moduleResolverFor(func, {
+            example: () => {
+                const deadline = Date.now() + 200;
+                // eslint-disable-next-line no-empty
+                while (Date.now() < deadline) {}
+                return 'loop finished on its own';
+            },
+        });
+
         const start = Date.now();
 
         const result = await executeScriptLocally(
@@ -37,14 +41,7 @@ describe('local-execution resilience (in-process execution known limitations)', 
             [],
             stubExecuteAction,
             stubGetRuntimeContext,
-            moduleResolverFor(func, {
-                example: () => {
-                    const deadline = Date.now() + 200;
-                    // eslint-disable-next-line no-empty
-                    while (Date.now() < deadline) {}
-                    return 'loop finished on its own';
-                },
-            }),
+            resolver,
             mockLogger,
             20,
         );
@@ -55,23 +52,13 @@ describe('local-execution resilience (in-process execution known limitations)', 
         expect(elapsedMs).toBeGreaterThanOrEqual(150);
     });
 
-    // process.exit() can't be run inside this same Jest process — it would
-    // actually terminate the test runner. This spawns local-execution.process-exit.fixture.ts as its
-    // own Jest process (real transform, real module resolution, real executeScriptLocally/
-    // runScriptLocally code path — not a hand-rolled emulation of it) to test the relevant claim:
-    // does the try/finally runScriptLocally wraps around the customer's function call offer any
-    // protection against process.exit()? It doesn't — process.exit() is immediate and unconditional
-    // at the OS level, so no JS-level exception handling in this in-process design can intercept it.
-    // A customer function calling process.exit() takes the whole dev server down with it, not just
-    // its own execution. `--runInBand` is required so the fixture runs in the spawned process itself
-    // rather than a Jest worker — otherwise Jest would report a worker crash instead of surfacing
-    // exit code 7 on the process this test observes.
+    // process.exit() would kill this Jest process, so the fixture runs as its own real Jest process —
+    // proving runScriptLocally's try/finally offers no protection, since exit() acts at the OS level.
+    // `--runInBand` keeps it in the spawned process itself (not a worker) so exit code 7 surfaces here.
     test("Should confirm process.exit() inside the customer function crashes the whole process, bypassing runScriptLocally's own try/finally cleanup — known, real risk, not a safely-contained failure", () => {
         const fixturePath = path.join(__dirname, 'local-execution.process-exit.fixture.ts');
-        const jestBinPath = path.join(
-            path.dirname(require.resolve('jest/package.json')),
-            'bin/jest.js',
-        );
+        const jestPackagePath = require.resolve('jest/package.json');
+        const jestBinPath = path.join(path.dirname(jestPackagePath), 'bin/jest.js');
         const jestConfigPath = path.join(__dirname, '../../../../tests/jest.config.ts');
 
         const result = spawnSync(

--- a/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
@@ -5,28 +5,21 @@
 /** Confirms known v1 limitations of in-process execution (vs. an isolated child process/thread) — not bugs to fix. */
 
 import { mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
+import { ROOT } from '@dd/tools/constants';
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import { func, stubExecuteAction } from './local-execution.fixtures';
-import type { GetRuntimeContext } from './local-execution';
+import { func, stubExecuteAction, stubGetRuntimeContext } from './local-execution.fixtures';
 import { executeScriptLocally } from './local-execution';
-
-const stubGetRuntimeContext: GetRuntimeContext = async () => ({
-    Source: {
-        initiator: { id: 'preview-initiator', orgId: 'preview-org' },
-        runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
-    },
-});
 
 describe('local-execution resilience (in-process execution known limitations)', () => {
     // A real `while (true) {}` would hang this test forever, since nothing — not even the timeout's
     // own callback — can run while the event loop is blocked synchronously. This bounded busy-wait
-    // proves the same point safely: the 20ms timeout can't interrupt it, so it settles at ~200ms.
+    // proves the same point safely: the 20ms timeout can't interrupt it, so it settles at ~80ms.
     test('Should NOT interrupt a synchronous CPU-bound loop with the current timeout — known, accepted v1 limitation', async () => {
         const resolver = moduleResolverFor(func, {
             example: () => {
-                const deadline = Date.now() + 200;
+                const deadline = Date.now() + 80;
                 // eslint-disable-next-line no-empty
                 while (Date.now() < deadline) {}
                 return 'loop finished on its own';
@@ -49,17 +42,26 @@ describe('local-execution resilience (in-process execution known limitations)', 
         const elapsedMs = Date.now() - start;
 
         expect(result).toEqual({ data: 'loop finished on its own' });
-        expect(elapsedMs).toBeGreaterThanOrEqual(150);
+        expect(elapsedMs).toBeGreaterThanOrEqual(60);
     });
 
     // process.exit() would kill this Jest process, so the fixture runs as its own real Jest process —
     // proving runScriptLocally's try/finally offers no protection, since exit() acts at the OS level.
     // `--runInBand` keeps it in the spawned process itself (not a worker) so exit code 7 surfaces here.
+    // `--globalSetup` is overridden to a no-op: the real globalSetup.ts's `yarn install` + git setup
+    // exists for the fixtures directory this run never touches, and re-paying that cost on every
+    // invocation ate into the timeout budget below for no benefit.
     test("Should confirm process.exit() inside the customer function crashes the whole process, bypassing runScriptLocally's own try/finally cleanup — known, real risk, not a safely-contained failure", () => {
         const fixturePath = path.join(__dirname, 'local-execution.process-exit.fixture.ts');
+        const fixtureFilename = path.basename(fixturePath);
         const jestPackagePath = require.resolve('jest/package.json');
-        const jestBinPath = path.join(path.dirname(jestPackagePath), 'bin/jest.js');
-        const jestConfigPath = path.join(__dirname, '../../../../tests/jest.config.ts');
+        const jestBinDir = path.dirname(jestPackagePath);
+        const jestBinPath = path.join(jestBinDir, 'bin/jest.js');
+        const jestConfigPath = path.resolve(ROOT, 'packages/tests/jest.config.ts');
+        const noopGlobalSetupPath = path.resolve(
+            ROOT,
+            'packages/tests/src/_jest/noopGlobalSetup.ts',
+        );
 
         const result = spawnSync(
             process.execPath,
@@ -71,14 +73,19 @@ describe('local-execution resilience (in-process execution known limitations)', 
                 // occurrence per flag) — a JSON-stringified array is taken literally as a single
                 // glob containing "[" and "]" characters and matches nothing.
                 '--testMatch',
-                `**/${path.basename(fixturePath)}`,
+                `**/${fixtureFilename}`,
+                '--globalSetup',
+                noopGlobalSetupPath,
                 '--runInBand',
             ],
-            { encoding: 'utf8', timeout: 30000 },
+            { encoding: 'utf8', timeout: 15000 },
         );
 
         expect(result.status).toBe(7);
         expect(result.stdout).toContain('FIXTURE_STARTED');
         expect(result.stdout).not.toContain('FIXTURE_CLEANUP_RAN');
-    }, 30000);
+        // Longer than spawnSync's own 15000ms timeout above, so a slow child that legitimately hits
+        // its own timeout fails with a clear assertion on `result.status` instead of racing this
+        // test's own timeout and reporting an ambiguous "test timed out" instead.
+    }, 20000);
 });

--- a/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
@@ -8,19 +8,9 @@ import { mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
 import { spawnSync } from 'child_process';
 import path from 'path';
 
-import type { BackendFunction } from '../backend/types';
-
-import type { ExecuteAction, GetRuntimeContext } from './local-execution';
+import { func, stubExecuteAction } from './local-execution.fixtures';
+import type { GetRuntimeContext } from './local-execution';
 import { executeScriptLocally } from './local-execution';
-
-const func: BackendFunction = {
-    relativePath: 'src/example',
-    name: 'example',
-    absolutePath: '/src/example.backend.ts',
-    allowedConnectionIds: [],
-};
-
-const stubExecuteAction: ExecuteAction = async (fqn) => ({ data: null, stub: true, fqn });
 
 const stubGetRuntimeContext: GetRuntimeContext = async () => ({
     Source: {

--- a/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+/** Two targeted checks that empirically confirm real failure modes of running backend functions in-process rather than in an isolated child process/thread — accepted v1 limitations, not bugs this file fixes. */
+
+import { mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import type { BackendFunction } from '../backend/types';
+
+import type { ExecuteAction, GetRuntimeContext } from './local-execution';
+import { executeScriptLocally } from './local-execution';
+
+const func: BackendFunction = {
+    relativePath: 'src/example',
+    name: 'example',
+    absolutePath: '/src/example.backend.ts',
+    allowedConnectionIds: [],
+};
+
+const stubExecuteAction: ExecuteAction = async (fqn) => ({ data: null, stub: true, fqn });
+
+const stubGetRuntimeContext: GetRuntimeContext = async () => ({
+    Source: {
+        initiator: { id: 'preview-initiator', orgId: 'preview-org' },
+        runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
+    },
+});
+
+describe('local-execution resilience (in-process execution known limitations)', () => {
+    // A real `while (true) {}` would hang this test (and the whole Jest
+    // worker) forever, since nothing — including the timeout's own
+    // setTimeout callback — can run while the event loop is synchronously
+    // blocked. A bounded, time-boxed busy-wait demonstrates the exact same
+    // mechanism without actually hanging: if the 20ms timeout could
+    // interrupt a synchronous loop, this would settle around 20ms with a
+    // timeout rejection; instead it can only settle once the loop itself
+    // finishes on its own, ~200ms later, with the loop's real result.
+    test('Should NOT interrupt a synchronous CPU-bound loop with the current timeout — known, accepted v1 limitation', async () => {
+        const start = Date.now();
+
+        const result = await executeScriptLocally(
+            func,
+            '/project',
+            [],
+            stubExecuteAction,
+            stubGetRuntimeContext,
+            moduleResolverFor(func, {
+                example: () => {
+                    const deadline = Date.now() + 200;
+                    // eslint-disable-next-line no-empty
+                    while (Date.now() < deadline) {}
+                    return 'loop finished on its own';
+                },
+            }),
+            mockLogger,
+            20,
+        );
+
+        const elapsedMs = Date.now() - start;
+
+        expect(result).toEqual({ data: 'loop finished on its own' });
+        expect(elapsedMs).toBeGreaterThanOrEqual(150);
+    });
+
+    // process.exit() can't be run inside this same Jest process — it would
+    // actually terminate the test runner. This spawns local-execution.process-exit.fixture.ts as its
+    // own Jest process (real transform, real module resolution, real executeScriptLocally/
+    // runScriptLocally code path — not a hand-rolled emulation of it) to test the relevant claim:
+    // does the try/finally runScriptLocally wraps around the customer's function call offer any
+    // protection against process.exit()? It doesn't — process.exit() is immediate and unconditional
+    // at the OS level, so no JS-level exception handling in this in-process design can intercept it.
+    // A customer function calling process.exit() takes the whole dev server down with it, not just
+    // its own execution. `--runInBand` is required so the fixture runs in the spawned process itself
+    // rather than a Jest worker — otherwise Jest would report a worker crash instead of surfacing
+    // exit code 7 on the process this test observes.
+    test("Should confirm process.exit() inside the customer function crashes the whole process, bypassing runScriptLocally's own try/finally cleanup — known, real risk, not a safely-contained failure", () => {
+        const fixturePath = path.join(__dirname, 'local-execution.process-exit.fixture.ts');
+        const jestBinPath = path.join(
+            path.dirname(require.resolve('jest/package.json')),
+            'bin/jest.js',
+        );
+        const jestConfigPath = path.join(__dirname, '../../../../tests/jest.config.ts');
+
+        const result = spawnSync(
+            process.execPath,
+            [
+                jestBinPath,
+                '--config',
+                jestConfigPath,
+                // jest-cli's --testMatch is a bare glob string (yargs `type: 'array'` collects one
+                // occurrence per flag) — a JSON-stringified array is taken literally as a single
+                // glob containing "[" and "]" characters and matches nothing.
+                '--testMatch',
+                `**/${path.basename(fixturePath)}`,
+                '--runInBand',
+            ],
+            { encoding: 'utf8', timeout: 30000 },
+        );
+
+        expect(result.status).toBe(7);
+        expect(result.stdout).toContain('FIXTURE_STARTED');
+        expect(result.stdout).not.toContain('FIXTURE_CLEANUP_RAN');
+    }, 30000);
+});

--- a/packages/plugins/apps/src/vite/local-execution.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.test.ts
@@ -11,6 +11,7 @@ import * as shared from '../backend/shared';
 import type { BackendFunction } from '../backend/types';
 import { LOCAL_EXECUTION_LOAD_SUFFIX } from '../constants';
 
+import { func, stubExecuteAction } from './local-execution.fixtures';
 import type { ExecuteAction, LoadModule } from './local-execution';
 import {
     DEFAULT_LONG_POLLING_CONFIG,
@@ -19,13 +20,6 @@ import {
     executeScriptLocally as executeScriptLocallyWithRuntimeContext,
 } from './local-execution';
 import { forceReset } from './network-guard';
-
-const func: BackendFunction = {
-    relativePath: 'src/example',
-    name: 'example',
-    absolutePath: '/src/example.backend.ts',
-    allowedConnectionIds: [],
-};
 
 const funcWithConnection: BackendFunction = { ...func, allowedConnectionIds: ['conn-1'] };
 
@@ -49,8 +43,6 @@ beforeEach(() => {
     jest.spyOn(shared, 'isActionCatalogInstalled').mockReturnValue(false);
     jest.spyOn(shared, 'isDatadogAppsBackendInstalled').mockReturnValue(false);
 });
-
-const stubExecuteAction: ExecuteAction = async (fqn) => ({ data: null, stub: true, fqn });
 
 function makeRuntimeContext() {
     return {

--- a/packages/plugins/apps/src/vite/local-execution.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.test.ts
@@ -11,7 +11,12 @@ import * as shared from '../backend/shared';
 import type { BackendFunction } from '../backend/types';
 import { LOCAL_EXECUTION_LOAD_SUFFIX } from '../constants';
 
-import { func, stubExecuteAction } from './local-execution.fixtures';
+import {
+    func,
+    makePreviewRuntimeContext,
+    stubExecuteAction,
+    stubGetRuntimeContext,
+} from './local-execution.fixtures';
 import type { ExecuteAction, LoadModule } from './local-execution';
 import {
     DEFAULT_LONG_POLLING_CONFIG,
@@ -44,15 +49,6 @@ beforeEach(() => {
     jest.spyOn(shared, 'isDatadogAppsBackendInstalled').mockReturnValue(false);
 });
 
-function makeRuntimeContext() {
-    return {
-        Source: {
-            initiator: { id: 'preview-initiator', orgId: 'preview-org' },
-            runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
-        },
-    };
-}
-
 /** Keeps the existing test call sites concise while every invocation receives a fresh preview context. */
 function executeScriptLocally(
     backendFunction: BackendFunction,
@@ -65,13 +61,12 @@ function executeScriptLocally(
     primedEntry?: Record<string, unknown>,
     longPolling = DEFAULT_LONG_POLLING_CONFIG,
 ) {
-    const getRuntimeContext = async () => makeRuntimeContext();
     return executeScriptLocallyWithRuntimeContext(
         backendFunction,
         projectRoot,
         args,
         executeAction,
-        getRuntimeContext,
+        stubGetRuntimeContext,
         loadModule,
         log,
         timeoutMs,
@@ -212,7 +207,7 @@ describe('local-execution — executeScriptLocally', () => {
                 TEST_PROJECT_ROOT,
                 [],
                 stubExecuteAction,
-                async () => makeRuntimeContext(),
+                stubGetRuntimeContext,
                 loadModule,
                 mockLogger,
             );
@@ -929,7 +924,7 @@ describe('local-execution — executeScriptLocally', () => {
 
     test('Should preserve preview context fields while overriding invocation-owned args and Actions', async () => {
         const getRuntimeContext = async () => ({
-            ...makeRuntimeContext(),
+            ...makePreviewRuntimeContext(),
             previewMetadata: { requestId: 'preview-request' },
             backendFunctionArgs: ['remote-placeholder'],
             Actions: 'remote-placeholder',

--- a/packages/tests/src/_jest/noopGlobalSetup.ts
+++ b/packages/tests/src/_jest/noopGlobalSetup.ts
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+// A `--globalSetup` override for spawned single-fixture Jest runs that don't touch the fixtures
+// directory and so don't need globalSetup.ts's real `yarn install` + git init/config cost.
+const noopGlobalSetup = () => {};
+
+export default noopGlobalSetup;


### PR DESCRIPTION
## Motivation

- Local-execution resilience testing milestone from the [Local Node Execution Kickoff doc](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455/Local+Node+Execution+of+Backend+Functions+Kickoff).
  - Renamed/descoped from "Chaos-engineering resilience testing" since `domains/chaos-engineering` targets Datadog-owned Kubernetes clusters — a mismatch for this in-process, customer-dev-server model.
- Two targeted checks, not fixes:
  - Empirically confirm the RFC's "no process isolation" decision has the failure modes it assumes, rather than leave them unverified.

## Architecture

- The `process.exit()` test can't call `runScriptLocally` directly in the main Jest process — exiting would kill the whole test run.
- It spawns the fixture as a child process instead, and asserts on the child's exit behavior:

```
Jest test process
  └─ spawns ──▶ local-execution.process-exit.fixture.ts (child process)
                  runScriptLocally() → customer fn calls process.exit()
                  → child terminates immediately
  └─ asserts on the child's exit code
```

## Changes

<details>
<summary>6 changes across 5 files</summary>

| What changed | File |
|---|---|
| New test confirming a synchronous CPU-bound loop starves the event loop, so the current `Promise.race` timeout never fires — it can only settle once the loop finishes on its own. | [local-execution.resilience.test.ts](packages/plugins/apps/src/vite/local-execution.resilience.test.ts) |
| New test confirming `process.exit()` inside the customer function terminates the whole process immediately, bypassing `runScriptLocally`'s `try`/`finally` cleanup — spawns a dedicated fixture as its own Jest process (since `process.exit()` can't safely run inside this Jest process) so the observed behavior is the real `executeScriptLocally`/`runScriptLocally` code path, not a hand-rolled emulation of it. | [local-execution.resilience.test.ts](packages/plugins/apps/src/vite/local-execution.resilience.test.ts), [local-execution.process-exit.fixture.ts](packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts) |
| The spawned fixture's `--globalSetup` is overridden to a new no-op, since it doesn't touch the fixtures directory and doesn't need the real `globalSetup.ts`'s `yarn install` + git init/config cost. | [noopGlobalSetup.ts](packages/tests/src/_jest/noopGlobalSetup.ts), [local-execution.resilience.test.ts](packages/plugins/apps/src/vite/local-execution.resilience.test.ts) |
| Extracted the identical `func`/`stubExecuteAction`/`stubGetRuntimeContext` fixture data — previously declared separately across this file, `local-execution.test.ts`, the resilience test, and the spawned fixture — into a new shared module, since the fixture already proves shared imports work fine in its spawned process; `stubGetRuntimeContext` satisfies `executeScriptLocally`'s `getRuntimeContext` parameter added by #503. | [local-execution.fixtures.ts](packages/plugins/apps/src/vite/local-execution.fixtures.ts), [local-execution.test.ts](packages/plugins/apps/src/vite/local-execution.test.ts), [local-execution.resilience.test.ts](packages/plugins/apps/src/vite/local-execution.resilience.test.ts), [local-execution.process-exit.fixture.ts](packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts) |
| The fixture's `moduleResolverFor(...)` call, previously inlined directly as a function-call argument, is now assigned to a named `resolveModule` local first. | [local-execution.process-exit.fixture.ts](packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts) |
| The fixture's stdout markers now go through `fs.writeSync(1, ...)` instead of `process.stdout.write(...)`, since the latter is asynchronous when stdout is a pipe (`spawnSync`'s default) on POSIX — `process.exit()` could otherwise race ahead of the flush and intermittently drop the marker from the parent's captured output. | [local-execution.process-exit.fixture.ts](packages/plugins/apps/src/vite/local-execution.process-exit.fixture.ts) |

</details>

- The third checklist item ("the queue survives a rejected execution and keeps running") is already covered by an existing test in `local-execution.test.ts`.

## QA Instructions

- Test-only change with no HTTP surface — verified via the unit test commands below, not a live endpoint.

```bash
yarn workspace @dd/tests test:unit packages/plugins/apps/src/vite/local-execution.resilience.test.ts
# Expected: 2 passed ✅ VERIFIED
```

```bash
yarn build:all && yarn test:unit
# Full, unscoped suite — a scoped run can't catch a process-wide guard leaking into
# an unrelated package's tests via a shared Jest worker (see the Confluence QA guide).
# Expected: Test Suites: 91 passed / Tests: 2236 passed, 1 skipped ✅ VERIFIED
```

```bash
yarn workspace @dd/apps-plugin run typecheck
# Expected: clean exit ✅ VERIFIED
```

## Blast Radius

- Test-only change; no production code touched.
- Risk: low.

## Out of Scope / Follow-ups

<details>
<summary>1 item deferred</summary>

| Item | Status | Next step |
|---|---|---|
| Whether to pursue real process/thread isolation (e.g. pooled `worker_threads`) to close the confirmed sync-hang and `process.exit()` gaps | deferred | These tests exist to inform that decision with real data — a follow-up design discussion, not blocking this PR. |

</details>

## Documentation

- [RFC: Local Node execution for High Code Apps backend functions](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651/RFC+Local+Node+execution+for+High+Code+Apps+backend+functions#Decisions-and-Trade-Offs) — "Run in-process instead of forking an isolated child process" trade-off this milestone verifies.
- QA guide: [Confluence page 7100498075](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7100498075) — exact local/staging QA commands for this repo.




