### PR TITLE
[APPS-2792] Fix: harden env-guard against bypass and reliability gaps

### DIFF
--- a/packages/plugins/apps/src/vite/env-guard.test.ts
+++ b/packages/plugins/apps/src/vite/env-guard.test.ts
@@ -348,29 +348,32 @@ describe('env-guard', () => {
 
         // Reflect.get throws for a non-object value, and isEnvProxy() is the setter's first check on
         // whatever gets assigned — without its own object/null guard, `process.env = null` (or
-        // undefined) would surface as an unhandled native TypeError instead of either this file's own
-        // clear rejection message (from inside a scope) or a graceful no-op (from outside one).
-        test('Should not throw a native TypeError when process.env is reassigned to null or undefined', () => {
-            // Each reassignment restored individually, not both bundled under one final restore:
-            // each is its own real reassignment, and a single self-assignment only undoes the one
-            // immediately before it.
-            const beforeNull = process.env;
-            try {
-                expect(() => {
-                    process.env = null as unknown as NodeJS.ProcessEnv;
-                }).not.toThrow();
-            } finally {
-                process.env = beforeNull;
-            }
+        // undefined) would surface as an unhandled native TypeError instead of this file's own clear
+        // rejection message.
+        test('Should reject reassigning process.env to null or undefined with a clear error, not a native TypeError', () => {
+            const originalPath = process.env.PATH;
 
-            const beforeUndefined = process.env;
-            try {
-                expect(() => {
-                    process.env = undefined as unknown as NodeJS.ProcessEnv;
-                }).not.toThrow();
-            } finally {
-                process.env = beforeUndefined;
-            }
+            expect(() => {
+                process.env = null as unknown as NodeJS.ProcessEnv;
+            }).toThrow(/process\.env/i);
+            expect(() => {
+                process.env = undefined as unknown as NodeJS.ProcessEnv;
+            }).toThrow(/process\.env/i);
+
+            expect(process.env.PATH).toBe(originalPath);
+        });
+
+        // A number or string reassigned to process.env would corrupt realEnv the same way
+        // null/undefined does, so the guard covers every non-object primitive, not just the two
+        // nullish ones.
+        test('Should reject reassigning process.env to a primitive (e.g. a number), not corrupt the real environment', () => {
+            const originalPath = process.env.PATH;
+
+            expect(() => {
+                process.env = 1 as unknown as NodeJS.ProcessEnv;
+            }).toThrow(/process\.env/i);
+
+            expect(process.env.PATH).toBe(originalPath);
         });
 
         // Regression coverage: this file gets evaluated more than once in practice (Jest's
@@ -451,6 +454,19 @@ describe('env-guard', () => {
             process.env.POST_ATTEMPT_KEY = 'still-writable';
             expect(process.env.POST_ATTEMPT_KEY).toBe('still-writable');
             delete process.env.POST_ATTEMPT_KEY;
+        });
+
+        // A non-configurable definition can never satisfy the Proxy invariant against
+        // INERT_PROXY_TARGET (always empty), so it must throw a clear, guard-specific error rather
+        // than a cryptic native Proxy TypeError — even outside any scope, since the target is
+        // permanently empty regardless of scope state.
+        test('Should throw a clear error for Object.defineProperty(process.env, key, { configurable: false })', () => {
+            expect(() =>
+                Object.defineProperty(process.env, 'LOCKED_KEY', {
+                    value: 'x',
+                    configurable: false,
+                }),
+            ).toThrow(/non-configurable/);
         });
     });
 
@@ -829,6 +845,54 @@ describe('env-guard', () => {
             });
         });
 
+        // fs.openAsBlob is its own entry point, separate from open*/readFile* above, so it needs its
+        // own guard coverage.
+        describe('fs.openAsBlob guard', () => {
+            test('Should block fs.openAsBlob("/proc/self/environ") during an active scoped-env window', async () => {
+                await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                    await expect(fs.openAsBlob('/proc/self/environ')).rejects.toThrow(
+                        /not allowed in backend functions/,
+                    );
+                });
+            });
+
+            test('Should not block fs.openAsBlob for an unrelated real file during an active scoped-env window', async () => {
+                const tmpFile = path.join(
+                    os.tmpdir(),
+                    `env-guard-openasblob-ok-${process.pid}.txt`,
+                );
+                fs.writeFileSync(tmpFile, 'hello world');
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        const blob = await fs.openAsBlob(tmpFile);
+                        await expect(blob.text()).resolves.toBe('hello world');
+                    });
+                } finally {
+                    fs.rmSync(tmpFile, { force: true });
+                }
+            });
+
+            // Deleting fs.openAsBlob and re-evaluating the module simulates Node 18, which has no
+            // fs.openAsBlob, matching the feature-detection in packages/core/src/helpers/fs.ts's
+            // getFile().
+            test('Should leave fs.openAsBlob undefined, not replace it with a broken wrapper, when the real function is absent', () => {
+                const originalOpenAsBlob = fs.openAsBlob;
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                delete (fs as any).openAsBlob;
+                try {
+                    expect(() => {
+                        jest.isolateModules(() => {
+                            // eslint-disable-next-line @typescript-eslint/no-require-imports
+                            require('./env-guard');
+                        });
+                    }).not.toThrow();
+                    expect(fs.openAsBlob).toBeUndefined();
+                } finally {
+                    fs.openAsBlob = originalOpenAsBlob;
+                }
+            });
+        });
+
         test('Should block a Buffer or URL path pointing at /proc/self/environ, not just a string path', async () => {
             await runWithScopedEnv({ PATH: '/scoped' }, async () => {
                 const environPathAsBuffer = Buffer.from('/proc/self/environ');
@@ -1142,6 +1206,14 @@ describe('env-guard', () => {
             }
         });
 
+        // A malformed fs.cp call throws synchronously from Node's own argument validation, not from
+        // the guard, so it must propagate unguarded like every other entry point here.
+        test('Should let a malformed fs.cp call (no callback) throw synchronously, not swallow the error', () => {
+            expect(() => {
+                (fs.cp as unknown as (src: string, dest: string) => void)('/tmp', '/tmp/x');
+            }).toThrow(/must be of type function/i);
+        });
+
         // new fs.ReadStream(path) constructs directly, bypassing the createReadStream factory the
         // guard above wraps, so it needs separate coverage. @types/node declares no (path, options)
         // constructor for ReadStream, so Reflect.construct invokes the real, untyped signature
@@ -1177,6 +1249,144 @@ describe('env-guard', () => {
                 stream?.destroy();
                 fs.rmSync(tmpFile);
             }
+        });
+
+        // fs.FileReadStream is a real, long-deprecated alias for fs.ReadStream — a separate property
+        // slot that must be re-pointed at the same wrapped class, or constructing through this name
+        // bypasses the guard above entirely.
+        describe('fs.FileReadStream alias guard', () => {
+            function constructFileReadStream(rawPath: string): fs.ReadStream {
+                const stream: fs.ReadStream = Reflect.construct(fs.FileReadStream, [rawPath]);
+                stream.on('error', () => {});
+                return stream;
+            }
+
+            test('Should block constructing new fs.FileReadStream("/proc/self/environ") during an active scoped-env window', async () => {
+                await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                    expect(() => constructFileReadStream('/proc/self/environ')).toThrow(
+                        /not allowed in backend functions/,
+                    );
+                });
+            });
+
+            test('Should not block constructing new fs.FileReadStream(...) for an unrelated real file during an active scoped-env window', async () => {
+                const tmpFile = path.join(
+                    os.tmpdir(),
+                    `env-guard-filereadstream-${process.pid}.txt`,
+                );
+                fs.writeFileSync(tmpFile, 'not a secret');
+                let stream: fs.ReadStream | undefined;
+
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        expect(() => {
+                            stream = constructFileReadStream(tmpFile);
+                        }).not.toThrow();
+                    });
+                } finally {
+                    stream?.destroy();
+                    fs.rmSync(tmpFile);
+                }
+            });
+        });
+
+        // fs.read/readSync/readv/readvSync take an fd directly, the same case toPathString()'s
+        // /proc/self/fd resolution already covers elsewhere — mocked here so that resolution runs
+        // on every OS, not just Linux.
+        describe('fd-based read guard (fs.read/readSync/readv/readvSync)', () => {
+            function mockFdResolvesToEnviron(fd: number): () => void {
+                const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+                Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+                const readlinkSyncSpy = jest
+                    .spyOn(fs, 'readlinkSync')
+                    .mockImplementation((linkPath) => {
+                        expect(linkPath).toBe(`/proc/self/fd/${fd}`);
+                        return '/proc/self/environ';
+                    });
+                reEvaluateEnvGuardWithCurrentMocks();
+                return () => {
+                    readlinkSyncSpy.mockRestore();
+                    if (platformDescriptor) {
+                        Object.defineProperty(process, 'platform', platformDescriptor);
+                    }
+                };
+            }
+
+            test('Should block fs.readSync(fd) when fd resolves to /proc/self/environ', async () => {
+                const restore = mockFdResolvesToEnviron(99);
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        expect(() => fs.readSync(99, Buffer.alloc(10), 0, 10, 0)).toThrow(
+                            /not allowed in backend functions/,
+                        );
+                    });
+                } finally {
+                    restore();
+                }
+            });
+
+            test('Should block the callback-style fs.read(fd) via its callback, not a synchronous throw, when fd resolves to /proc/self/environ', async () => {
+                const restore = mockFdResolvesToEnviron(99);
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        const error = await callbackError((callback) =>
+                            fs.read(99, Buffer.alloc(10), 0, 10, 0, callback),
+                        );
+                        expect(error).toBeInstanceOf(Error);
+                        expect((error as Error).message).toMatch(
+                            /not allowed in backend functions/,
+                        );
+                    });
+                } finally {
+                    restore();
+                }
+            });
+
+            test('Should block fs.readvSync(fd) when fd resolves to /proc/self/environ', async () => {
+                const restore = mockFdResolvesToEnviron(99);
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        expect(() => fs.readvSync(99, [Buffer.alloc(10)])).toThrow(
+                            /not allowed in backend functions/,
+                        );
+                    });
+                } finally {
+                    restore();
+                }
+            });
+
+            test('Should block the callback-style fs.readv(fd) via its callback, not a synchronous throw, when fd resolves to /proc/self/environ', async () => {
+                const restore = mockFdResolvesToEnviron(99);
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        const error = await callbackError((callback) =>
+                            fs.readv(99, [Buffer.alloc(10)], callback),
+                        );
+                        expect(error).toBeInstanceOf(Error);
+                        expect((error as Error).message).toMatch(
+                            /not allowed in backend functions/,
+                        );
+                    });
+                } finally {
+                    restore();
+                }
+            });
+
+            test('Should not block fs.readSync/readvSync for an unrelated real fd during an active scoped-env window', async () => {
+                const tmpFile = path.join(os.tmpdir(), `env-guard-read-fd-${process.pid}.txt`);
+                fs.writeFileSync(tmpFile, 'hello world');
+                const fd = fs.openSync(tmpFile, 'r');
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        const buffer = Buffer.alloc(5);
+                        expect(fs.readSync(fd, buffer, 0, 5, 0)).toBe(5);
+                        expect(buffer.toString('utf8')).toBe('hello');
+                    });
+                } finally {
+                    fs.closeSync(fd);
+                    fs.rmSync(tmpFile, { force: true });
+                }
+            });
         });
 
         // FileHandle isn't part of Node's public API, so ensureFileHandleReadGuarded patches its
@@ -1533,6 +1743,186 @@ describe('env-guard', () => {
                     fs.rmSync(tmpFile, { force: true });
                 }
             });
+        });
+
+        // fs.cpSync's recursive copy calls neither fs.copyFileSync nor fs.readFileSync — Node's
+        // internal traversal never re-enters the wrapped entry points above, so a symlink inside the
+        // copied tree pointing at /proc/.../environ would have its real content copied to an
+        // unguarded destination with no guard ever seeing it.
+        describe('cp recursive+dereference guard', () => {
+            test('Should block fs.cpSync/fs.cp/fs.promises.cp with recursive+dereference during an active scoped-env window', async () => {
+                const srcDir = path.join(os.tmpdir(), `env-guard-cp-recursive-src-${process.pid}`);
+                const destDir = path.join(
+                    os.tmpdir(),
+                    `env-guard-cp-recursive-dest-${process.pid}`,
+                );
+                fs.mkdirSync(srcDir, { recursive: true });
+                fs.writeFileSync(path.join(srcDir, 'a.txt'), 'not a secret');
+
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        expect(() =>
+                            fs.cpSync(srcDir, destDir, { recursive: true, dereference: true }),
+                        ).toThrow(/not allowed in backend functions/);
+
+                        const error = await callbackError((callback) =>
+                            fs.cp(
+                                srcDir,
+                                destDir,
+                                { recursive: true, dereference: true },
+                                callback,
+                            ),
+                        );
+                        expect(error).toBeInstanceOf(Error);
+                        expect((error as Error).message).toMatch(
+                            /not allowed in backend functions/,
+                        );
+
+                        await expect(
+                            fs.promises.cp(srcDir, destDir, {
+                                recursive: true,
+                                dereference: true,
+                            }),
+                        ).rejects.toThrow(/not allowed in backend functions/);
+                    });
+                } finally {
+                    fs.rmSync(srcDir, { recursive: true, force: true });
+                    fs.rmSync(destDir, { recursive: true, force: true });
+                }
+            });
+
+            test('Should not block a recursive copy WITHOUT dereference during an active scoped-env window', async () => {
+                const srcDir = path.join(os.tmpdir(), `env-guard-cp-plain-src-${process.pid}`);
+                const destDir = path.join(os.tmpdir(), `env-guard-cp-plain-dest-${process.pid}`);
+                fs.mkdirSync(srcDir, { recursive: true });
+                fs.writeFileSync(path.join(srcDir, 'a.txt'), 'not a secret');
+
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        expect(() => fs.cpSync(srcDir, destDir, { recursive: true })).not.toThrow();
+                    });
+                    expect(fs.readFileSync(path.join(destDir, 'a.txt'), 'utf8')).toBe(
+                        'not a secret',
+                    );
+                } finally {
+                    fs.rmSync(srcDir, { recursive: true, force: true });
+                    fs.rmSync(destDir, { recursive: true, force: true });
+                }
+            });
+
+            test('Should not block fs.cpSync for a single unrelated file with no recursive option at all', async () => {
+                const srcFile = path.join(
+                    os.tmpdir(),
+                    `env-guard-cp-single-src-${process.pid}.txt`,
+                );
+                const destFile = path.join(
+                    os.tmpdir(),
+                    `env-guard-cp-single-dest-${process.pid}.txt`,
+                );
+                fs.writeFileSync(srcFile, 'not a secret');
+
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        expect(() => fs.cpSync(srcFile, destFile)).not.toThrow();
+                    });
+                    expect(fs.readFileSync(destFile, 'utf8')).toBe('not a secret');
+                } finally {
+                    fs.rmSync(srcFile, { force: true });
+                    fs.rmSync(destFile, { force: true });
+                }
+            });
+
+            test('Should still block fs.cpSync("/proc/self/environ", dest) via the plain top-level path check', async () => {
+                const dest = path.join(
+                    os.tmpdir(),
+                    `env-guard-cp-still-blocked-${process.pid}.txt`,
+                );
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        expect(() => fs.cpSync('/proc/self/environ', dest)).toThrow(
+                            /not allowed in backend functions/,
+                        );
+                    });
+                } finally {
+                    fs.rmSync(dest, { force: true });
+                }
+            });
+
+            // The generic makeGuardWrapper machinery forwards a caller's original options object
+            // unchanged — without snapshotting, a getter-backed recursive/dereference could report
+            // false to this check and true when Node's own fs.cp* implementation reads the same
+            // property again internally.
+            test('Should read options.recursive/options.dereference exactly once each, not read again by the real implementation', async () => {
+                const srcDir = path.join(
+                    os.tmpdir(),
+                    `env-guard-cp-recursive-once-src-${process.pid}`,
+                );
+                const destDir = path.join(
+                    os.tmpdir(),
+                    `env-guard-cp-recursive-once-dest-${process.pid}`,
+                );
+                fs.mkdirSync(srcDir, { recursive: true });
+                fs.writeFileSync(path.join(srcDir, 'a.txt'), 'not a secret');
+
+                let recursiveReadCount = 0;
+                let dereferenceReadCount = 0;
+                const options = {
+                    get recursive() {
+                        recursiveReadCount += 1;
+                        return true;
+                    },
+                    get dereference() {
+                        dereferenceReadCount += 1;
+                        return false;
+                    },
+                };
+
+                try {
+                    await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                        expect(() =>
+                            fs.cpSync(srcDir, destDir, options as fs.CopySyncOptions),
+                        ).not.toThrow();
+                    });
+                    expect(fs.readFileSync(path.join(destDir, 'a.txt'), 'utf8')).toBe(
+                        'not a secret',
+                    );
+                    // Exactly 1 each: the guard's own snapshotting read, not a second, independent
+                    // read by the real cp implementation.
+                    expect(recursiveReadCount).toBe(1);
+                    expect(dereferenceReadCount).toBe(1);
+                } finally {
+                    fs.rmSync(srcDir, { recursive: true, force: true });
+                    fs.rmSync(destDir, { recursive: true, force: true });
+                }
+            });
+        });
+
+        // The TOCTOU test above verifies "resolve exactly once" by content; this asserts the
+        // invocation count directly.
+        test('Should read options.fd exactly once, not twice via a stray spread', async () => {
+            const tmpFile = path.join(os.tmpdir(), `env-guard-fd-single-read-${process.pid}.txt`);
+            fs.writeFileSync(tmpFile, 'not a secret');
+            const fd = fs.openSync(tmpFile, 'r');
+            let readCount = 0;
+            const options = {
+                get fd() {
+                    readCount += 1;
+                    return fd;
+                },
+            };
+            let stream: fs.ReadStream | undefined;
+
+            try {
+                await runWithScopedEnv({ PATH: '/scoped' }, async () => {
+                    stream = fs.createReadStream('/some/unrelated/path', options);
+                    stream.on('error', () => {});
+                });
+                expect(readCount).toBe(1);
+            } finally {
+                stream?.destroy();
+                fs.closeSync(fd);
+                fs.rmSync(tmpFile, { force: true });
+            }
         });
     });
 

--- a/packages/plugins/apps/src/vite/env-guard.ts
+++ b/packages/plugins/apps/src/vite/env-guard.ts
@@ -493,6 +493,35 @@ function extractFdNumber(fdValue: unknown): unknown {
     return fdValue;
 }
 
+// Reads each of `keys` from a getter-backed options object exactly once, then rebuilds a plain
+// object where a key absent from the caller's own options stays absent — see guardCpOptions's own
+// comment for why re-adding an absent key as explicit `undefined` breaks Node's own cp validation.
+// Shared by guardEnvironPathOrFdOption (a single always-present key) and guardCpOptions (two
+// independently-optional keys): presence-conditional restore is correct for both, since a
+// guaranteed-present key just never hits the "absent" branch.
+function snapshotOptionKeysOnce<K extends string>(
+    options: Record<string, unknown>,
+    keys: readonly K[],
+): Record<string, unknown> {
+    // Copying every OTHER own-enumerable key first, via Object.keys rather than a `{ ...options }`
+    // spread, is what keeps this to exactly one read per snapshotted key below — a spread of the
+    // full options object would invoke every key's getter once on its own, then a second time when
+    // that same key is explicitly snapshotted next.
+    const keySet = new Set<string>(keys);
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(options)) {
+        if (!keySet.has(key)) {
+            result[key] = options[key];
+        }
+    }
+    for (const key of keys) {
+        if (key in options) {
+            result[key] = options[key];
+        }
+    }
+    return result;
+}
+
 // createReadStream/ReadStream's options.fd (a raw fd number, or a FileHandle whose own .fd is one)
 // makes Node read from that fd directly, ignoring the leading path argument — a plain
 // throwIfBlockedEnvironPath(rawPath) would never see the real target. Returns a safe options
@@ -510,12 +539,9 @@ function guardEnvironPathOrFdOption(rawPath: unknown, options: unknown): unknown
     if (typeof options !== 'object' || options === null || !('fd' in options)) {
         return options;
     }
-    // Destructuring reads the getter exactly once, into fdValue — spreading the remainder (with fd
-    // already removed) can't invoke it again the way `{ ...options, fd: fdValue }` would have.
-    const { fd: fdValue, ...restOptions } = options as { fd: unknown };
-    const fdNumber = extractFdNumber(fdValue);
-    throwIfBlockedEnvironPath(fdNumber);
-    return { ...restOptions, fd: fdValue };
+    const snapshot = snapshotOptionKeysOnce(options as Record<string, unknown>, ['fd'] as const);
+    throwIfBlockedEnvironPath(extractFdNumber(snapshot.fd));
+    return snapshot;
 }
 
 // Every guarded fs entry point below except createReadStream takes only a leading path argument —
@@ -778,26 +804,18 @@ function guardCpOptions(options: unknown): unknown {
     if (typeof options !== 'object' || options === null) {
         return options;
     }
-    const {
-        recursive: recursiveValue,
-        dereference: dereferenceValue,
-        ...restOptions
-    } = options as { recursive?: unknown; dereference?: unknown };
-    if (recursiveValue === true && dereferenceValue === true) {
+    // Node's cp implementations distinguish an absent key (defaulted internally) from one
+    // explicitly present with value `undefined` (rejected by its own validation), so
+    // snapshotOptionKeysOnce restoring both keys unconditionally would turn a caller's
+    // `{ recursive: true }` (no dereference key at all) into `{ recursive: true, dereference:
+    // undefined }` and throw a validation error that never happens when the real options object is
+    // forwarded as-is — this is why it only re-adds keys actually present on the caller's options.
+    const safeOptions = snapshotOptionKeysOnce(
+        options as Record<string, unknown>,
+        ['recursive', 'dereference'] as const,
+    );
+    if (safeOptions.recursive === true && safeOptions.dereference === true) {
         throw new Error(CP_BLOCKED_MESSAGE);
-    }
-    // Only re-adds a key that was actually present on the caller's own options — Node's cp
-    // implementations distinguish an absent key (defaulted internally) from one explicitly present
-    // with value `undefined` (rejected by its own validation), so restoring both keys unconditionally
-    // would turn a caller's `{ recursive: true }` (no dereference key at all) into
-    // `{ recursive: true, dereference: undefined }` and throw a validation error that never happens
-    // when the real options object is forwarded as-is.
-    const safeOptions = restOptions as Record<string, unknown>;
-    if ('recursive' in options) {
-        safeOptions.recursive = recursiveValue;
-    }
-    if ('dereference' in options) {
-        safeOptions.dereference = dereferenceValue;
     }
     return safeOptions;
 }
@@ -813,11 +831,8 @@ const originalPromisesCp = fs.promises.cp;
 // implementations don't consult it, but nothing here should be the one silent exception.
 fs.cpSync = function (this: unknown, src: unknown, dest: unknown, options?: unknown) {
     throwIfBlockedEnvironPath(src);
-    return originalCpSync.apply(this, [
-        src as string | URL,
-        dest as string | URL,
-        guardCpOptions(options) as fs.CopySyncOptions,
-    ]);
+    const safeOptions = guardCpOptions(options) as fs.CopySyncOptions;
+    return originalCpSync.apply(this, [src as string | URL, dest as string | URL, safeOptions]);
 } as typeof fs.cpSync;
 
 // cp reports failure via an error-first callback, never a synchronous throw. Only the guard's own
@@ -844,11 +859,8 @@ fs.cp = function (this: unknown, src: unknown, dest: unknown, ...rest: unknown[]
 // promises.cp rejects, matching its real Promise-returning contract.
 fs.promises.cp = async function (this: unknown, src: unknown, dest: unknown, options?: unknown) {
     throwIfBlockedEnvironPath(src);
-    return originalPromisesCp.apply(this, [
-        src as string | URL,
-        dest as string | URL,
-        guardCpOptions(options) as fs.CopyOptions,
-    ]);
+    const safeOptions = guardCpOptions(options) as fs.CopyOptions;
+    return originalPromisesCp.apply(this, [src as string | URL, dest as string | URL, safeOptions]);
 } as typeof fs.promises.cp;
 
 // createReadStream's own wrap above only covers that factory function — Node also exports the

--- a/packages/plugins/apps/src/vite/env-guard.ts
+++ b/packages/plugins/apps/src/vite/env-guard.ts
@@ -10,7 +10,7 @@ import { syncBuiltinESMExports } from 'node:module';
 import nodePath from 'path';
 import { fileURLToPath } from 'url';
 
-import { makeGuardCallbackWrapper, makeGuardWrapper } from './guarded-wrapper';
+import { invokeCallbackArg, makeGuardCallbackWrapper, makeGuardWrapper } from './guarded-wrapper';
 import { getOrCreateShared } from './shared-module-singleton';
 
 // Captured at module load — before any customer code runs — so a backend function can't replace
@@ -185,7 +185,13 @@ function getSharedState(): EnvGuardSharedState {
                 if (activeScopeTokens.size > 0) {
                     // An unrelated caller writing from outside any scope while a DIFFERENT scope is
                     // still active elsewhere — applying it immediately would disarm redaction out
-                    // from under that scope, so it's deferred until the active scope's own cleanup.
+                    // from under that scope, so it's deferred instead. Applied and immediately
+                    // reverted here (rather than just stashed) so Node's own setter validation still
+                    // runs now — an invalid value throws here instead of surfacing later,
+                    // misattributed to whichever scope's cleanup happens to apply it.
+                    const currentValue = getExcludeEnv();
+                    applyExcludeEnvValue(newValue);
+                    applyExcludeEnvValue(currentValue);
                     savedExcludeEnv = newValue;
                     return;
                 }
@@ -200,6 +206,15 @@ function getSharedState(): EnvGuardSharedState {
                 if (nativeGetStore() !== undefined) {
                     throw new Error(
                         "Reassigning process.env is not allowed in backend functions — it would corrupt the dev server's real environment for every future execution. Use $.Source or a declared Custom Credential instead.",
+                    );
+                }
+                if (typeof newValue !== 'object' || newValue === null) {
+                    // isEnvProxy() only ever returns true for an object, so without this check a
+                    // primitive assignment (process.env = 1, process.env = null) would store that
+                    // primitive as realEnv — every later unscoped access then calls
+                    // Reflect.get/ownKeys on it and throws, permanently breaking process.env.
+                    throw new Error(
+                        'Reassigning process.env to a non-object value is not allowed — it would permanently break every future process.env access.',
                     );
                 }
                 realEnvHistory.push(realEnv);
@@ -254,6 +269,13 @@ const sharedState = getSharedState();
 // get/ownKeys/etc. traps into each other forever.
 const ENV_PROXY_MARKER = Symbol.for('@dd/apps-plugin/env-guard/scoped-env-proxy');
 
+// Re-checked on every fs.promises.open() call rather than trusted as a one-time-installed flag — a
+// stray jest.spyOn(...).mockRestore() elsewhere in the process, on the same shared FileHandle
+// prototype, can silently strip one of these wrappers without this file ever re-running to notice.
+const FILE_HANDLE_READ_GUARD_MARKER = Symbol.for(
+    '@dd/apps-plugin/env-guard/file-handle-read-guard',
+);
+
 // Takes `unknown`, not NodeJS.ProcessEnv: the setter below calls this on whatever a caller actually
 // assigns to process.env at runtime, which TypeScript's parameter typing can't constrain — a bare
 // `Reflect.get(value, ...)` throws for null/undefined/primitives, which would surface as a confusing
@@ -276,6 +298,13 @@ function forwardToCurrentEnv<Args extends unknown[], R>(
     };
 }
 
+// util.inspect()/console.log() read a Proxy's target directly via V8's getProxyDetails, bypassing
+// every trap below — with the real env as target, that would leak it straight through a bare
+// console.log(process.env) inside a scope. An always-empty, always-extensible dummy target closes
+// this: Proxy invariants only constrain traps when the target is non-extensible or holds
+// non-configurable properties, never true here, so every trap still resolves through
+// getCurrentEnv() as before.
+const INERT_PROXY_TARGET = {} as NodeJS.ProcessEnv;
 // Re-checked on every runWithScopedEnv call rather than installed once and assumed permanent, since
 // isEnvProxy() is what actually detects "is this already installed" — the accessor property below
 // makes a bare `process.env = X` (rather than a call through this function) impossible to reach the
@@ -285,7 +314,7 @@ function ensureEnvProxyInstalled(): void {
     if (isEnvProxy(process.env)) {
         return;
     }
-    const proxy = new Proxy(process.env, {
+    const proxy = new Proxy(INERT_PROXY_TARGET, {
         get: (_target, prop, receiver) => {
             if (prop === ENV_PROXY_MARKER) {
                 return true;
@@ -305,20 +334,34 @@ function ensureEnvProxyInstalled(): void {
         deleteProperty: forwardToCurrentEnv(Reflect.deleteProperty),
         ownKeys: forwardToCurrentEnv(Reflect.ownKeys),
         getOwnPropertyDescriptor: forwardToCurrentEnv(Reflect.getOwnPropertyDescriptor),
-        defineProperty: forwardToCurrentEnv(Reflect.defineProperty),
+        // A non-configurable definition can never be forwarded: the Proxy invariant requires
+        // `target` (INERT_PROXY_TARGET, always empty) to carry that exact property afterward, which
+        // it deliberately never does. Checked upfront rather than left to surface as Reflect's own
+        // invariant-violation TypeError, which gives no hint this guard is involved. Accepted gap:
+        // locking an env var non-configurable stops working process-wide once local execution has
+        // run once, in exchange for `console.log(process.env)` never bypassing the scope via V8's
+        // getProxyDetails (see INERT_PROXY_TARGET's own comment).
+        defineProperty: (_target, prop, descriptor) => {
+            if (descriptor.configurable === false) {
+                throw new Error(
+                    `Cannot define a non-configurable property (${String(prop)}) on process.env: local execution's environment scoping requires every property to stay configurable.`,
+                );
+            }
+            return Reflect.defineProperty(sharedState.getCurrentEnv(), prop, descriptor);
+        },
         // Without this trap, Object.setPrototypeOf(process.env, ...) defaults to forwarding to
-        // `target` (the real, unscoped env object) and silently poisons its prototype chain
-        // permanently, even when called from inside a scope — since getCurrentEnv() only affects
-        // property access, not the object identity a prototype mutation lands on.
+        // `target` (INERT_PROXY_TARGET, not the real env) and silently poisons its prototype chain
+        // instead, even when called from inside a scope — getCurrentEnv() only affects property
+        // access, not the object identity a prototype mutation lands on.
         setPrototypeOf: forwardToCurrentEnv(Reflect.setPrototypeOf),
         // Paired with setPrototypeOf above: without this trap, a customer function that sets a
-        // scoped prototype and immediately reads it back would see `target`'s (the real env's)
+        // scoped prototype and immediately reads it back would see `target`'s (INERT_PROXY_TARGET's)
         // untouched prototype instead of the one it just set on the scoped view.
         getPrototypeOf: forwardToCurrentEnv(Reflect.getPrototypeOf),
-        // Can't forward to getCurrentEnv(): the Proxy invariants only honor a `preventExtensions` trap
-        // returning `true` if `target` (always the real env object) is also non-extensible, so
-        // routing this to the scoped object would either desync the invariant or force freezing the
-        // real env process-wide. Refusing outright is the only option that risks neither.
+        // Can't forward to getCurrentEnv(): the Proxy invariant only honors this trap returning `true`
+        // if `target` (INERT_PROXY_TARGET, not the real env) is also non-extensible, and freezing it
+        // would break every other trap's scoped view. Refusing outright is the only option that
+        // doesn't leak real-env state or break the proxy.
         preventExtensions: () => false,
     });
     // process.env must be an accessor property, not the plain data property it started as — a bare
@@ -457,17 +500,22 @@ function extractFdNumber(fdValue: unknown): unknown {
 // harmless value to this check and a different, real target to Node's own later read.
 function guardEnvironPathOrFdOption(rawPath: unknown, options: unknown): unknown {
     throwIfBlockedEnvironPath(rawPath);
+    // No scope active means nothing here can be an environ read worth blocking — returning options
+    // untouched (rather than destructuring/rebuilding it below) preserves whatever createReadStream/
+    // ReadStream call a caller outside any scope makes, including non-enumerable or inherited
+    // options properties a plain spread would otherwise silently drop.
+    if (!sharedState.isInsideScope()) {
+        return options;
+    }
     if (typeof options !== 'object' || options === null || !('fd' in options)) {
         return options;
     }
-    const fdValue = options.fd;
-    // Gated the same way isBlockedEnvironPath's own short-circuit is: extractFdNumber now reads a
-    // real FileHandle's native .fd getter, which callers outside any scope must never trigger.
-    if (sharedState.isInsideScope()) {
-        const fdNumber = extractFdNumber(fdValue);
-        throwIfBlockedEnvironPath(fdNumber);
-    }
-    return { ...options, fd: fdValue };
+    // Destructuring reads the getter exactly once, into fdValue — spreading the remainder (with fd
+    // already removed) can't invoke it again the way `{ ...options, fd: fdValue }` would have.
+    const { fd: fdValue, ...restOptions } = options as { fd: unknown };
+    const fdNumber = extractFdNumber(fdValue);
+    throwIfBlockedEnvironPath(fdNumber);
+    return { ...restOptions, fd: fdValue };
 }
 
 // Every guarded fs entry point below except createReadStream takes only a leading path argument —
@@ -533,13 +581,6 @@ function wrapGuardedStreamFn<T extends (...args: never[]) => unknown>(real: T): 
     };
     return wrapped as T;
 }
-
-// Re-checked on every fs.promises.open() call rather than trusted as a one-time-installed flag — a
-// stray jest.spyOn(...).mockRestore() elsewhere in the process, on the same shared FileHandle
-// prototype, can silently strip one of these wrappers without this file ever re-running to notice.
-const FILE_HANDLE_READ_GUARD_MARKER = Symbol.for(
-    '@dd/apps-plugin/env-guard/file-handle-read-guard',
-);
 
 // Shared by every FileHandle prototype method patched below — re-checks proto[methodName] fresh on
 // every fs.promises.open() call rather than trusting a one-time flag, for the same reason
@@ -657,6 +698,7 @@ function patchFileHandleSyncMethod(
     proto[methodName] = guarded;
 }
 
+// FileHandle isn't part of Node's public API, so read/readFile/readv/createReadStream/
 // readableWebStream/readLines are patched lazily off the first real handle fs.promises.open()
 // returns — a handle obtained before that patch installs is unaffected, matching every other guard
 // here. These six are distinct prototype methods that don't delegate to each other, so each needs
@@ -693,15 +735,121 @@ fs.openSync = wrapGuardedFsFn(fs.openSync);
 fs.open = wrapGuardedCallbackFsFn(fs.open);
 fs.promises.open = wrapGuardedAsyncFsFn(fs.promises.open, ensureFileHandleReadGuarded);
 
-// copyFileSync/copyFile/promises.copyFile/cpSync/promises.cp read the source file's bytes through
-// a distinct native binding that never calls through readFile*/open* above — an uncovered path that
-// could otherwise copy /proc/.../environ to an ordinary, unguarded file and read it back from there.
+// openAsBlob is its own entry point, separate from open*/readFile* above, and absent on Node 18.
+// Feature-detected the same way packages/core/src/helpers/fs.ts's getFile() already checks for it
+// — an unconditional assignment here would replace that check's `undefined` with an always-defined
+// wrapper, silently forcing every Node 18 caller onto the unsupported branch.
+if (typeof fs.openAsBlob === 'function') {
+    fs.openAsBlob = wrapGuardedAsyncFsFn(fs.openAsBlob);
+}
+
+// read/readSync/readv/readvSync take an already-open fd as their own leading argument — the same
+// shape isBlockedEnvironPath's toPathString() already resolves via /proc/self/fd for the numeric-fd
+// case above, just on entry points that were never wrapped at all.
+fs.read = wrapGuardedCallbackFsFn(fs.read);
+fs.readSync = wrapGuardedFsFn(fs.readSync);
+fs.readv = wrapGuardedCallbackFsFn(fs.readv);
+fs.readvSync = wrapGuardedFsFn(fs.readvSync);
+
+// copyFileSync/copyFile/promises.copyFile read the source file's bytes through a distinct native
+// binding that never calls through readFile*/open* above — an uncovered path that could otherwise
+// copy /proc/.../environ to an ordinary, unguarded file and read it back from there.
 fs.copyFileSync = wrapGuardedFsFn(fs.copyFileSync);
 fs.copyFile = wrapGuardedCallbackFsFn(fs.copyFile);
 fs.promises.copyFile = wrapGuardedAsyncFsFn(fs.promises.copyFile);
-fs.cpSync = wrapGuardedFsFn(fs.cpSync);
-fs.cp = wrapGuardedCallbackFsFn(fs.cp);
-fs.promises.cp = wrapGuardedAsyncFsFn(fs.promises.cp);
+
+// cp/cpSync/promises.cp additionally need to reject a recursive+dereference copy of ANY directory
+// (see guardCpOptions's own comment) — a check the plain isBlockedEnvironPath(src) check above
+// can't cover, since it only ever inspects the top-level source argument.
+const CP_BLOCKED_MESSAGE =
+    "Copying /proc/.../environ, or recursively copying with dereference: true, is not allowed in backend functions — both can expose the dev server's real, unscoped environment. Use $.Source or a declared Custom Credential instead.";
+
+// Snapshots options.recursive/dereference into plain data properties, read exactly once — the
+// generic makeGuardWrapper machinery forwards a caller's original options object unchanged, which
+// would let a getter-backed recursive/dereference report false here and true when Node's own
+// fs.cp* reads it again internally, letting a symlinked /proc/.../environ get dereferenced and
+// copied through undetected. Same TOCTOU reasoning as guardEnvironPathOrFdOption's options.fd
+// handling above; hand-rolled here since arg transformation isn't something makeGuardWrapper
+// supports.
+function guardCpOptions(options: unknown): unknown {
+    if (!sharedState.isInsideScope()) {
+        return options;
+    }
+    if (typeof options !== 'object' || options === null) {
+        return options;
+    }
+    const {
+        recursive: recursiveValue,
+        dereference: dereferenceValue,
+        ...restOptions
+    } = options as { recursive?: unknown; dereference?: unknown };
+    if (recursiveValue === true && dereferenceValue === true) {
+        throw new Error(CP_BLOCKED_MESSAGE);
+    }
+    // Only re-adds a key that was actually present on the caller's own options — Node's cp
+    // implementations distinguish an absent key (defaulted internally) from one explicitly present
+    // with value `undefined` (rejected by its own validation), so restoring both keys unconditionally
+    // would turn a caller's `{ recursive: true }` (no dereference key at all) into
+    // `{ recursive: true, dereference: undefined }` and throw a validation error that never happens
+    // when the real options object is forwarded as-is.
+    const safeOptions = restOptions as Record<string, unknown>;
+    if ('recursive' in options) {
+        safeOptions.recursive = recursiveValue;
+    }
+    if ('dereference' in options) {
+        safeOptions.dereference = dereferenceValue;
+    }
+    return safeOptions;
+}
+
+// Captured into local consts before reassignment below — a lazy `() => fs.cpSync` getter would
+// re-read the property AFTER it's replaced with this very wrapper, recursing into itself forever.
+const originalCpSync = fs.cpSync;
+const originalCp = fs.cp;
+const originalPromisesCp = fs.promises.cp;
+
+// cpSync is genuinely synchronous — a guard failure throwing matches its real contract. `this`
+// is forwarded via .apply, matching every other guarded fs entry point in this file — Node's own
+// implementations don't consult it, but nothing here should be the one silent exception.
+fs.cpSync = function (this: unknown, src: unknown, dest: unknown, options?: unknown) {
+    throwIfBlockedEnvironPath(src);
+    return originalCpSync.apply(this, [
+        src as string | URL,
+        dest as string | URL,
+        guardCpOptions(options) as fs.CopySyncOptions,
+    ]);
+} as typeof fs.cpSync;
+
+// cp reports failure via an error-first callback, never a synchronous throw. Only the guard's own
+// decision logic runs inside the try/catch — the real call runs outside it, so a synchronous throw
+// from Node's own validation propagates normally instead of being swallowed by invokeCallbackArg
+// when a malformed call has no valid callback to report through.
+fs.cp = function (this: unknown, src: unknown, dest: unknown, ...rest: unknown[]) {
+    let safeArgs: unknown[];
+    try {
+        throwIfBlockedEnvironPath(src);
+        const hasOptions = rest.length > 1;
+        const safeOptions = hasOptions ? guardCpOptions(rest[0]) : undefined;
+        safeArgs = hasOptions ? [src, dest, safeOptions, ...rest.slice(1)] : [src, dest, ...rest];
+    } catch (error) {
+        invokeCallbackArg(
+            [src, dest, ...rest],
+            error instanceof Error ? error : new Error(String(error)),
+        );
+        return undefined;
+    }
+    return (originalCp as unknown as (...a: unknown[]) => unknown).apply(this, safeArgs);
+} as typeof fs.cp;
+
+// promises.cp rejects, matching its real Promise-returning contract.
+fs.promises.cp = async function (this: unknown, src: unknown, dest: unknown, options?: unknown) {
+    throwIfBlockedEnvironPath(src);
+    return originalPromisesCp.apply(this, [
+        src as string | URL,
+        dest as string | URL,
+        guardCpOptions(options) as fs.CopyOptions,
+    ]);
+} as typeof fs.promises.cp;
 
 // createReadStream's own wrap above only covers that factory function — Node also exports the
 // ReadStream class it constructs internally, and `new fs.ReadStream(path)` never calls through
@@ -715,6 +863,23 @@ fs.ReadStream = new Proxy(fs.ReadStream, {
         return Reflect.construct(target, [args[0], safeOptions], newTarget);
     },
 });
+
+// @types/node doesn't declare fs.FileReadStream at all, even though Node itself still exports it.
+// `let`, not `const` — ReadStream itself is declared as a class (an assignable binding, matching
+// the reassignment already made above), and this needs to be assignable too.
+declare module 'fs' {
+    // no-undef doesn't understand module-augmentation scoping (ReadStream is 'fs's own ambient
+    // class, visible here without an import); import/no-mutable-exports doesn't apply either — this
+    // `let` declares the shape of the 'fs' module's own property, not a real value this file exports.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-undef, import/no-mutable-exports
+    export let FileReadStream: typeof ReadStream;
+}
+
+// fs.FileReadStream is a real, long-deprecated alias for fs.ReadStream — reassigning fs.ReadStream
+// only rebinds that one property; fs.FileReadStream is a separate slot that keeps pointing at the
+// original, unwrapped class, so `new fs.FileReadStream(path)` would construct through it with no
+// guard at all.
+fs.FileReadStream = fs.ReadStream;
 
 // @types/node doesn't declare excludeEnv yet. It's real, but only wired up to the native report
 // generator from Node v22.13.0 — CI pins Node 20.19.4, where setting it is a no-op. Kept anyway:
@@ -754,6 +919,10 @@ function wrapReportFn<T extends (...args: never[]) => unknown>(
 // writeReport() call is redacted on every supported Node version, not just where excludeEnv is
 // wired up. writeReport() lets Node handle filename generation/defaults as normal, then
 // post-processes the file it actually wrote rather than reimplementing its naming convention.
+// Gated on sharedState.isInsideScope(), not a global scope count — forceResetEnv() clears the
+// count for an abandoned execution whose fn() is still running, and keying redaction on that count
+// would let the zombie's own getReport()/writeReport() call see the real environment the moment the
+// count resets, even though its own continuation never actually closed.
 const originalGetReport = process.report.getReport.bind(process.report);
 process.report.getReport = wrapReportFn(originalGetReport, (original, ...args) => {
     const report = original(...args);
@@ -763,14 +932,44 @@ process.report.getReport = wrapReportFn(originalGetReport, (original, ...args) =
     return report;
 });
 
+// writeReport(fileName) can target a non-regular destination — a FIFO, socket, or character device
+// like /dev/stdout — and Node writes the real, unredacted report straight there before this wrap
+// can read it back and strip environmentVariables. Redacting after the fact can't undo bytes
+// already delivered to whatever's reading the other end, so refusing the call once the destination
+// is verified non-regular is the only option that can't leak.
+const WRITE_REPORT_NON_REGULAR_SINK_MESSAGE =
+    "process.report.writeReport() to a non-regular destination (a pipe, socket, or similar) is not allowed in backend functions — Node would write its real, unscoped report there before this file's own redaction could ever run. Use $.Source or a declared Custom Credential instead.";
+
+// A not-yet-existing path is fine — writeReport creates a fresh, ordinary regular file there —
+// so ENOENT is the one failure treated as "not a non-regular sink," matching isEnvironPath's own
+// identical ENOENT fallback elsewhere in this file. fs.statSync follows symlinks on its own,
+// unlike lstatSync, so a symlink pointing at a FIFO is resolved to its real target automatically.
+function isVerifiedNonRegularDestination(filePath: string): boolean {
+    try {
+        return !fs.statSync(filePath).isFile();
+    } catch (error) {
+        if (isErrnoException(error) && error.code === 'ENOENT') {
+            return false;
+        }
+        throw error;
+    }
+}
+
 const originalWriteReport = process.report.writeReport.bind(process.report);
 process.report.writeReport = wrapReportFn(originalWriteReport, (original, ...args) => {
     if (sharedState.isInsideScope()) {
         // writeReport(fileName?, err?) also accepts writeReport(err?) with no fileName at all —
         // only a string first argument is ever a caller-chosen destination, so this branch is
         // skipped (falling through to Node's own write below) when none was given.
+        // Checked as the last statement before the real write, not earlier in this function: an
+        // external process could swap a symlink at fileNameArg between this check and the write
+        // below. This doesn't close that window entirely (the write is still a separate syscall
+        // right after), but narrows it to two back-to-back synchronous calls with nothing between.
         const fileNameArg = args[0];
         if (typeof fileNameArg === 'string') {
+            if (isVerifiedNonRegularDestination(fileNameArg)) {
+                throw new Error(WRITE_REPORT_NON_REGULAR_SINK_MESSAGE);
+            }
             // Builds the redacted report itself and writes it directly, rather than letting Node
             // persist the real report first and rewriting it after — that would leave unredacted
             // content on disk if anything between the two writes throws. Cast: TS collapses the

--- a/packages/plugins/apps/src/vite/guarded-wrapper.ts
+++ b/packages/plugins/apps/src/vite/guarded-wrapper.ts
@@ -37,8 +37,10 @@ export function makeGuardWrapper<F extends (...args: never[]) => unknown>(
 }
 
 // The last argument is a function in every real call this wraps (fs.readFile/open/copyFile/cp all
-// require their callback), so no other heuristic is needed to find it.
-function invokeCallbackArg(args: unknown[], error: Error): void {
+// require their callback), so no other heuristic is needed to find it. Exported for env-guard.ts's
+// own hand-rolled cp wrappers, which need this same callback-reporting behavior for a guard failure
+// that isn't just a fixed shouldBlock() result (see their own comment).
+export function invokeCallbackArg(args: unknown[], error: Error): void {
     const maybeCallback = args[args.length - 1];
     if (typeof maybeCallback === 'function') {
         // Deferred, not called synchronously: every real error-first-callback fs function reports


### PR DESCRIPTION
## Motivation

- Tracked in [APPS-2792](https://datadoghq.atlassian.net/browse/APPS-2792) (Milestone: Secret Store parity for local execution). Stacked on #504, which introduces `env-guard.ts`'s core `process.env` scoping mechanism.
- Repeated review of that mechanism surfaced further bypass and reliability gaps in the guarded `fs`/`process.report`/`util.inspect`/Proxy surface. See the Changes table below for the full, itemized list.

## Architecture

All fixes land inside `env-guard.ts`'s existing scoping mechanism (introduced in #504) — this PR closes bypass and reliability gaps in that mechanism rather than changing its shape:

```
runWithScopedEnv(scopedEnv, fn)
  │
  ├─ fs wrappers — coverage extended to fs.read/readv(Sync)/openAsBlob/
  │    FileReadStream and every FileHandle.prototype read method, with a
  │    real fd resolved via a captured native getter so an own-property
  │    shadow on the handle can't fool the guard; cp/cpSync/promises.cp
  │    reject recursive+dereference outright and read their options once
  │
  ├─ process.env — reassigning to null/undefined/a primitive is rejected;
  │    Object.defineProperty(..., { configurable: false }) throws a clear
  │    guard-specific error instead of a native Proxy invariant violation
  │
  ├─ process.report — writeReport() refuses a non-regular destination,
  │    re-checked immediately before the real write to narrow a symlink-
  │    swap TOCTOU window; a deferred excludeEnv write is now validated
  │    via Node's native setter
  │
  └─ util.inspect(process.env) — Proxy target repointed to a permanently
       empty dummy object, closing the default-mode + showProxy:true leak
```

<details><summary>16 changes across env-guard.ts, env-guard.test.ts, guarded-wrapper.ts</summary>

| What changed | File |
|---|---|
| `fs.read`/`readSync`/`readv`/`readvSync` and every `FileHandle.prototype` read method (`read`/`readFile`/`readv`/`createReadStream`/`readableWebStream`/`readLines`) are now guarded against the `/proc/.../environ` bypass | `packages/plugins/apps/src/vite/env-guard.ts` |
| The `FileHandle` guard resolves the real fd via a getter captured once from the prototype at patch time, so a customer-controlled own property shadowing `.fd` with a harmless value can't fool the check | `packages/plugins/apps/src/vite/env-guard.ts` |
| That fd resolution — and the guard check depending on it — now only runs inside an active scope; the native `.fd` getter (and the guard's own logic) was previously invoked unconditionally on every call | `packages/plugins/apps/src/vite/env-guard.ts` |
| `fs.cp`/`cpSync`/`promises.cp` now reject a `recursive: true, dereference: true` copy outright, since Node's own internal traversal for that case bypasses the top-level source-path check | `packages/plugins/apps/src/vite/env-guard.ts` |
| `guardCpOptions`/`guardEnvironPathOrFdOption` read a getter-backed option value exactly once via destructuring, instead of risking a second, differently-answered read during a later spread | `packages/plugins/apps/src/vite/env-guard.ts` |
| `fs.openAsBlob` and `fs.FileReadStream` are now guarded, each gated on the real function actually existing on the running Node version | `packages/plugins/apps/src/vite/env-guard.ts` |
| Reassigning `process.env` to `null`, `undefined`, or a primitive (not an object) is now rejected instead of silently corrupting the real environment fallback | `packages/plugins/apps/src/vite/env-guard.ts` |
| `Object.defineProperty(process.env, key, { configurable: false })` now throws a clear, guard-specific error instead of a native Proxy invariant `TypeError` — a non-configurable definition can never be satisfied against the Proxy's permanently-empty target | `packages/plugins/apps/src/vite/env-guard.ts` |
| `process.env`'s Proxy now targets a permanently-empty dummy object, closing `util.inspect(process.env)` reading the real environment straight off the Proxy's internal target — both default mode and `showProxy: true` bypass every trap by design, per Node's own docs | `packages/plugins/apps/src/vite/env-guard.ts` |
| `process.report.writeReport()` refuses a verified non-regular destination (FIFO/socket/character device), re-checked immediately before the real write (not just once, earlier in the function) to narrow the window for an external symlink swap | `packages/plugins/apps/src/vite/env-guard.ts` |
| A deferred `excludeEnv` write (made from outside an active scope while a different scope is active) is now validated immediately via Node's native setter instead of skipping that validation | `packages/plugins/apps/src/vite/env-guard.ts` |
| `wrapGuardedAsyncFsFn`'s `onResolved` hook (used by `fs.promises.open`) now forwards the caller's `this` through to the wrapped function, instead of losing it on a bare call | `packages/plugins/apps/src/vite/env-guard.ts` |
| Two inlined function-call arguments (a repo convention violation) replaced with named locals | `packages/plugins/apps/src/vite/env-guard.ts` |
| New tests for every fix above: FileHandle fd-shadow bypass, fd-based reads, `openAsBlob`/`FileReadStream` guards, cp TOCTOU, primitive `process.env` rejection, the `defineProperty` invariant, and the existing `/proc/.../environ`/scope tests extended to the newly-guarded entry points | `packages/plugins/apps/src/vite/env-guard.test.ts` |
| `makeGuardWrapper`/`makeGuardCallbackWrapper` doc comment tightened | `packages/plugins/apps/src/vite/guarded-wrapper.ts` |

</details>

## QA Instructions

```bash
yarn typecheck:all
# Expected: no errors ✅ VERIFIED

yarn build:all
yarn test:unit
# Expected: 94 suites, 2405 tests (2404 passed, 1 pre-existing unrelated skip) ✅ VERIFIED
```

<details><summary>Manual QA: standalone-process reproduction for the util.inspect(process.env) fix (click to expand — the only fix here that needs a genuinely fresh OS process, not just an in-process Jest test)</summary>

Every other fix in this PR is exercised directly by a named test in `env-guard.test.ts` (run `yarn test:unit packages/plugins/apps/src/vite/env-guard.test.ts` to reproduce all of them). The `util.inspect` fix needs a fresh, never-before-scoped `process.env` to observe the Proxy's real target, which a single Jest test file (already sharing the module's installed state across its own tests) can't produce on its own — verified instead via a standalone script:

```ts
// /tmp/inspect-proxy-repro.mjs
import util from 'util';

process.env.REAL_SECRET_ONLY_HERE = 'sk_should_never_leak_via_inspect';

const { runWithScopedEnv } = await import(
    '/path/to/build-plugins/packages/plugins/apps/src/vite/env-guard.ts'
);

await runWithScopedEnv({ PATH: '/scoped' }, async () => {
    const withoutShowProxy = util.inspect(process.env);
    const withShowProxy = util.inspect(process.env, { showProxy: true });
    const leaked =
        withoutShowProxy.includes('sk_should_never_leak_via_inspect') ||
        withShowProxy.includes('sk_should_never_leak_via_inspect');
    console.log(leaked ? 'LEAKED' : 'NOT LEAKED');
});
```

```bash
npx tsx /tmp/inspect-proxy-repro.mjs
# NOT LEAKED ✅ VERIFIED
```

</details>

<details><summary>Manual QA: env-guard's process.env scoping under a real end-to-end $.Actions call (click to expand — exercises the guard inside the actual dev-server request path, not just Jest)</summary>

- The tests above exercise env-guard in isolation. This reproduction drives it through the real path a customer function takes: `POST /__dd/executeAction` → staging auth → runtime-context priming (`preview-async`, long-polled) → in-process execution of the function body under `runWithScopedEnv` → a live `$.Actions` proxy call.
- Reproduced against a scaffolded consumer app with `@datadog/vite-plugin` built from this branch (`yarn build` in `packages/published/vite-plugin`) and imported by absolute path in the app's `vite.config.ts`, since `publishConfig`-based `exports` only resolve via a real `npm publish`, not a local link.

```ts
// src/envGuardActionsCheck.backend.ts
export async function envGuardActionsCheck() {
    const results: Record<string, unknown> = {};
    results.pathVisible = process.env.PATH !== undefined;
    results.realSecretHidden = process.env.QA_REAL_SECRET_MARKER === undefined;
    try {
        Object.defineProperty(process.env, 'LOCKED', { value: 'x', configurable: false });
        results.defineNonConfigurable = 'did not throw (unexpected)';
    } catch (error) {
        results.defineNonConfigurable = (error as Error).message;
    }
    try {
        const actionResult = await $.Actions.slack.chat.postMessage({
            inputs: { channel: '#test', text: 'env-guard QA' },
            connectionId: 'qa-connection-id',
        });
        results.actionsCallSucceeded = true;
        results.actionsCallResult = actionResult;
    } catch (error) {
        results.actionsCallSucceeded = false;
        results.actionsCallError = (error as Error).message;
    }
    return results;
}
```

```bash
# Import the function above from App.tsx, then start the dev server with real staging credentials
# (site set to dd.datad0g.com in vite.config.ts's auth block):
dd-auth --domain dd.datad0g.com -- sh -c 'npm run dev'

# Load the app once in a browser so Vite's transform hook registers the function, then call it:
HASH=$(node -e "console.log(require('crypto').createHash('sha256').update('src/envGuardActionsCheck').digest('hex'))")
curl -s -X POST http://localhost:5173/__dd/executeAction \
  -H 'Content-Type: application/json' \
  -d "{\"functionName\": \"${HASH}.envGuardActionsCheck\", \"args\": []}"
# Expected: pathVisible: true, realSecretHidden: true, defineNonConfigurable: guard-specific
# error message (not a native Proxy invariant TypeError), actionsCallSucceeded: false,
# actionsCallError: "Action $.Actions.slack.chat.postMessage used connection \"qa-connection-id\",
# which is not in this function's allowed connections: []" ✅ VERIFIED
```

- The connection-allowlist rejection at the end confirms the call reached PR #479's real enforcement layer — i.e. every layer in front of it (staging auth, runtime-context priming, in-process execution under this PR's env-guard fixes) ran for real rather than being mocked or short-circuited.

</details>

## Blast Radius

- Defense-in-depth hardening of an already-shipped scoping mechanism (#504) — no production-facing behavior change outside local dev-server execution.
- Risk: low. These are bypass-closing and reliability fixes to a JS-level guard already scoped to the dev server's local-execution path, not a hard security boundary.

## Out of Scope / Follow-ups

<details><summary>1 item deferred</summary>

| Item | Status | Next step |
|---|---|---|
| `process.report.writeReport()`'s TOCTOU window is narrowed (re-checked immediately before the real write) but not fully closed — a symlink swap in the remaining gap between that check and Node's own write syscall is still theoretically possible | Deferred, accepted | No action planned: exploiting this requires the backend function itself (or a coordinated external process) to actively race its own call, which is outside this guard's stated "JS-level defense-in-depth, not a hard security boundary" threat model |

</details>

## Documentation

- [APPS-2792](https://datadoghq.atlassian.net/browse/APPS-2792)
- [RFC (Confluence)](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651) — architecture, Decisions and Trade-Offs, Security, Open Questions
- [Kickoff (Confluence)](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455) — milestone breakdown, dependency graph, status


[APPS-2792]: https://datadoghq.atlassian.net/browse/APPS-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPS-2792]: https://datadoghq.atlassian.net/browse/APPS-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
