### PR TITLE
Use dd-sts for Datadog API keys in workflows

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -141,6 +141,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
 
+      # Best effort telemetry credentials, never block a bump on them.
+      - name: Get Datadog credentials
+        id: dd-sts
+        continue-on-error: true
+        uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2 # v1.0.5
+        with:
+          policy: build-plugins-bump
+
       - name: Log bump
         if: success()
         continue-on-error: true
@@ -162,7 +170,7 @@ jobs:
           URL="https://http-intake.logs.datadoghq.com/api/v2/logs"
           curl -X POST "${HEADERS[@]}" -d "$DATA" "$URL"
         env:
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
 
       - name: Cleanup failed bump refs
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - "mq-working-branch-*"
 
+permissions:
+  contents: read
+  id-token: write # Needed to federate tokens.
+
 jobs:
   unit-test:
     name: Unit tests
@@ -32,12 +36,20 @@ jobs:
             'packages/published/**', 'packages/tools/src/**',
             'yarn.lock') }}
 
+      # Best effort telemetry credentials: fork PRs can't federate a token.
+      - name: Get Datadog credentials
+        id: dd-sts
+        continue-on-error: true
+        uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2 # v1.0.5
+        with:
+          policy: build-plugins-ci
+
       - name: Configure Datadog Test Optimization
         uses: datadog/test-visibility-github-action@f76512a963e7375dab9ad7f1abc0cacd41806c5c # v2.6.0
         with:
           languages: js
           service: build-plugins
-          api_key: ${{secrets.DATADOG_API_KEY}}
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
           site: datadoghq.com
 
       - run: yarn install --immutable --immutable-cache
@@ -88,12 +100,20 @@ jobs:
             %USERPROFILE%\AppData\Local\ms-playwright
           key: cache-playwright-binaries-${{ hashFiles('yarn.lock') }}
 
+      # Best effort telemetry credentials: fork PRs can't federate a token.
+      - name: Get Datadog credentials
+        id: dd-sts
+        continue-on-error: true
+        uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2 # v1.0.5
+        with:
+          policy: build-plugins-ci
+
       - name: Configure Datadog Test Optimization
         uses: datadog/test-visibility-github-action@f76512a963e7375dab9ad7f1abc0cacd41806c5c # v2.6.0
         with:
           languages: js
           service: build-plugins
-          api_key: ${{secrets.DATADOG_API_KEY}}
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
           site: datadoghq.com
 
       - run: yarn install --immutable --immutable-cache
@@ -172,6 +192,15 @@ jobs:
         if: steps.cache-build-rollup.outputs.cache-hit != 'true'
         run: yarn workspace @datadog/rollup-plugin run buildBasic
 
+      # Best effort telemetry credentials: fork PRs can't federate a token.
+      - name: Get Datadog credentials
+        id: dd-sts
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2 # v1.0.5
+        with:
+          policy: build-plugins-ci
+
       - name: Build all plugins
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: yarn build:all-no-types
@@ -179,7 +208,7 @@ jobs:
           ADD_BUILD_PLUGINS: 1
           BUILD_PLUGINS_REPORTS: 1
           DD_GITHUB_JOB_NAME: Linting # Needs to be the same as the job to have CI Vis link the spans.
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: steps.cache-build.outputs.cache-hit != 'true'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -103,6 +103,14 @@ jobs:
       - run: yarn workspace @datadog/rollup-plugin buildBasic
       - run: export BUILD_PLUGINS_ENV=production
 
+      # Best effort telemetry credentials, never block a release on them.
+      - name: Get Datadog credentials
+        id: dd-sts
+        continue-on-error: true
+        uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2 # v1.0.5
+        with:
+          policy: build-plugins-publish
+
       - name: Publish to NPM
         run: |
           CHANNEL="${{ steps.channel.outputs.channel }}"
@@ -116,7 +124,7 @@ jobs:
         env:
           ADD_BUILD_PLUGINS: 1
           DD_GITHUB_JOB_NAME: Publish to NPM # Needs to be the same as the job to have CI Vis link the spans.
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
       - name: Log version published
         run: |
           VERSION="$(yarn workspace @datadog/webpack-plugin info @datadog/webpack-plugin --json | jq -r '.children.Version')"
@@ -139,4 +147,4 @@ jobs:
           URL="https://http-intake.logs.datadoghq.com/api/v2/logs"
           curl -X POST "${HEADERS[@]}" -d "$DATA" "$URL"
         env:
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}


### PR DESCRIPTION
#### What and why?

Replace every `secrets.DATADOG_API_KEY` usage in our workflows with a short-lived API key federated from **dd-sts** (`DataDog/dd-sts-action@v1.0.5`, GitHub OIDC), removing the long-lived org-wide GitHub secret from CI (SDLC Security initiative). Env var and input names are unchanged (`DATADOG_API_KEY` / `api_key`), so no source code changes.

⚠️ **Prerequisite:** [ddoghq/dd-source#79039](https://github.com/ddoghq/dd-source/pull/79039) must be merged and deployed before this PR merges.

**Follow-up once CI is green** (repo admin, outside this PR): delete the `DATADOG_API_KEY` repo secret.

#### How?

- **ci.yaml**: new top-level `permissions` (`contents: read`, `id-token: write`) — this workflow previously had no permissions block at any level, and its checkout needs `contents: read` — plus a `Get Datadog credentials` step (`id: dd-sts`, `continue-on-error: true`) in each job: before *Configure Datadog Test Optimization* in `unit-test` and `e2e` (fed via `api_key`), and cache-gated before *Build all plugins* in `lint` (same `if` as the consuming step, so no pointless exchange on a cache hit).
- **publish.yaml** / **bump.yaml**: their jobs already declare the `id-token: write` permission dd-sts needs at job level (it was there for npm provenance / octo-sts respectively), so only the `dd-sts` step is added — publish before *Publish to NPM* (feeding it and *Log version published*), bump before *Log bump*.

Every credential step is `continue-on-error: true`: Datadog telemetry is best-effort, and fork PRs cannot federate an OIDC token, so they keep passing exactly as today. Nothing here can break a build — an empty key makes `sendMetrics` a no-op, the log-intake `curl` has no `-f`, and `test-visibility-github-action` just exports an empty `DD_API_KEY`. Security-wise there is no new exposure on `pull_request`: same-repo PRs already receive `secrets.DATADOG_API_KEY` today, and dd-sts swaps a static org-wide secret for a short-lived, policy-scoped, audited credential.

Policies validated locally with `dd-sts check` (schema) and a synthetic claim matrix: each policy accepts only its own event shape (PR / release tag or branch dispatch / master-`v2` dispatch) and rejects the other two plus a wrong-workflow claim. Workflows validated with `actionlint` (no new findings) and `yarn cli integrity`.

