### PR TITLE
[APPS] Fix broken getInitiatingUser() and getExecutionUser() during local dev

### DIFF
--- a/packages/plugins/apps/src/vite/dev-server.integration.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.integration.test.ts
@@ -97,6 +97,44 @@ const mixedImportsFunc: BackendFunction = {
     allowedConnectionIds: [],
 };
 
+const previewRuntimeContext = {
+    Source: {
+        initiator: { id: 'preview-initiator', orgId: 'preview-org' },
+        runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
+    },
+};
+
+function mockRuntimeContextHydration() {
+    nock('https://api.datadoghq.com', {
+        reqheaders: {
+            'DD-API-KEY': 'test-api-key',
+            'DD-APPLICATION-KEY': 'test-app-key',
+        },
+    })
+        .post('/api/v2/app-builder/queries/preview-async', (body) => {
+            const fqn = (
+                body as {
+                    data?: {
+                        attributes?: {
+                            query?: { properties?: { spec?: { fqn?: unknown } } };
+                        };
+                    };
+                }
+            ).data?.attributes?.query?.properties?.spec?.fqn;
+            return fqn === 'com.datadoghq.datatransformation.jsFunctionWithActions';
+        })
+        .reply(200, { data: { id: 'runtime-context-receipt' } })
+        .get('/api/v2/app-builder/queries/execution-long-polling/runtime-context-receipt')
+        .reply(200, {
+            data: {
+                attributes: {
+                    done: true,
+                    outputs: { data: previewRuntimeContext },
+                },
+            },
+        });
+}
+
 describe('Dev Server Middleware — real end-to-end local execution', () => {
     let server: ViteDevServer;
 
@@ -135,6 +173,14 @@ describe('Dev Server Middleware — real end-to-end local execution', () => {
         await server.close();
     });
 
+    beforeEach(() => {
+        mockRuntimeContextHydration();
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
     test('Should import a real backend function directly via the real Vite dev server and execute it locally, with a real @datadog/apps-backend typed import resolving $.Source correctly', async () => {
         const auth: AuthOptionsWithDefaults = {
             apiKey: 'test-api-key',
@@ -168,8 +214,8 @@ describe('Dev Server Middleware — real end-to-end local execution', () => {
         expect(body.result).toEqual({
             data: {
                 label: 'e2e-test',
-                executionUser: { id: 'local-dev', orgId: 'local-dev-org' },
-                initiatingUser: { id: 'local-dev', orgId: 'local-dev-org' },
+                executionUser: { id: 'preview-run-as', orgId: 'preview-org' },
+                initiatingUser: { id: 'preview-initiator', orgId: 'preview-org' },
             },
         });
     }, 30000);

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -1190,25 +1190,26 @@ describe('Dev Server Middleware', () => {
             expect(mockLoadModule).not.toHaveBeenCalled();
         });
 
-        test('Should abort stalled runtime-context hydration so later local executions are not wedged', async () => {
+        test('Should bound stalled runtime-context hydration when the request ignores abort so later local executions are not wedged', async () => {
             jest.useFakeTimers();
             try {
                 nock.cleanAll();
-                const hangingRuntimeContextRequest = <T>(options: Omit<RequestOpts, 'auth'>) =>
-                    new Promise<T>((_resolve, reject) => {
-                        options.signal?.addEventListener(
-                            'abort',
-                            () => reject(options.signal?.reason),
-                            { once: true },
-                        );
-                    });
+                let hydrationSignal: AbortSignal | undefined;
+                const nonAbortableRuntimeContextRequest = <T>(
+                    options: Omit<RequestOpts, 'auth'>,
+                ) => {
+                    hydrationSignal = options.signal;
+                    // Models doRequest sleeping in async-retry backoff: the signal is aborted,
+                    // but the request promise does not settle until the retry timer wakes up.
+                    return new Promise<T>(() => {});
+                };
                 const hangingHydrationMiddleware = createDevServerMiddleware(
                     mockViteBuild,
                     mockLoadModule,
                     () => mockFunctions,
                     async () => [],
                     mockAuth,
-                    hangingRuntimeContextRequest,
+                    nonAbortableRuntimeContextRequest,
                     mockLongPolling,
                     '/project',
                     mockLog,
@@ -1229,6 +1230,7 @@ describe('Dev Server Middleware', () => {
                 expect(res.statusCode).toBe(500);
                 const body = JSON.parse(res.getBody());
                 expect(body.error).toContain('Runtime context hydration timed out after 60000ms');
+                expect(hydrationSignal?.aborted).toBe(true);
                 expect(mockLoadModule).not.toHaveBeenCalled();
 
                 const recoveringRuntimeContextRequest = makeImmediateRuntimeContextRequest();

--- a/packages/plugins/apps/src/vite/dev-server.test.ts
+++ b/packages/plugins/apps/src/vite/dev-server.test.ts
@@ -6,7 +6,7 @@
 
 import { getAuthenticatedRequest } from '@dd/apps-plugin/auth';
 import { createDevServerMiddleware, getRetryDelay } from '@dd/apps-plugin/vite/dev-server';
-import type { AuthOptionsWithDefaults } from '@dd/core/types';
+import type { AuthOptionsWithDefaults, RequestOpts } from '@dd/core/types';
 import { cleanEnv } from '@dd/tests/_jest/helpers/env';
 import {
     createMockRequest,
@@ -217,6 +217,72 @@ function mockLoadModuleReturning(func: BackendFunction, fn: (...args: never[]) =
     mockLoadModule.mockImplementation(resolveModule);
 }
 
+const previewRuntimeContext = {
+    Source: {
+        initiator: { id: 'preview-initiator', orgId: 'preview-org' },
+        runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
+    },
+};
+
+function mockRuntimeContextHydration(
+    times: number = 1,
+    outputs: unknown = { data: previewRuntimeContext },
+) {
+    return nock(DD_API_ORIGIN, {
+        reqheaders: { Authorization: 'Bearer test-oauth-token' },
+    })
+        .post('/api/v2/app-builder/queries/preview-async', (body) => {
+            const querySpec = (
+                body as {
+                    data?: {
+                        attributes?: {
+                            query?: {
+                                properties?: {
+                                    spec?: {
+                                        fqn?: unknown;
+                                        inputs?: {
+                                            script?: unknown;
+                                            allowedConnectionIds?: unknown;
+                                            context?: unknown;
+                                        };
+                                    };
+                                };
+                            };
+                        };
+                    };
+                }
+            ).data?.attributes?.query?.properties?.spec;
+            return (
+                querySpec?.fqn === 'com.datadoghq.datatransformation.jsFunctionWithActions' &&
+                typeof querySpec.inputs?.script === 'string' &&
+                querySpec.inputs.script.includes('return $;') &&
+                JSON.stringify(querySpec.inputs.allowedConnectionIds) === '[]' &&
+                JSON.stringify(querySpec.inputs.context) === '{}'
+            );
+        })
+        .times(times)
+        .reply(200, { data: { id: 'runtime-context-receipt' } })
+        .get('/api/v2/app-builder/queries/execution-long-polling/runtime-context-receipt')
+        .times(times)
+        .reply(200, {
+            data: { attributes: { done: true, outputs } },
+        });
+}
+
+function makeImmediateRuntimeContextRequest() {
+    return jest
+        .fn()
+        .mockResolvedValueOnce({ data: { id: 'runtime-context-receipt' } })
+        .mockResolvedValueOnce({
+            data: {
+                attributes: {
+                    done: true,
+                    outputs: { data: previewRuntimeContext },
+                },
+            },
+        });
+}
+
 describe('Dev Server Middleware', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -282,7 +348,8 @@ describe('Dev Server Middleware', () => {
             expect(res.end).toHaveBeenCalled();
         });
 
-        test('Should handle /__dd/executeAction POST by running the function directly, no bundling, no network call', async () => {
+        test('Should handle /__dd/executeAction POST by hydrating context and running the function locally without bundling', async () => {
+            mockRuntimeContextHydration();
             mockLoadModuleReturning(mockFunctions[0], (arg) => arg);
 
             const req = createMockRequest('/__dd/executeAction', {
@@ -1013,6 +1080,10 @@ describe('Dev Server Middleware', () => {
     });
 
     describe('executeAction handler (local)', () => {
+        beforeEach(() => {
+            mockRuntimeContextHydration();
+        });
+
         const middleware = createDevServerMiddleware(
             mockViteBuild,
             mockLoadModule,
@@ -1047,7 +1118,7 @@ describe('Dev Server Middleware', () => {
             expect(res.statusCode).toBe(404);
         });
 
-        test('Should run the function directly in-process and return its result, with no bundling and no network call', async () => {
+        test('Should hydrate context, run the function directly in-process, and return its result without bundling', async () => {
             mockLoadModuleReturning(mockFunctions[0], (arg: number) => arg * 2);
 
             const req = createMockRequest('/__dd/executeAction', {
@@ -1064,6 +1135,133 @@ describe('Dev Server Middleware', () => {
             expect(body.success).toBe(true);
             expect(body.result).toEqual({ data: 42 });
             expect(mockViteBuild).not.toHaveBeenCalled();
+        });
+
+        test('Should reject a malformed hydrated identity before loading customer code without exposing the response body', async () => {
+            nock.cleanAll();
+            mockRuntimeContextHydration(1, {
+                data: {
+                    Source: {
+                        initiator: { id: 'initiator-without-org' },
+                        runAsUser: { id: 'run-as', orgId: 'preview-org' },
+                    },
+                    secretSentinel: 'must-not-appear',
+                },
+            });
+
+            const req = createMockRequest('/__dd/executeAction', {
+                functionName: encodeQueryName(mockFunctions[0]),
+                args: [],
+            });
+            const res = createMockResponse();
+
+            middleware(req, res, jest.fn());
+            await res.done;
+
+            expect(res.statusCode).toBe(500);
+            const body = JSON.parse(res.getBody());
+            expect(body.error).toContain('Source.initiator');
+            expect(body.error).not.toContain('must-not-appear');
+            expect(mockLoadModule).not.toHaveBeenCalled();
+            expect(mockLogFn).not.toHaveBeenCalledWith(
+                expect.stringContaining('must-not-appear'),
+                expect.anything(),
+            );
+        });
+
+        test('Should reject hydration outputs with no data field before loading customer code', async () => {
+            nock.cleanAll();
+            mockRuntimeContextHydration(1, {});
+
+            const req = createMockRequest('/__dd/executeAction', {
+                functionName: encodeQueryName(mockFunctions[0]),
+                args: [],
+            });
+            const res = createMockResponse();
+
+            middleware(req, res, jest.fn());
+            await res.done;
+
+            expect(res.statusCode).toBe(500);
+            const body = JSON.parse(res.getBody());
+            expect(body.error).toContain(
+                'Runtime context hydration completed without a "data" field',
+            );
+            expect(mockLoadModule).not.toHaveBeenCalled();
+        });
+
+        test('Should abort stalled runtime-context hydration so later local executions are not wedged', async () => {
+            jest.useFakeTimers();
+            try {
+                nock.cleanAll();
+                const hangingRuntimeContextRequest = <T>(options: Omit<RequestOpts, 'auth'>) =>
+                    new Promise<T>((_resolve, reject) => {
+                        options.signal?.addEventListener(
+                            'abort',
+                            () => reject(options.signal?.reason),
+                            { once: true },
+                        );
+                    });
+                const hangingHydrationMiddleware = createDevServerMiddleware(
+                    mockViteBuild,
+                    mockLoadModule,
+                    () => mockFunctions,
+                    async () => [],
+                    mockAuth,
+                    hangingRuntimeContextRequest,
+                    mockLongPolling,
+                    '/project',
+                    mockLog,
+                );
+
+                const req = createMockRequest('/__dd/executeAction', {
+                    functionName: encodeQueryName(mockFunctions[0]),
+                    args: [],
+                });
+                const res = createMockResponse();
+
+                hangingHydrationMiddleware(req, res, jest.fn());
+                const doneAssertion = res.done;
+                await jest.advanceTimersByTimeAsync(0);
+                await jest.advanceTimersByTimeAsync(60_000);
+                await doneAssertion;
+
+                expect(res.statusCode).toBe(500);
+                const body = JSON.parse(res.getBody());
+                expect(body.error).toContain('Runtime context hydration timed out after 60000ms');
+                expect(mockLoadModule).not.toHaveBeenCalled();
+
+                const recoveringRuntimeContextRequest = makeImmediateRuntimeContextRequest();
+                const recoveringMiddleware = createDevServerMiddleware(
+                    mockViteBuild,
+                    mockLoadModule,
+                    () => mockFunctions,
+                    async () => [],
+                    mockAuth,
+                    recoveringRuntimeContextRequest,
+                    mockLongPolling,
+                    '/project',
+                    mockLog,
+                );
+                mockLoadModuleReturning(mockFunctions[0], () => 'recovered');
+                const recoveringReq = createMockRequest('/__dd/executeAction', {
+                    functionName: encodeQueryName(mockFunctions[0]),
+                    args: [],
+                });
+                const recoveringRes = createMockResponse();
+
+                recoveringMiddleware(recoveringReq, recoveringRes, jest.fn());
+                const recoveringDone = recoveringRes.done;
+                await jest.advanceTimersByTimeAsync(0);
+                await recoveringDone;
+
+                expect(recoveringRes.statusCode).toBe(200);
+                expect(JSON.parse(recoveringRes.getBody()).result).toEqual({
+                    data: 'recovered',
+                });
+            } finally {
+                jest.useRealTimers();
+            }
         });
 
         test('Should reject a request with no auth configured upfront, even for a function that never calls $.Actions — matching production, which authenticates before any backend code runs', async () => {
@@ -1330,6 +1528,18 @@ describe('Dev Server Middleware', () => {
         test('Should eventually time out and return a clear error when the priming load never settles', async () => {
             jest.useFakeTimers();
             try {
+                const immediateRuntimeContextRequest = makeImmediateRuntimeContextRequest();
+                const immediateHydrationMiddleware = createDevServerMiddleware(
+                    mockViteBuild,
+                    mockLoadModule,
+                    () => mockFunctions,
+                    async () => [],
+                    mockAuth,
+                    immediateRuntimeContextRequest,
+                    mockLongPolling,
+                    '/project',
+                    mockLog,
+                );
                 mockLoadModule.mockImplementation(
                     // Never settles.
                     () => new Promise(() => {}),
@@ -1341,7 +1551,7 @@ describe('Dev Server Middleware', () => {
                 });
                 const res = createMockResponse();
 
-                middleware(req, res, jest.fn());
+                immediateHydrationMiddleware(req, res, jest.fn());
                 const doneAssertion = res.done;
 
                 // createMockRequest emits the body via a real process.nextTick, which fake timers
@@ -1363,6 +1573,7 @@ describe('Dev Server Middleware', () => {
         // enqueue() call, two concurrent requests for two different cold functions could evaluate
         // their top-level code in genuine parallel instead of one fully finishing before the other starts.
         test('Should never let two concurrent requests for different cold functions race their priming loads', async () => {
+            mockRuntimeContextHydration();
             const order: string[] = [];
             let releaseGreetPriming: (() => void) | undefined;
             const greetPrimingGate = new Promise<void>((resolve) => {
@@ -1460,6 +1671,7 @@ describe('Dev Server Middleware', () => {
             jest.useFakeTimers();
             try {
                 mockLoadModuleReturning(mockFunctions[0], () => 'done');
+                const immediateRuntimeContextRequest = makeImmediateRuntimeContextRequest();
                 const hangingMiddleware = createDevServerMiddleware(
                     mockViteBuild,
                     mockLoadModule,
@@ -1467,7 +1679,7 @@ describe('Dev Server Middleware', () => {
                     // Never settles.
                     () => new Promise(() => {}),
                     mockAuth,
-                    testAuthenticatedRequest,
+                    immediateRuntimeContextRequest,
                     mockLongPolling,
                     '/project',
                     mockLog,

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -276,30 +276,40 @@ function makeGetRuntimeContextRemotely(
 ): GetRuntimeContext {
     return async () => {
         const controller = new AbortController();
-        const timeout = setTimeout(() => {
-            controller.abort(
-                new Error(
-                    `Runtime context hydration timed out after ${RUNTIME_CONTEXT_TIMEOUT_MS}ms`,
-                ),
-            );
-        }, RUNTIME_CONTEXT_TIMEOUT_MS);
+        const timeoutError = new Error(
+            `Runtime context hydration timed out after ${RUNTIME_CONTEXT_TIMEOUT_MS}ms`,
+        );
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        const deadline = new Promise<never>((_resolve, reject) => {
+            timeout = setTimeout(() => {
+                controller.abort(timeoutError);
+                reject(timeoutError);
+            }, RUNTIME_CONTEXT_TIMEOUT_MS);
+        });
         try {
-            const outputs = await submitQuery(
-                {
-                    fqn: 'com.datadoghq.datatransformation.jsFunctionWithActions',
-                    inputs: {
-                        script: RUNTIME_CONTEXT_SCRIPT,
-                        allowedConnectionIds: [],
-                        context: {},
+            // The request signal cancels active fetches and our own retry delays. Racing the whole
+            // operation also releases the local-execution queue if doRequest is already sleeping
+            // inside async-retry, whose backoff timer does not observe AbortSignal. Promise.race
+            // keeps observing submitQuery's eventual settlement after the deadline wins.
+            const outputs = await Promise.race([
+                submitQuery(
+                    {
+                        fqn: 'com.datadoghq.datatransformation.jsFunctionWithActions',
+                        inputs: {
+                            script: RUNTIME_CONTEXT_SCRIPT,
+                            allowedConnectionIds: [],
+                            context: {},
+                        },
                     },
-                },
-                RUNTIME_CONTEXT_DISPLAY_NAME,
-                auth,
-                doAuthenticatedRequest,
-                longPolling,
-                log,
-                controller.signal,
-            );
+                    RUNTIME_CONTEXT_DISPLAY_NAME,
+                    auth,
+                    doAuthenticatedRequest,
+                    longPolling,
+                    log,
+                    controller.signal,
+                ),
+                deadline,
+            ]);
 
             if (typeof outputs !== 'object' || outputs === null || !('data' in outputs)) {
                 throw new Error(
@@ -313,7 +323,9 @@ function makeGetRuntimeContextRemotely(
             }
             throw error;
         } finally {
-            clearTimeout(timeout);
+            if (timeout !== undefined) {
+                clearTimeout(timeout);
+            }
         }
     };
 }

--- a/packages/plugins/apps/src/vite/dev-server.ts
+++ b/packages/plugins/apps/src/vite/dev-server.ts
@@ -20,7 +20,7 @@ import type { LongPollingOptions } from '../types';
 import { createBackendConnectionIdCollector } from './backend-connection-id-collector';
 import { createBackendStaticChecksPlugin } from './backend-static-checks-plugin';
 import { getBaseBackendBuildConfig } from './build-config';
-import type { ExecuteAction, LoadModule } from './local-execution';
+import type { ExecuteAction, GetRuntimeContext, LoadModule } from './local-execution';
 import { DEFAULT_TIMEOUT_MS, executeColdActionLocally } from './local-execution';
 import { getMaxRetryDelayMs } from './retry-delay';
 
@@ -36,9 +36,26 @@ const DEV_VIRTUAL_PREFIX = 'virtual:dd-backend-dev:';
 type AuthConfig = AuthOptionsWithDefaults;
 type LongPollingConfig = Required<LongPollingOptions>;
 
-function delay(ms: number): Promise<void> {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
+const RUNTIME_CONTEXT_SCRIPT = `export async function main($) {
+    return $;
+}`;
+const RUNTIME_CONTEXT_DISPLAY_NAME = 'Datadog Apps local runtime context';
+const RUNTIME_CONTEXT_TIMEOUT_MS = 60_000;
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            signal?.removeEventListener('abort', onAbort);
+            resolve();
+        }, ms);
+        const onAbort = () => {
+            clearTimeout(timer);
+            reject(signal?.reason);
+        };
+        signal?.addEventListener('abort', onAbort, { once: true });
+        if (signal?.aborted) {
+            onAbort();
+        }
     });
 }
 
@@ -166,6 +183,7 @@ async function submitQuery(
     doAuthenticatedRequest: DoAuthenticatedRequest,
     longPolling: LongPollingConfig,
     log: Logger,
+    signal?: AbortSignal,
 ): Promise<unknown> {
     const endpoint = `https://api.${auth.site}/api/v2/app-builder/queries/preview-async`;
 
@@ -193,6 +211,7 @@ async function submitQuery(
         url: endpoint,
         method: 'POST',
         type: 'json',
+        signal,
         getData: () => ({
             data: body,
             headers: { 'Content-Type': 'application/json' },
@@ -207,7 +226,7 @@ async function submitQuery(
 
     log.debug(`Query execution started with receipt: ${receiptId}`);
 
-    return pollQueryExecution(receiptId, auth, doAuthenticatedRequest, longPolling, log);
+    return pollQueryExecution(receiptId, auth, doAuthenticatedRequest, longPolling, log, signal);
 }
 
 /** Executes a script via Datadog's app-builder queries API — the production round trip, wrapping the whole script as a `jsFunctionWithActions` query. */
@@ -242,6 +261,61 @@ async function executeScriptViaDatadog(
         throw new Error('Query execution completed without a "data" field in its outputs');
     }
     return outputs;
+}
+
+/**
+ * Resolves the serializable `$` context exposed by an authenticated preview execution. The
+ * platform response is deliberately kept opaque here; local-execution validates the identity
+ * fields it needs before loading customer code and overlays invocation-owned fields locally.
+ */
+function makeGetRuntimeContextRemotely(
+    auth: AuthConfig,
+    doAuthenticatedRequest: DoAuthenticatedRequest,
+    longPolling: LongPollingConfig,
+    log: Logger,
+): GetRuntimeContext {
+    return async () => {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => {
+            controller.abort(
+                new Error(
+                    `Runtime context hydration timed out after ${RUNTIME_CONTEXT_TIMEOUT_MS}ms`,
+                ),
+            );
+        }, RUNTIME_CONTEXT_TIMEOUT_MS);
+        try {
+            const outputs = await submitQuery(
+                {
+                    fqn: 'com.datadoghq.datatransformation.jsFunctionWithActions',
+                    inputs: {
+                        script: RUNTIME_CONTEXT_SCRIPT,
+                        allowedConnectionIds: [],
+                        context: {},
+                    },
+                },
+                RUNTIME_CONTEXT_DISPLAY_NAME,
+                auth,
+                doAuthenticatedRequest,
+                longPolling,
+                log,
+                controller.signal,
+            );
+
+            if (typeof outputs !== 'object' || outputs === null || !('data' in outputs)) {
+                throw new Error(
+                    'Runtime context hydration completed without a "data" field in its outputs',
+                );
+            }
+            return outputs.data;
+        } catch (error: unknown) {
+            if (controller.signal.aborted) {
+                throw controller.signal.reason;
+            }
+            throw error;
+        } finally {
+            clearTimeout(timeout);
+        }
+    };
 }
 
 /** Submits a single-action `preview-async` query per `$.Actions` call and logs its result/error, since production's equivalent signal never reaches the `npm run dev` console. Callers must have already confirmed auth is configured (see `createDevServerMiddleware`). */
@@ -292,6 +366,7 @@ async function pollQueryExecution(
     doAuthenticatedRequest: DoAuthenticatedRequest,
     longPolling: LongPollingConfig,
     log: Logger,
+    signal?: AbortSignal,
 ): Promise<unknown> {
     const endpoint = `https://api.${auth.site}/api/v2/app-builder/queries/execution-long-polling/${receiptId}`;
     const { maxRetries, timeoutMs } = longPolling;
@@ -300,20 +375,27 @@ async function pollQueryExecution(
         if (attempt > 0) {
             const retryDelay = getRetryDelay(attempt, longPolling);
             log.debug(`Waiting ${Math.round(retryDelay)}ms before long-poll retry...`);
-            await delay(retryDelay);
+            await delay(retryDelay, signal);
         }
 
         log.debug(`Long-poll attempt ${attempt + 1}/${maxRetries}...`);
 
         let result: PollResult;
         try {
+            const attemptTimeoutSignal = AbortSignal.timeout(timeoutMs);
+            const requestSignal = signal
+                ? AbortSignal.any([signal, attemptTimeoutSignal])
+                : attemptTimeoutSignal;
             result = await doAuthenticatedRequest<PollResult>({
                 url: endpoint,
                 type: 'json',
                 // Bounds the whole call, doRequest's internal retries included.
-                signal: AbortSignal.timeout(timeoutMs),
+                signal: requestSignal,
             });
         } catch (error: unknown) {
+            if (signal?.aborted) {
+                throw signal.reason;
+            }
             // A stall is recoverable: the receipt stays valid, so poll again.
             if (!isAbortError(error)) {
                 throw error;
@@ -486,11 +568,18 @@ async function handleExecuteAction(
             longPolling,
             log,
         );
+        const getRuntimeContext = makeGetRuntimeContextRemotely(
+            auth,
+            doAuthenticatedRequest,
+            longPolling,
+            log,
+        );
         const result = await executeColdActionLocally(
             func,
             projectRoot,
             args,
             executeAction,
+            getRuntimeContext,
             loadModule,
             getAllowedConnectionIds,
             log,

--- a/packages/plugins/apps/src/vite/local-execution.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.test.ts
@@ -4,6 +4,7 @@
 
 /* global globalThis, NodeJS */
 
+import type { Logger } from '@dd/core/types';
 import { mockLogFn, mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
 
 import * as shared from '../backend/shared';
@@ -13,8 +14,9 @@ import { LOCAL_EXECUTION_LOAD_SUFFIX } from '../constants';
 import type { ExecuteAction, LoadModule } from './local-execution';
 import {
     DEFAULT_LONG_POLLING_CONFIG,
+    DEFAULT_TIMEOUT_MS,
     deriveActionTimeouts,
-    executeScriptLocally,
+    executeScriptLocally as executeScriptLocallyWithRuntimeContext,
 } from './local-execution';
 
 const func: BackendFunction = {
@@ -33,6 +35,7 @@ interface TestGlobalDollar {
     // Left untyped: $.Actions is a Proxy of unbounded, dynamic depth ($.Actions.<any>.<any>...(...)), the same shape a real customer's untyped code sees.
     Actions: any;
     Source: { initiator: { id: string; orgId: string }; runAsUser: { id: string; orgId: string } };
+    previewMetadata?: unknown;
 }
 
 /** Reads the `$` local-execution.ts installs onto `globalThis` via `Object.defineProperty` — genuinely untyped, so the cast is centralized here instead of repeated at each call site. */
@@ -47,6 +50,42 @@ beforeEach(() => {
 });
 
 const stubExecuteAction: ExecuteAction = async (fqn) => ({ data: null, stub: true, fqn });
+
+function makeRuntimeContext() {
+    return {
+        Source: {
+            initiator: { id: 'preview-initiator', orgId: 'preview-org' },
+            runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
+        },
+    };
+}
+
+/** Keeps the existing test call sites concise while every invocation receives a fresh preview context. */
+function executeScriptLocally(
+    backendFunction: BackendFunction,
+    projectRoot: string,
+    args: unknown[],
+    executeAction: ExecuteAction,
+    loadModule: LoadModule,
+    log: Logger,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+    primedEntry?: Record<string, unknown>,
+    longPolling = DEFAULT_LONG_POLLING_CONFIG,
+) {
+    const getRuntimeContext = async () => makeRuntimeContext();
+    return executeScriptLocallyWithRuntimeContext(
+        backendFunction,
+        projectRoot,
+        args,
+        executeAction,
+        getRuntimeContext,
+        loadModule,
+        log,
+        timeoutMs,
+        primedEntry,
+        longPolling,
+    );
+}
 
 /** A `loadModule` double that resolves the customer's function from a map and rejects anything else with a module-not-found error, matching the common case where neither optional package is installed. */
 function loadModuleReturning(exports: Record<string, unknown>): LoadModule {
@@ -136,7 +175,7 @@ describe('local-execution — executeScriptLocally', () => {
         const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, '$');
         const preExisting = { fromZxGlobals: true };
         (globalThis as Record<string, unknown>).$ = preExisting;
-        let isolatedExecuteScriptLocally!: typeof executeScriptLocally;
+        let isolatedExecuteScriptLocally!: typeof executeScriptLocallyWithRuntimeContext;
         try {
             jest.isolateModules(() => {
                 // A fresh module instance re-runs its Reflect.has check with preExisting already set; the outer instance was imported too early to exercise this path.
@@ -157,6 +196,7 @@ describe('local-execution — executeScriptLocally', () => {
                 TEST_PROJECT_ROOT,
                 [],
                 stubExecuteAction,
+                async () => makeRuntimeContext(),
                 loadModule,
                 mockLogger,
             );
@@ -600,9 +640,13 @@ describe('local-execution — executeScriptLocally', () => {
             );
 
             const { totalExecutionTimeoutMs } = deriveActionTimeouts(DEFAULT_LONG_POLLING_CONFIG);
-            const hungAssertion = expect(hungExecution).rejects.toThrow(
-                new RegExp(`exceeded the absolute ${totalExecutionTimeoutMs}ms execution ceiling`),
-            );
+            const hungAssertion = (async () => {
+                await expect(hungExecution).rejects.toThrow(
+                    new RegExp(
+                        `exceeded the absolute ${totalExecutionTimeoutMs}ms execution ceiling`,
+                    ),
+                );
+            })();
 
             await jest.runAllTimersAsync();
             await hungAssertion;
@@ -637,9 +681,13 @@ describe('local-execution — executeScriptLocally', () => {
             );
 
             const { totalExecutionTimeoutMs } = deriveActionTimeouts(DEFAULT_LONG_POLLING_CONFIG);
-            const assertion = expect(execution).rejects.toThrow(
-                new RegExp(`exceeded the absolute ${totalExecutionTimeoutMs}ms execution ceiling`),
-            );
+            const assertion = (async () => {
+                await expect(execution).rejects.toThrow(
+                    new RegExp(
+                        `exceeded the absolute ${totalExecutionTimeoutMs}ms execution ceiling`,
+                    ),
+                );
+            })();
 
             await jest.advanceTimersByTimeAsync(totalExecutionTimeoutMs);
             await assertion;
@@ -711,19 +759,38 @@ describe('local-execution — executeScriptLocally', () => {
         ).rejects.toThrow(/timed out after 50ms/);
     });
 
-    // Asserts $'s exact key set, since a token added inside globalThis.$ wouldn't be caught by the weaker top-level check below.
-    test('Should never expose an auth token to the customer module — only backendFunctionArgs, Actions, and Source are visible on globalThis.$', async () => {
-        const result = await executeScriptLocally(
+    test('Should preserve preview context fields while overriding invocation-owned args and Actions', async () => {
+        const getRuntimeContext = async () => ({
+            ...makeRuntimeContext(),
+            previewMetadata: { requestId: 'preview-request' },
+            backendFunctionArgs: ['remote-placeholder'],
+            Actions: 'remote-placeholder',
+        });
+        const result = await executeScriptLocallyWithRuntimeContext(
             func,
             TEST_PROJECT_ROOT,
-            [],
+            ['local-argument'],
             stubExecuteAction,
+            getRuntimeContext,
             loadModuleReturning({
-                example: () => Object.keys(testDollar()).sort(),
+                example: () => {
+                    const dollar = testDollar();
+                    return {
+                        args: dollar.backendFunctionArgs,
+                        previewMetadata: dollar.previewMetadata,
+                        actionsIsRemotePlaceholder: dollar.Actions === 'remote-placeholder',
+                    };
+                },
             }),
             mockLogger,
         );
-        expect(result).toEqual({ data: ['Actions', 'Source', 'backendFunctionArgs'] });
+        expect(result).toEqual({
+            data: {
+                args: ['local-argument'],
+                previewMetadata: { requestId: 'preview-request' },
+                actionsIsRemotePlaceholder: false,
+            },
+        });
     });
 
     test('Should never expose an auth token via globalThis, including nested inside $.Source', async () => {
@@ -754,7 +821,7 @@ describe('local-execution — executeScriptLocally', () => {
         expect(result).toEqual({ data: false });
     });
 
-    test('Should populate $.Source with a synthetic local-dev identity, reachable via globalThis.$', async () => {
+    test('Should populate $.Source with the preview identity, reachable via globalThis.$', async () => {
         const result = await executeScriptLocally(
             func,
             TEST_PROJECT_ROOT,
@@ -765,10 +832,35 @@ describe('local-execution — executeScriptLocally', () => {
         );
         expect(result).toEqual({
             data: {
-                initiator: { id: 'local-dev', orgId: 'local-dev-org' },
-                runAsUser: { id: 'local-dev', orgId: 'local-dev-org' },
+                initiator: { id: 'preview-initiator', orgId: 'preview-org' },
+                runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
             },
         });
+    });
+
+    test('Should reject malformed preview identity before loading the customer module', async () => {
+        const loadModule = jest.fn();
+        const getRuntimeContext = async () => ({
+            Source: {
+                initiator: { id: 'missing-org' },
+                runAsUser: { id: 'run-as', orgId: 'preview-org' },
+            },
+        });
+
+        await expect(
+            executeScriptLocallyWithRuntimeContext(
+                func,
+                TEST_PROJECT_ROOT,
+                [],
+                stubExecuteAction,
+                getRuntimeContext,
+                loadModule,
+                mockLogger,
+            ),
+        ).rejects.toThrow(
+            'The preview runtime context Source.initiator must have a non-empty string "orgId" field.',
+        );
+        expect(loadModule).not.toHaveBeenCalled();
     });
 
     test("Should give each execution its own $.Source object, so one execution mutating it can't corrupt a later execution's identity", async () => {
@@ -797,8 +889,8 @@ describe('local-execution — executeScriptLocally', () => {
         );
         expect(second).toEqual({
             data: {
-                initiator: { id: 'local-dev', orgId: 'local-dev-org' },
-                runAsUser: { id: 'local-dev', orgId: 'local-dev-org' },
+                initiator: { id: 'preview-initiator', orgId: 'preview-org' },
+                runAsUser: { id: 'preview-run-as', orgId: 'preview-org' },
             },
         });
     });

--- a/packages/plugins/apps/src/vite/local-execution.ts
+++ b/packages/plugins/apps/src/vite/local-execution.ts
@@ -18,10 +18,23 @@ import { resolveLongPolling } from '../validate';
 import { createEpochGuard } from './execution-epoch';
 import { getTotalRetryDelayBudgetMs } from './retry-delay';
 
-type BackendGlobals = {
+type RuntimeUser = {
+    id: string;
+    orgId: string;
+    email?: string | null;
+    name?: string | null;
+};
+
+export type RuntimeContext = Record<string, unknown> & {
+    Source: {
+        initiator: RuntimeUser;
+        runAsUser: RuntimeUser;
+    };
+};
+
+type BackendGlobals = RuntimeContext & {
     backendFunctionArgs: unknown[];
     Actions: unknown;
-    Source: ReturnType<typeof makeLocalDevSource>;
 };
 
 /** Boxed so a customer module assigning to `globalThis.$` (e.g. `zx/globals`) mutates only its own execution's box, never a concurrent or zombie execution's. */
@@ -114,6 +127,45 @@ function isIndexableRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
 }
 
+function assertRuntimeUser(value: unknown, label: string): asserts value is RuntimeUser {
+    if (!isIndexableRecord(value) || Array.isArray(value)) {
+        throw new Error(`The preview runtime context ${label} must be an object.`);
+    }
+    if (typeof value.id !== 'string' || value.id.length === 0) {
+        throw new Error(
+            `The preview runtime context ${label} must have a non-empty string "id" field.`,
+        );
+    }
+    if (typeof value.orgId !== 'string' || value.orgId.length === 0) {
+        throw new Error(
+            `The preview runtime context ${label} must have a non-empty string "orgId" field.`,
+        );
+    }
+    if (value.email !== undefined && value.email !== null && typeof value.email !== 'string') {
+        throw new Error(
+            `The preview runtime context ${label} must have a string "email" field when provided.`,
+        );
+    }
+    if (value.name !== undefined && value.name !== null && typeof value.name !== 'string') {
+        throw new Error(
+            `The preview runtime context ${label} must have a string "name" field when provided.`,
+        );
+    }
+}
+
+/** Validates the identity-bearing minimum of the preview-provided `$` snapshot before any customer module is loaded. */
+export function assertValidRuntimeContext(value: unknown): asserts value is RuntimeContext {
+    if (!isIndexableRecord(value) || Array.isArray(value)) {
+        throw new Error('The preview runtime context must be an object.');
+    }
+    const source = value.Source;
+    if (!isIndexableRecord(source) || Array.isArray(source)) {
+        throw new Error('The preview runtime context must have a "Source" object.');
+    }
+    assertRuntimeUser(source.initiator, 'Source.initiator');
+    assertRuntimeUser(source.runAsUser, 'Source.runAsUser');
+}
+
 export const DEFAULT_TIMEOUT_MS = 10_000;
 
 type LongPollingConfig = Required<LongPollingOptions>;
@@ -167,13 +219,8 @@ export type ExecuteAction = (
     connectionId: string | undefined,
 ) => Promise<unknown>;
 
-/** Synthetic local-dev identity for `$.Source` — a fresh object per call, since customer code could otherwise mutate a shared singleton and corrupt every later execution's identity. */
-function makeLocalDevSource() {
-    return {
-        initiator: { id: 'local-dev', orgId: 'local-dev-org' },
-        runAsUser: { id: 'local-dev', orgId: 'local-dev-org' },
-    };
-}
+/** Resolves a fresh serializable `$` snapshot from an authenticated preview execution. */
+export type GetRuntimeContext = () => Promise<unknown>;
 
 /** Mirrors the cloud path's server-side allowedConnectionIds restriction, so local dev enforces the same connection scoping as production. */
 function assertConnectionIdAllowed(
@@ -514,25 +561,29 @@ export async function executeScriptLocally(
     projectRoot: string,
     args: unknown[],
     executeAction: ExecuteAction,
+    getRuntimeContext: GetRuntimeContext,
     loadModule: LoadModule,
     log: Logger,
     timeoutMs: number = DEFAULT_TIMEOUT_MS,
     primedEntry?: Record<string, unknown>,
     longPolling: LongPollingConfig = DEFAULT_LONG_POLLING_CONFIG,
 ): Promise<BackendOutputs> {
-    return enqueue(() =>
-        runScriptLocally(
+    return enqueue(async () => {
+        const runtimeContext = await getRuntimeContext();
+        assertValidRuntimeContext(runtimeContext);
+        return runScriptLocally(
             func,
             projectRoot,
             args,
             executeAction,
+            runtimeContext,
             loadModule,
             log,
             timeoutMs,
             primedEntry,
             longPolling,
-        ),
-    );
+        );
+    });
 }
 
 /**
@@ -546,6 +597,7 @@ export async function executeColdActionLocally(
     projectRoot: string,
     args: unknown[],
     executeAction: ExecuteAction,
+    getRuntimeContext: GetRuntimeContext,
     loadModule: LoadModule,
     getAllowedConnectionIds: (entryId: string) => Promise<string[]>,
     log: Logger,
@@ -554,6 +606,8 @@ export async function executeColdActionLocally(
 ): Promise<BackendOutputs> {
     const displayName = `${func.relativePath}/${func.name}`;
     return enqueue(async () => {
+        const runtimeContext = await getRuntimeContext();
+        assertValidRuntimeContext(runtimeContext);
         // Each step needs its own timeout bound independent of runScriptLocally's, which only
         // starts once its body begins.
         const connectionIdsPromise = getAllowedConnectionIds(func.absolutePath);
@@ -575,6 +629,7 @@ export async function executeColdActionLocally(
             projectRoot,
             args,
             executeAction,
+            runtimeContext,
             loadModule,
             log,
             timeoutMs,
@@ -589,6 +644,7 @@ async function runScriptLocally(
     projectRoot: string,
     args: unknown[],
     executeAction: ExecuteAction,
+    runtimeContext: RuntimeContext,
     loadModule: LoadModule,
     log: Logger,
     timeoutMs: number,
@@ -664,10 +720,14 @@ async function runScriptLocally(
         scope.concludeIfCurrent();
     };
 
-    const $ = {
+    // The preview response is the same context already available to cloud backend code, but it
+    // belongs to a bootstrap invocation. The platform owns that context's safe-field contract;
+    // this executor never merges its API/App keys or OAuth token. Target-invocation-owned values
+    // are always replaced locally.
+    const $: BackendGlobals = {
+        ...runtimeContext,
         backendFunctionArgs: args,
         Actions: makeActionsProxy(guardedExecuteAction, func.allowedConnectionIds),
-        Source: makeLocalDevSource(),
     };
 
     const dispatch: ExecutionDispatch = {


### PR DESCRIPTION
### What and why?

Local Apps backend execution currently synthesizes `$.Source` with `local-dev` identities. As a result, `getInitiatingUser()` and `getExecutionUser()` cannot exercise organization-aware code during `npm run dev`.

Hydrate local backend executions with the serializable `$` context returned by an authenticated App Builder preview. This gives backend SDK helpers the real preview user and organization while keeping backend functions themselves in the fast local execution path.

This intentionally models the authenticated preview identity. Because the bootstrap preview is not tied to a published app's execution policy, it does not model an app-specific service-account run-as identity.

### How?

- Execute a fixed, connection-free `return $` JavaScript preview before each local backend invocation.
- Validate the returned `Source.initiator` and `Source.runAsUser` identities before loading customer code.
- Preserve other serializable preview context fields, then override `Actions` and `backendFunctionArgs` with the local invocation-owned values.
- Keep hydration inside the existing global local-execution queue so context cannot leak between concurrent or abandoned executions.
- Apply a 60-second end-to-end hydration deadline across submission, retry delays, and long polling so a stalled preview cannot wedge subsequent executions.
- Keep API, application, and OAuth credentials in the authenticated request layer; they are never merged into `$`.

### Verification

- Confirmed an authenticated `return $` preview exposes real `Source.initiator` and `Source.runAsUser` identities and omits the remote `Actions` implementation from the serialized response.
- Verified local execution preserves preview context, overrides invocation-owned fields, rejects malformed identities before module loading, and isolates context mutations between invocations.
- Verified stalled hydration times out and a subsequent queued execution succeeds.
- Verified a real Vite dev server resolves `getInitiatingUser()` and `getExecutionUser()` through `@datadog/apps-backend` using the hydrated preview identities.
- Apps plugin typecheck and changed-file lint pass. The repository-wide integrity check is currently blocked by the existing unresolved `@datadog/rspack-plugin/dist/src` import in `packages/tests/src/bench/liveDebuggerRuntime/preflight-build.js`.
