### PR TITLE
[APPS-2792] Add: local-file resolution for Custom Credentials

### DIFF
--- a/packages/plugins/apps/README.md
+++ b/packages/plugins/apps/README.md
@@ -50,6 +50,10 @@ Backend functions read Custom Credentials from a `datadog-app.local.json` file i
 root — a flat JSON object mapping env var name to value. Add this file to your project's
 `.gitignore`; it holds real secret values.
 
+Values are only available while a backend function body is running — not during a module's
+top-level evaluation (e.g. `const client = new Stripe(process.env.STRIPE_API_KEY)` at import
+time). Read `process.env` inside the function body instead.
+
 ## Package output
 
 A production `vite build` writes `datadog-app-assets.zip` beside the Vite output. The ZIP contains `frontend/`, `backend/`, and `manifest.json`. The app's identity is resolved by `@datadog/apps-cli` at deploy time.

--- a/packages/plugins/apps/README.md
+++ b/packages/plugins/apps/README.md
@@ -10,6 +10,7 @@ A Vite plugin that builds a deployable Datadog Apps package. Publishing is owned
 <!-- #toc -->
 -   [Configuration](#configuration)
 -   [Development server authentication](#development-server-authentication)
+-   [Custom Credentials for local execution](#custom-credentials-for-local-execution)
 -   [Package output](#package-output)
     -   [apps.enable](#appsenable)
     -   [apps.include](#appsinclude)
@@ -42,6 +43,12 @@ Backend function execution authenticates in this order:
 passes it to the dev server via `DD_OAUTH_ACCESS_TOKEN`. When no credentials are
 configured, backend function execution is unavailable and the dev server tells
 you to start it with `datadog-apps dev`.
+
+## Custom Credentials for local execution
+
+Backend functions read Custom Credentials from a `datadog-app.local.json` file in the project
+root — a flat JSON object mapping env var name to value. Add this file to your project's
+`.gitignore`; it holds real secret values.
 
 ## Package output
 

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -2,6 +2,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+/* global NodeJS */
+
 import * as archive from '@dd/apps-plugin/archive';
 import * as assets from '@dd/apps-plugin/assets';
 import { getPlugins } from '@dd/apps-plugin';
@@ -179,6 +181,101 @@ describe('Apps Plugin - package output', () => {
         expect(Object.keys(zip.files)).not.toEqual(
             expect.arrayContaining(['frontend/Datadog-App.Local.Json']),
         );
+    });
+
+    // Regression test: a symlink under a different name still reads the credentials file's real
+    // content, so the exclusion filter must check the resolved target, not just the discovered
+    // path's own basename.
+    test('never packages a symlink pointing at datadog-app.local.json, even under a different name', async () => {
+        const localCredentialsPath = path.join(root, 'datadog-app.local.json');
+        await fs.writeFile(localCredentialsPath, '{"STRIPE_API_KEY":"sk_test_should_not_ship"}');
+        const symlinkPath = path.join(root, 'backup-config.json');
+        await fs.symlink(localCredentialsPath, symlinkPath);
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: sourcePath, relativePath: 'index.html' },
+            { absolutePath: symlinkPath, relativePath: 'backup-config.json' },
+        ]);
+
+        await buildAppPackage(packageOptions({ options: { include: ['**/*.json'] } }));
+
+        const zip = await JSZip.loadAsync(
+            await fs.readFile(path.join(packageDirectory, ARCHIVE_FILENAME)),
+        );
+        expect(Object.keys(zip.files)).not.toEqual(
+            expect.arrayContaining(['frontend/backup-config.json']),
+        );
+    });
+
+    // Regression test: when datadog-app.local.json is itself a symlink, the file glob-matched at
+    // its target path carries the same secret bytes under a different name and must be excluded too.
+    test('never packages the real target of a symlinked datadog-app.local.json', async () => {
+        const realSecretsPath = path.join(root, 'config', 'dev-secrets.json');
+        await fs.mkdir(path.dirname(realSecretsPath), { recursive: true });
+        await fs.writeFile(realSecretsPath, '{"STRIPE_API_KEY":"sk_test_should_not_ship"}');
+        const localCredentialsPath = path.join(root, 'datadog-app.local.json');
+        await fs.symlink(realSecretsPath, localCredentialsPath);
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: sourcePath, relativePath: 'index.html' },
+            { absolutePath: realSecretsPath, relativePath: 'config/dev-secrets.json' },
+        ]);
+
+        await buildAppPackage(packageOptions({ options: { include: ['**/*.json'] } }));
+
+        const zip = await JSZip.loadAsync(
+            await fs.readFile(path.join(packageDirectory, ARCHIVE_FILENAME)),
+        );
+        expect(Object.keys(zip.files)).not.toEqual(
+            expect.arrayContaining(['frontend/config/dev-secrets.json']),
+        );
+    });
+
+    // Regression test: a hardlink shares the credentials file's inode without ever being a
+    // symlink, so an identity check must compare (device, inode), not just resolve symlink targets.
+    test('never packages a hardlink to datadog-app.local.json, even under a different name', async () => {
+        const localCredentialsPath = path.join(root, 'datadog-app.local.json');
+        await fs.writeFile(localCredentialsPath, '{"STRIPE_API_KEY":"sk_test_should_not_ship"}');
+        const hardlinkPath = path.join(root, 'backup-hardlink.json');
+        await fs.link(localCredentialsPath, hardlinkPath);
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: sourcePath, relativePath: 'index.html' },
+            { absolutePath: hardlinkPath, relativePath: 'backup-hardlink.json' },
+        ]);
+
+        await buildAppPackage(packageOptions({ options: { include: ['**/*.json'] } }));
+
+        const zip = await JSZip.loadAsync(
+            await fs.readFile(path.join(packageDirectory, ARCHIVE_FILENAME)),
+        );
+        expect(Object.keys(zip.files)).not.toEqual(
+            expect.arrayContaining(['frontend/backup-hardlink.json']),
+        );
+    });
+
+    // Regression test: a stat failure on the candidate asset itself (not on the credentials file)
+    // must still propagate rather than being swallowed as "not a match" — the mock only intercepts
+    // the asset's own stat call so a real credentials file resolves normally first.
+    test('propagates a non-ENOENT stat failure instead of treating an unverifiable asset as safe', async () => {
+        const localCredentialsPath = path.join(root, 'datadog-app.local.json');
+        await fs.writeFile(localCredentialsPath, '{"STRIPE_API_KEY":"sk_test_should_not_ship"}');
+        const symlinkPath = path.join(root, 'mystery-config.json');
+        await fs.symlink(sourcePath, symlinkPath);
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: sourcePath, relativePath: 'index.html' },
+            { absolutePath: symlinkPath, relativePath: 'mystery-config.json' },
+        ]);
+        const realStat = fs.stat.bind(fs);
+        jest.spyOn(fs, 'stat').mockImplementation(async (target, ...args) => {
+            if (target === symlinkPath) {
+                const error: NodeJS.ErrnoException = new Error('permission denied');
+                error.code = 'EACCES';
+                throw error;
+            }
+            return realStat(target as string, ...(args as []));
+        });
+
+        await expect(
+            buildAppPackage(packageOptions({ options: { include: ['**/*.json'] } })),
+        ).rejects.toThrow('permission denied');
     });
 
     test('writes manifest.json with only backend function entries', async () => {

--- a/packages/plugins/apps/src/index.test.ts
+++ b/packages/plugins/apps/src/index.test.ts
@@ -143,6 +143,44 @@ describe('Apps Plugin - package output', () => {
         );
     });
 
+    test('never packages datadog-app.local.json, even when options.include matches it', async () => {
+        const localCredentialsPath = path.join(root, 'datadog-app.local.json');
+        await fs.writeFile(localCredentialsPath, '{"STRIPE_API_KEY":"sk_test_should_not_ship"}');
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: sourcePath, relativePath: 'index.html' },
+            { absolutePath: localCredentialsPath, relativePath: 'datadog-app.local.json' },
+        ]);
+
+        await buildAppPackage(packageOptions({ options: { include: ['**/*.json'] } }));
+
+        const zip = await JSZip.loadAsync(
+            await fs.readFile(path.join(packageDirectory, ARCHIVE_FILENAME)),
+        );
+        expect(Object.keys(zip.files)).not.toEqual(
+            expect.arrayContaining(['frontend/datadog-app.local.json']),
+        );
+    });
+
+    // Regression test: a case-insensitive filesystem resolves a differently-cased basename to the
+    // same file a glob matched, so the exclusion filter must compare case-insensitively.
+    test('never packages a case-variant of datadog-app.local.json, even when options.include matches it', async () => {
+        const localCredentialsPath = path.join(root, 'Datadog-App.Local.Json');
+        await fs.writeFile(localCredentialsPath, '{"STRIPE_API_KEY":"sk_test_should_not_ship"}');
+        jest.spyOn(assets, 'collectAssets').mockResolvedValue([
+            { absolutePath: sourcePath, relativePath: 'index.html' },
+            { absolutePath: localCredentialsPath, relativePath: 'Datadog-App.Local.Json' },
+        ]);
+
+        await buildAppPackage(packageOptions({ options: { include: ['**/*.json'] } }));
+
+        const zip = await JSZip.loadAsync(
+            await fs.readFile(path.join(packageDirectory, ARCHIVE_FILENAME)),
+        );
+        expect(Object.keys(zip.files)).not.toEqual(
+            expect.arrayContaining(['frontend/Datadog-App.Local.Json']),
+        );
+    });
+
     test('writes manifest.json with only backend function entries', async () => {
         await buildAppPackage(packageOptions());
 

--- a/packages/plugins/apps/src/vite/build-package.ts
+++ b/packages/plugins/apps/src/vite/build-package.ts
@@ -2,6 +2,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+/* global NodeJS */
+
 import { getDDEnvValue } from '@dd/core/helpers/env';
 import { rm } from '@dd/core/helpers/fs';
 import type { GlobalContext } from '@dd/core/types';
@@ -24,6 +26,52 @@ export interface BuildAppPackageOptions {
     backendFunctions: BackendFunction[];
     context: GlobalContext;
     options: AppsOptionsWithDefaults;
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+    return typeof error === 'object' && error !== null && 'code' in error;
+}
+
+type FileIdentity = { dev: number; ino: number };
+
+/** Resolves the root credentials file's (device, inode) identity, or undefined if it doesn't exist. */
+async function resolveCredentialsIdentity(buildRoot: string): Promise<FileIdentity | undefined> {
+    try {
+        const stats = await fsp.stat(path.join(buildRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME));
+        return { dev: stats.dev, ino: stats.ino };
+    } catch (error) {
+        if (isErrnoException(error) && error.code === 'ENOENT') {
+            return undefined;
+        }
+        throw error;
+    }
+}
+
+/**
+ * Compares an asset's (device, inode) identity against the credentials file's, since fs.stat
+ * follows symlinks either way and inode identity also catches a hardlink — cases a path-string
+ * comparison alone can miss. A vanished asset has nothing left to leak; any other stat failure is
+ * re-thrown rather than silently treated as safe to package.
+ */
+async function isCustomCredentialsAsset(
+    absolutePath: string,
+    credentialsIdentity: FileIdentity | undefined,
+): Promise<boolean> {
+    if (path.basename(absolutePath).toLowerCase() === CUSTOM_CREDENTIALS_LOCAL_FILENAME) {
+        return true;
+    }
+    if (!credentialsIdentity) {
+        return false;
+    }
+    try {
+        const stats = await fsp.stat(absolutePath);
+        return stats.dev === credentialsIdentity.dev && stats.ino === credentialsIdentity.ino;
+    } catch (error) {
+        if (isErrnoException(error) && error.code === 'ENOENT') {
+            return false;
+        }
+        throw error;
+    }
 }
 
 function buildManifest(backendFunctions: BackendFunction[]): AppsManifest {
@@ -90,21 +138,25 @@ export async function buildAppPackage({
     try {
         const generatedPaths = new Set([archivePath, defaultArchivePath]);
         const backendPaths = new Set(backendOutputs.values());
-        const frontendAssets = assets
+        const candidateAssets = assets
             .filter((asset) => !generatedPaths.has(path.resolve(asset.absolutePath)))
-            .filter((asset) => !backendPaths.has(asset.absolutePath))
-            // options.include has no gitignore-awareness, and filenames may differ in case on a
-            // case-insensitive filesystem, so compare lowercased basenames to keep a broad
-            // pattern (e.g. "**/*.json") from shipping this real-secrets file under any casing.
-            .filter(
-                (asset) =>
-                    path.basename(asset.absolutePath).toLowerCase() !==
-                    CUSTOM_CREDENTIALS_LOCAL_FILENAME,
+            .filter((asset) => !backendPaths.has(asset.absolutePath));
+        const credentialsIdentity = await resolveCredentialsIdentity(buildRoot);
+        const nonCredentialsAssets = (
+            await Promise.all(
+                candidateAssets.map(async (asset) => ({
+                    asset,
+                    isCredentialsAsset: await isCustomCredentialsAsset(
+                        asset.absolutePath,
+                        credentialsIdentity,
+                    ),
+                })),
             )
-            .map((asset) => ({
-                ...asset,
-                relativePath: `frontend/${asset.relativePath}`,
-            }));
+        ).filter(({ isCredentialsAsset }) => !isCredentialsAsset);
+        const frontendAssets = nonCredentialsAssets.map(({ asset }) => ({
+            ...asset,
+            relativePath: `frontend/${asset.relativePath}`,
+        }));
         const packageAssets: Asset[] = [...frontendAssets];
         for (const [bundleName, absolutePath] of backendOutputs) {
             packageAssets.push({

--- a/packages/plugins/apps/src/vite/build-package.ts
+++ b/packages/plugins/apps/src/vite/build-package.ts
@@ -17,6 +17,8 @@ import type { BackendFunction } from '../backend/types';
 import { ARCHIVE_FILENAME, PLUGIN_NAME } from '../constants';
 import type { AppsManifest, AppsOptionsWithDefaults } from '../types';
 
+import { CUSTOM_CREDENTIALS_LOCAL_FILENAME } from './custom-credentials-resolver';
+
 export interface BuildAppPackageOptions {
     backendOutputs: Map<string, string>;
     backendFunctions: BackendFunction[];
@@ -91,6 +93,14 @@ export async function buildAppPackage({
         const frontendAssets = assets
             .filter((asset) => !generatedPaths.has(path.resolve(asset.absolutePath)))
             .filter((asset) => !backendPaths.has(asset.absolutePath))
+            // options.include has no gitignore-awareness, and filenames may differ in case on a
+            // case-insensitive filesystem, so compare lowercased basenames to keep a broad
+            // pattern (e.g. "**/*.json") from shipping this real-secrets file under any casing.
+            .filter(
+                (asset) =>
+                    path.basename(asset.absolutePath).toLowerCase() !==
+                    CUSTOM_CREDENTIALS_LOCAL_FILENAME,
+            )
             .map((asset) => ({
                 ...asset,
                 relativePath: `frontend/${asset.relativePath}`,

--- a/packages/plugins/apps/src/vite/custom-credentials-resolver.test.ts
+++ b/packages/plugins/apps/src/vite/custom-credentials-resolver.test.ts
@@ -46,6 +46,32 @@ describe('resolveCustomCredentials', () => {
         await expect(resolveCustomCredentials(projectRoot)).rejects.toThrow(/not valid JSON/);
     });
 
+    it('never echoes a real secret value into the parse-error message', async () => {
+        // V8's own JSON.parse error embeds a slice of the source text around an unquoted token
+        // (e.g. `..."API_KEY": sk_live_ab"...` for a real credential) — this file writes an
+        // unquoted token on purpose to trigger that same parse-error shape. Deliberately NOT
+        // shaped like a real provider key (no digits, no mixed case, no known prefix): GitHub's
+        // own secret scanning blocked this exact commit twice already for using key-shaped
+        // fixtures (`sk_live_...`, then `sk_test_...`) even though neither was a real credential.
+        const secret = 'THIS_TOKEN_MUST_NEVER_LEAK_INTO_ANY_ERROR_MESSAGE';
+        await fs.writeFile(
+            path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME),
+            `{"STRIPE_API_KEY": ${secret}}`,
+        );
+
+        let thrown: unknown;
+        try {
+            await resolveCustomCredentials(projectRoot);
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(Error);
+        const message = (thrown as Error).message;
+        expect(message).not.toContain(secret);
+        expect(message).not.toContain(secret.slice(0, 10));
+    });
+
     it('rejects a top-level array', async () => {
         await fs.writeFile(
             path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME),
@@ -64,6 +90,29 @@ describe('resolveCustomCredentials', () => {
         await expect(resolveCustomCredentials(projectRoot)).rejects.toThrow(
             /"STRIPE_API_KEY".*must be a string/,
         );
+    });
+
+    it('resolves a credential literally named "__proto__" instead of silently dropping it', async () => {
+        // A plain {} target makes `resolved['__proto__'] = value` hit Object.prototype's own
+        // __proto__ setter, which no-ops for a non-object value — the credential just vanishes
+        // with no error. Object.create(null) avoids the setter entirely.
+        // Written as a raw string, not an object-literal + JSON.stringify: `{ __proto__: ... }`
+        // in JS source is special-cased by the *object literal* grammar to set the prototype
+        // (a no-op here, since the value's a string) rather than create an own property, so
+        // JSON.stringify would silently drop it before this test ever exercises the resolver.
+        // JSON.parse has no such special case — "__proto__" is a completely ordinary key there.
+        await fs.writeFile(
+            path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME),
+            '{"__proto__": "sk_test_proto", "STRIPE_API_KEY": "sk_test_123"}',
+        );
+
+        // Bracket access via a variable key, not `resolved.__proto__`, since the latter triggers
+        // eslint's no-proto rule even though this is reading an ordinary data property here.
+        const protoKey = '__proto__';
+        const resolved = await resolveCustomCredentials(projectRoot);
+        expect(Object.prototype.hasOwnProperty.call(resolved, protoKey)).toBe(true);
+        expect(resolved[protoKey]).toBe('sk_test_proto');
+        expect(resolved.STRIPE_API_KEY).toBe('sk_test_123');
     });
 
     it('propagates a non-ENOENT filesystem error instead of treating it as "missing"', async () => {

--- a/packages/plugins/apps/src/vite/custom-credentials-resolver.test.ts
+++ b/packages/plugins/apps/src/vite/custom-credentials-resolver.test.ts
@@ -67,9 +67,11 @@ describe('resolveCustomCredentials', () => {
         }
 
         expect(thrown).toBeInstanceOf(Error);
-        const message = (thrown as Error).message;
-        expect(message).not.toContain(secret);
-        expect(message).not.toContain(secret.slice(0, 10));
+        if (!(thrown instanceof Error)) {
+            throw thrown;
+        }
+        expect(thrown.message).not.toContain(secret);
+        expect(thrown.message).not.toContain(secret.slice(0, 10));
     });
 
     it('rejects a top-level array', async () => {

--- a/packages/plugins/apps/src/vite/custom-credentials-resolver.test.ts
+++ b/packages/plugins/apps/src/vite/custom-credentials-resolver.test.ts
@@ -47,12 +47,9 @@ describe('resolveCustomCredentials', () => {
     });
 
     it('never echoes a real secret value into the parse-error message', async () => {
-        // V8's own JSON.parse error embeds a slice of the source text around an unquoted token
-        // (e.g. `..."API_KEY": sk_live_ab"...` for a real credential) — this file writes an
-        // unquoted token on purpose to trigger that same parse-error shape. Deliberately NOT
-        // shaped like a real provider key (no digits, no mixed case, no known prefix): GitHub's
-        // own secret scanning blocked this exact commit twice already for using key-shaped
-        // fixtures (`sk_live_...`, then `sk_test_...`) even though neither was a real credential.
+        // An unquoted JSON value triggers V8's parse error to embed a source-text slice — the
+        // real bug this guards against. Deliberately not shaped like a real credential (no
+        // digits, no known prefix) so this fixture doesn't trip secret-scanning on push.
         const secret = 'THIS_TOKEN_MUST_NEVER_LEAK_INTO_ANY_ERROR_MESSAGE';
         await fs.writeFile(
             path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME),
@@ -95,14 +92,9 @@ describe('resolveCustomCredentials', () => {
     });
 
     it('resolves a credential literally named "__proto__" instead of silently dropping it', async () => {
-        // A plain {} target makes `resolved['__proto__'] = value` hit Object.prototype's own
-        // __proto__ setter, which no-ops for a non-object value — the credential just vanishes
-        // with no error. Object.create(null) avoids the setter entirely.
-        // Written as a raw string, not an object-literal + JSON.stringify: `{ __proto__: ... }`
-        // in JS source is special-cased by the *object literal* grammar to set the prototype
-        // (a no-op here, since the value's a string) rather than create an own property, so
-        // JSON.stringify would silently drop it before this test ever exercises the resolver.
-        // JSON.parse has no such special case — "__proto__" is a completely ordinary key there.
+        // Written as a raw string, not JSON.stringify({...}): object-literal `__proto__` syntax
+        // special-cases to set the prototype rather than create an own property, so stringifying
+        // it would silently produce {} here — JSON.parse has no such special case.
         await fs.writeFile(
             path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME),
             '{"__proto__": "sk_test_proto", "STRIPE_API_KEY": "sk_test_123"}',

--- a/packages/plugins/apps/src/vite/custom-credentials-resolver.test.ts
+++ b/packages/plugins/apps/src/vite/custom-credentials-resolver.test.ts
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+    CUSTOM_CREDENTIALS_LOCAL_FILENAME,
+    resolveCustomCredentials,
+} from './custom-credentials-resolver';
+
+describe('resolveCustomCredentials', () => {
+    let projectRoot: string;
+
+    beforeEach(async () => {
+        projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'custom-credentials-resolver-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(projectRoot, { recursive: true, force: true });
+    });
+
+    it('resolves to {} when the file does not exist', async () => {
+        await expect(resolveCustomCredentials(projectRoot)).resolves.toEqual({});
+    });
+
+    it('resolves the flat object of env var name to value', async () => {
+        await fs.writeFile(
+            path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME),
+            JSON.stringify({ STRIPE_API_KEY: 'sk_test_123' }),
+        );
+
+        await expect(resolveCustomCredentials(projectRoot)).resolves.toEqual({
+            STRIPE_API_KEY: 'sk_test_123',
+        });
+    });
+
+    it('rejects malformed JSON instead of silently returning {}', async () => {
+        await fs.writeFile(
+            path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME),
+            '{ not valid json',
+        );
+
+        await expect(resolveCustomCredentials(projectRoot)).rejects.toThrow(/not valid JSON/);
+    });
+
+    it('rejects a top-level array', async () => {
+        await fs.writeFile(
+            path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME),
+            JSON.stringify(['STRIPE_API_KEY']),
+        );
+
+        await expect(resolveCustomCredentials(projectRoot)).rejects.toThrow(/flat JSON object/);
+    });
+
+    it('rejects a non-string value, naming the offending key', async () => {
+        await fs.writeFile(
+            path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME),
+            JSON.stringify({ STRIPE_API_KEY: 12345 }),
+        );
+
+        await expect(resolveCustomCredentials(projectRoot)).rejects.toThrow(
+            /"STRIPE_API_KEY".*must be a string/,
+        );
+    });
+
+    it('propagates a non-ENOENT filesystem error instead of treating it as "missing"', async () => {
+        // A directory where a file is expected fails to read with EISDIR, not ENOENT — resolving
+        // to {} here would hide a real misconfiguration (e.g. a stray directory shadowing the file).
+        await fs.mkdir(path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME));
+
+        await expect(resolveCustomCredentials(projectRoot)).rejects.toThrow();
+    });
+});

--- a/packages/plugins/apps/src/vite/custom-credentials-resolver.ts
+++ b/packages/plugins/apps/src/vite/custom-credentials-resolver.ts
@@ -4,7 +4,7 @@
 
 /* global NodeJS */
 
-import fs from 'node:fs/promises';
+import { readFile } from '@dd/core/helpers/fs';
 import path from 'node:path';
 
 /** One process.env entry per secret the developer has supplied locally, keyed the same way production's resolved Custom Credentials env vars are (e.g. `STRIPE_API_KEY`). */
@@ -30,7 +30,7 @@ export async function resolveCustomCredentials(
     const filePath = path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME);
     let raw: string;
     try {
-        raw = await fs.readFile(filePath, 'utf8');
+        raw = await readFile(filePath);
     } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
             return {};

--- a/packages/plugins/apps/src/vite/custom-credentials-resolver.ts
+++ b/packages/plugins/apps/src/vite/custom-credentials-resolver.ts
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+/* global NodeJS */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/** One process.env entry per secret the developer has supplied locally, keyed the same way production's resolved Custom Credentials env vars are (e.g. `STRIPE_API_KEY`). */
+export type ResolvedCustomCredentials = Record<string, string>;
+
+/**
+ * A git-ignored file the developer maintains themselves with real Custom Credentials values for
+ * local execution — no server call, no new auth model, since no server-side resolution endpoint
+ * exists for this. Same convention Rapid already documents for local secrets (`config/dev.json`,
+ * gitignored), applied here to Custom Credentials.
+ */
+export const CUSTOM_CREDENTIALS_LOCAL_FILENAME = 'datadog-app.local.json';
+
+/**
+ * Resolves Custom Credentials for local execution by reading {@link CUSTOM_CREDENTIALS_LOCAL_FILENAME}
+ * from the project root. A missing file resolves to `{}` — most projects won't have one — but a
+ * present-and-malformed file throws, since silently ignoring a typo would make a declared secret
+ * look identical to an undeclared one.
+ */
+export async function resolveCustomCredentials(
+    projectRoot: string,
+): Promise<ResolvedCustomCredentials> {
+    const filePath = path.join(projectRoot, CUSTOM_CREDENTIALS_LOCAL_FILENAME);
+    let raw: string;
+    try {
+        raw = await fs.readFile(filePath, 'utf8');
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return {};
+        }
+        throw error;
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (error) {
+        throw new Error(
+            `${CUSTOM_CREDENTIALS_LOCAL_FILENAME} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        throw new Error(
+            `${CUSTOM_CREDENTIALS_LOCAL_FILENAME} must be a flat JSON object mapping env var names to string values.`,
+        );
+    }
+
+    const resolved: ResolvedCustomCredentials = {};
+    for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value !== 'string') {
+            throw new Error(
+                `${CUSTOM_CREDENTIALS_LOCAL_FILENAME}'s "${key}" value must be a string, got ${typeof value}.`,
+            );
+        }
+        resolved[key] = value;
+    }
+    return resolved;
+}

--- a/packages/plugins/apps/src/vite/custom-credentials-resolver.ts
+++ b/packages/plugins/apps/src/vite/custom-credentials-resolver.ts
@@ -41,10 +41,12 @@ export async function resolveCustomCredentials(
     let parsed: unknown;
     try {
         parsed = JSON.parse(raw);
-    } catch (error) {
-        throw new Error(
-            `${CUSTOM_CREDENTIALS_LOCAL_FILENAME} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
-        );
+    } catch {
+        // Never interpolate the underlying JSON.parse error here: V8's own message can embed a
+        // raw slice of the source text (e.g. `..."API_KEY": sk_test_ab"...`) when the malformed
+        // token looks like an unquoted value, which would echo a real secret into this error's
+        // message — and from there into the dev server's debug log and its HTTP response body.
+        throw new Error(`${CUSTOM_CREDENTIALS_LOCAL_FILENAME} is not valid JSON.`);
     }
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
         throw new Error(
@@ -52,7 +54,9 @@ export async function resolveCustomCredentials(
         );
     }
 
-    const resolved: ResolvedCustomCredentials = {};
+    // Object.create(null) rather than {} so a credential literally named "__proto__" round-trips
+    // as a normal own property instead of silently no-op'ing against Object.prototype's setter.
+    const resolved: ResolvedCustomCredentials = Object.create(null);
     for (const [key, value] of Object.entries(parsed)) {
         if (typeof value !== 'string') {
             throw new Error(

--- a/packages/plugins/apps/src/vite/custom-credentials-resolver.ts
+++ b/packages/plugins/apps/src/vite/custom-credentials-resolver.ts
@@ -18,6 +18,10 @@ export type ResolvedCustomCredentials = Record<string, string>;
  */
 export const CUSTOM_CREDENTIALS_LOCAL_FILENAME = 'datadog-app.local.json';
 
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+    return typeof error === 'object' && error !== null && 'code' in error;
+}
+
 /**
  * Resolves Custom Credentials for local execution by reading {@link CUSTOM_CREDENTIALS_LOCAL_FILENAME}
  * from the project root. A missing file resolves to `{}` — most projects won't have one — but a
@@ -32,7 +36,7 @@ export async function resolveCustomCredentials(
     try {
         raw = await readFile(filePath);
     } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        if (isErrnoException(error) && error.code === 'ENOENT') {
             return {};
         }
         throw error;
@@ -42,10 +46,8 @@ export async function resolveCustomCredentials(
     try {
         parsed = JSON.parse(raw);
     } catch {
-        // Never interpolate the underlying JSON.parse error here: V8's own message can embed a
-        // raw slice of the source text (e.g. `..."API_KEY": sk_test_ab"...`) when the malformed
-        // token looks like an unquoted value, which would echo a real secret into this error's
-        // message — and from there into the dev server's debug log and its HTTP response body.
+        // Never interpolate the underlying JSON.parse error: V8's message can embed a raw slice
+        // of an unquoted value's source text, echoing a real secret into logs/HTTP responses.
         throw new Error(`${CUSTOM_CREDENTIALS_LOCAL_FILENAME} is not valid JSON.`);
     }
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {

--- a/packages/plugins/apps/src/vite/env-guard.ts
+++ b/packages/plugins/apps/src/vite/env-guard.ts
@@ -33,8 +33,6 @@ const nativeReadlinkSync = fs.readlinkSync;
 
 export const SAFE_ENV_KEYS = ['PATH', 'HOME', 'NODE_ENV', 'TMPDIR'] as const;
 
-// customCredentials comes from custom-credentials-resolver.ts's resolveCustomCredentials — a
-// developer-maintained local file, empty by default.
 export function buildScopedEnv(customCredentials: Record<string, string>): Record<string, string> {
     const scoped: Record<string, string> = {};
     for (const key of SAFE_ENV_KEYS) {

--- a/packages/plugins/apps/src/vite/env-guard.ts
+++ b/packages/plugins/apps/src/vite/env-guard.ts
@@ -33,7 +33,8 @@ const nativeReadlinkSync = fs.readlinkSync;
 
 export const SAFE_ENV_KEYS = ['PATH', 'HOME', 'NODE_ENV', 'TMPDIR'] as const;
 
-// customCredentials is currently always {} — Custom Credential resolution for local execution is still undecided, so those values stay unset here rather than read from the real environment.
+// customCredentials comes from custom-credentials-resolver.ts's resolveCustomCredentials — a
+// developer-maintained local file, empty by default.
 export function buildScopedEnv(customCredentials: Record<string, string>): Record<string, string> {
     const scoped: Record<string, string> = {};
     for (const key of SAFE_ENV_KEYS) {

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -678,21 +678,24 @@ describe('Backend Functions - getVitePlugin', () => {
         });
     });
 
-    // Regression test: build-package.ts's exclusion filter only sees the unbundled file, so a
-    // direct import must be rejected separately or Vite would inline the real secret values.
-    test.each([{ ssr: true }, { ssr: false }])(
-        'Should reject a direct import of the local Custom Credentials file (ssr: $ssr)',
-        async ({ ssr }) => {
+    // Regression test: build-package.ts's exclusion filter only sees the unbundled file, and a
+    // query-suffixed specifier (`?raw`, `?url`) defeats a naive basename check — both must be
+    // rejected here or Vite inlines the real secret values into a built chunk.
+    test.each([
+        { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}`, ssr: true },
+        { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}`, ssr: false },
+        { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}?raw`, ssr: true },
+        { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}?url`, ssr: false },
+    ])(
+        'Should reject a direct import of the local Custom Credentials file (specifier: $specifier, ssr: $ssr)',
+        async ({ specifier, ssr }) => {
             const plugin = getVitePlugin(defaultOptions);
             const resolveIdHandler = getResolveIdHandler(plugin);
 
             await expect(
-                resolveIdHandler.call(
-                    { resolve: jest.fn() },
-                    `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}`,
-                    '/build/src/index.ts',
-                    { ssr },
-                ),
+                resolveIdHandler.call({ resolve: jest.fn() }, specifier, '/build/src/index.ts', {
+                    ssr,
+                }),
             ).rejects.toThrow(/cannot be imported directly/);
         },
     );

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -96,6 +96,23 @@ function isDevServerMiddleware(value: unknown): value is DevServerMiddleware {
     return typeof value === 'function';
 }
 
+type ConfigHookResult = {
+    ssr: { noExternal: string[] };
+    server: { fs: { deny: string[] } };
+};
+
+// Narrows `plugin.config` to its plain-function hook form via a runtime check, avoiding an `as`
+// cast on its return value — mirrors `getConfigureServer` above.
+function getConfigHandler(plugin: ReturnType<typeof getVitePlugin>): () => ConfigHookResult {
+    const { config } = plugin ?? {};
+    if (typeof config !== 'function') {
+        throw new Error('Expected plugin.config to be the plain function-hook form');
+    }
+    return function callConfig(): ConfigHookResult {
+        return Reflect.apply(config, undefined, []);
+    };
+}
+
 const functions: BackendFunction[] = [
     {
         relativePath: 'src/backend/myHandler',
@@ -661,6 +678,25 @@ describe('Backend Functions - getVitePlugin', () => {
         });
     });
 
+    // Regression test: build-package.ts's exclusion filter only sees the unbundled file, so a
+    // direct import must be rejected separately or Vite would inline the real secret values.
+    test.each([{ ssr: true }, { ssr: false }])(
+        'Should reject a direct import of the local Custom Credentials file (ssr: $ssr)',
+        async ({ ssr }) => {
+            const plugin = getVitePlugin(defaultOptions);
+            const resolveIdHandler = getResolveIdHandler(plugin);
+
+            await expect(
+                resolveIdHandler.call(
+                    { resolve: jest.fn() },
+                    `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}`,
+                    '/build/src/index.ts',
+                    { ssr },
+                ),
+            ).rejects.toThrow(/cannot be imported directly/);
+        },
+    );
+
     test('Should inject the apps runtime', () => {
         getVitePlugin(defaultOptions);
 
@@ -677,10 +713,7 @@ describe('Backend Functions - getVitePlugin', () => {
         // module" for them — ssr.noExternal is what server.ssrLoadModule depends on to load them
         // correctly.
         const plugin = getVitePlugin(defaultOptions);
-        const configHook = plugin!.config as () => {
-            ssr: { noExternal: string[] };
-            server: { fs: { deny: string[] } };
-        };
+        const configHook = getConfigHandler(plugin);
         const config = configHook();
 
         expect(config).toEqual({
@@ -699,7 +732,7 @@ describe('Backend Functions - getVitePlugin', () => {
     // so .env/cert/.git protection must be preserved explicitly alongside this filename.
     test("Should preserve Vite's default server.fs.deny patterns alongside the credentials filename", () => {
         const plugin = getVitePlugin(defaultOptions);
-        const configHook = plugin!.config as () => { server: { fs: { deny: string[] } } };
+        const configHook = getConfigHandler(plugin);
         const { deny } = configHook().server.fs;
 
         expect(deny).toEqual(expect.arrayContaining(VITE_DEFAULT_SERVER_FS_DENY));

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import { CUSTOM_CREDENTIALS_LOCAL_FILENAME } from '@dd/apps-plugin/vite/custom-credentials-resolver';
 import { getVitePlugin } from '@dd/apps-plugin/vite/index';
 import type { ViteBundler } from '@dd/apps-plugin/vite/index';
 import { localExecutionResolutionContext } from '@dd/apps-plugin/vite/local-execution';
@@ -676,14 +677,30 @@ describe('Backend Functions - getVitePlugin', () => {
         // module" for them — ssr.noExternal is what server.ssrLoadModule depends on to load them
         // correctly.
         const plugin = getVitePlugin(defaultOptions);
-        const configHook = plugin!.config as () => { ssr: { noExternal: string[] } };
+        const configHook = plugin!.config as () => {
+            ssr: { noExternal: string[] };
+            server: { fs: { deny: string[] } };
+        };
         const config = configHook();
 
         expect(config).toEqual({
             ssr: {
                 noExternal: ['@datadog/apps-backend', '@datadog/action-catalog'],
             },
+            server: {
+                fs: {
+                    deny: [CUSTOM_CREDENTIALS_LOCAL_FILENAME],
+                },
+            },
         });
+    });
+
+    test('Should deny the dev server from serving the local Custom Credentials file over HTTP', () => {
+        const plugin = getVitePlugin(defaultOptions);
+        const configHook = plugin!.config as () => { server: { fs: { deny: string[] } } };
+        const config = configHook();
+
+        expect(config.server.fs.deny).toContain(CUSTOM_CREDENTIALS_LOCAL_FILENAME);
     });
 
     // Uses the real configureServer hook, not createDevServerMiddleware directly, to catch mode-forwarding regressions.

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -679,13 +679,15 @@ describe('Backend Functions - getVitePlugin', () => {
     });
 
     // Regression test: build-package.ts's exclusion filter only sees the unbundled file, and a
-    // query-suffixed specifier (`?raw`, `?url`) defeats a naive basename check — both must be
-    // rejected here or Vite inlines the real secret values into a built chunk.
+    // query- or hash-suffixed specifier (`?raw`, `?url`, `#fragment`) defeats a naive basename
+    // check — all must be rejected here or Vite inlines the real secret values into a built chunk.
     test.each([
         { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}`, ssr: true },
         { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}`, ssr: false },
         { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}?raw`, ssr: true },
         { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}?url`, ssr: false },
+        { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}#fragment`, ssr: true },
+        { specifier: `../${CUSTOM_CREDENTIALS_LOCAL_FILENAME}?raw#fragment`, ssr: false },
     ])(
         'Should reject a direct import of the local Custom Credentials file (specifier: $specifier, ssr: $ssr)',
         async ({ specifier, ssr }) => {

--- a/packages/plugins/apps/src/vite/index.test.ts
+++ b/packages/plugins/apps/src/vite/index.test.ts
@@ -3,7 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import { CUSTOM_CREDENTIALS_LOCAL_FILENAME } from '@dd/apps-plugin/vite/custom-credentials-resolver';
-import { getVitePlugin } from '@dd/apps-plugin/vite/index';
+import { getVitePlugin, VITE_DEFAULT_SERVER_FS_DENY } from '@dd/apps-plugin/vite/index';
 import type { ViteBundler } from '@dd/apps-plugin/vite/index';
 import { localExecutionResolutionContext } from '@dd/apps-plugin/vite/local-execution';
 import { InjectPosition } from '@dd/core/types';
@@ -689,18 +689,20 @@ describe('Backend Functions - getVitePlugin', () => {
             },
             server: {
                 fs: {
-                    deny: [CUSTOM_CREDENTIALS_LOCAL_FILENAME],
+                    deny: expect.arrayContaining([CUSTOM_CREDENTIALS_LOCAL_FILENAME]),
                 },
             },
         });
     });
 
-    test('Should deny the dev server from serving the local Custom Credentials file over HTTP', () => {
+    // Regression test: a plugin's own server.fs.deny replaces Vite's defaults instead of merging,
+    // so .env/cert/.git protection must be preserved explicitly alongside this filename.
+    test("Should preserve Vite's default server.fs.deny patterns alongside the credentials filename", () => {
         const plugin = getVitePlugin(defaultOptions);
         const configHook = plugin!.config as () => { server: { fs: { deny: string[] } } };
-        const config = configHook();
+        const { deny } = configHook().server.fs;
 
-        expect(config.server.fs.deny).toContain(CUSTOM_CREDENTIALS_LOCAL_FILENAME);
+        expect(deny).toEqual(expect.arrayContaining(VITE_DEFAULT_SERVER_FS_DENY));
     });
 
     // Uses the real configureServer hook, not createDevServerMiddleware directly, to catch mode-forwarding regressions.

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -165,12 +165,12 @@ export const getVitePlugin = ({
             // first, short-circuiting the hook chain before this plugin ever sees it.
             order: 'pre',
             async handler(source, importer, resolveOptions) {
-                // An import of this file (including a query-suffixed one, e.g. `?raw`) would let
-                // Vite inline its real secret values into a chunk that build-package.ts's exclusion
-                // filter never sees — strip the query before comparing basenames below.
-                const sourceWithoutQuery = source.split('?')[0];
+                // Strips the query/hash suffix before comparing, matching Vite's own postfixRE —
+                // otherwise a `?raw`/`#fragment`-suffixed import bypasses this check and Vite
+                // inlines the real secret into a chunk build-package.ts's filter never sees.
+                const sourceWithoutPostfix = source.replace(/[?#].*$/, '');
                 if (
-                    path.basename(sourceWithoutQuery).toLowerCase() ===
+                    path.basename(sourceWithoutPostfix).toLowerCase() ===
                     CUSTOM_CREDENTIALS_LOCAL_FILENAME
                 ) {
                     throw new Error(

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -33,6 +33,7 @@ import type { AppsOptionsWithDefaults } from '../types';
 
 import { buildBackendFunctions } from './build-backend-functions';
 import { buildAppPackage } from './build-package';
+import { CUSTOM_CREDENTIALS_LOCAL_FILENAME } from './custom-credentials-resolver';
 import { collectModuleGraphFromServer } from './dev-server-module-graph';
 import { createDevServerMiddleware } from './dev-server';
 import { localExecutionResolutionContext } from './local-execution';
@@ -141,6 +142,13 @@ export const getVitePlugin = ({
             return {
                 ssr: {
                     noExternal: ['@datadog/apps-backend', '@datadog/action-catalog'],
+                },
+                // Vite's dev server serves any project-root file not on this list over HTTP —
+                // the default list only covers .env/.git/certs, not this filename.
+                server: {
+                    fs: {
+                        deny: [CUSTOM_CREDENTIALS_LOCAL_FILENAME],
+                    },
                 },
             };
         },

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -165,10 +165,14 @@ export const getVitePlugin = ({
             // first, short-circuiting the hook chain before this plugin ever sees it.
             order: 'pre',
             async handler(source, importer, resolveOptions) {
-                // An import/import.meta.glob of this file would let Vite inline its real secret
-                // values into a generated chunk — build-package.ts's exclusion filter only ever sees
-                // the original, unbundled file.
-                if (path.basename(source).toLowerCase() === CUSTOM_CREDENTIALS_LOCAL_FILENAME) {
+                // An import of this file (including a query-suffixed one, e.g. `?raw`) would let
+                // Vite inline its real secret values into a chunk that build-package.ts's exclusion
+                // filter never sees — strip the query before comparing basenames below.
+                const sourceWithoutQuery = source.split('?')[0];
+                if (
+                    path.basename(sourceWithoutQuery).toLowerCase() ===
+                    CUSTOM_CREDENTIALS_LOCAL_FILENAME
+                ) {
                     throw new Error(
                         `${CUSTOM_CREDENTIALS_LOCAL_FILENAME} cannot be imported directly — read Custom Credentials via process.env instead.`,
                     );

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -165,6 +165,15 @@ export const getVitePlugin = ({
             // first, short-circuiting the hook chain before this plugin ever sees it.
             order: 'pre',
             async handler(source, importer, resolveOptions) {
+                // An import/import.meta.glob of this file would let Vite inline its real secret
+                // values into a generated chunk — build-package.ts's exclusion filter only ever sees
+                // the original, unbundled file.
+                if (path.basename(source).toLowerCase() === CUSTOM_CREDENTIALS_LOCAL_FILENAME) {
+                    throw new Error(
+                        `${CUSTOM_CREDENTIALS_LOCAL_FILENAME} cannot be imported directly — read Custom Credentials via process.env instead.`,
+                    );
+                }
+
                 // Top-level guard (not folded into each branch) so any future branch added below
                 // inherits it automatically: local execution's traversal is always SSR, so without
                 // this a client-mode resolution could inherit the marker and leak real backend code.

--- a/packages/plugins/apps/src/vite/index.ts
+++ b/packages/plugins/apps/src/vite/index.ts
@@ -99,6 +99,9 @@ function createBackendFunctionRegistry() {
 
 const APPS_RUNTIME_PATH = path.join(__dirname, './apps-runtime.mjs');
 
+// Not exported by Vite; mirrors its server.fs.deny default so it can be spread in below.
+export const VITE_DEFAULT_SERVER_FS_DENY = ['.env', '.env.*', '*.{crt,pem}', '**/.git/**'];
+
 /**
  * Returns the Vite-specific plugin hooks for the apps plugin.
  *
@@ -143,11 +146,12 @@ export const getVitePlugin = ({
                 ssr: {
                     noExternal: ['@datadog/apps-backend', '@datadog/action-catalog'],
                 },
-                // Vite's dev server serves any project-root file not on this list over HTTP —
-                // the default list only covers .env/.git/certs, not this filename.
+                // Vite replaces its whole server.fs.deny default rather than merging with a
+                // plugin's own list, so the defaults above must be spread in here or dev-server
+                // protection for .env/.git/certs silently disappears once this filename is added.
                 server: {
                     fs: {
-                        deny: [CUSTOM_CREDENTIALS_LOCAL_FILENAME],
+                        deny: [...VITE_DEFAULT_SERVER_FS_DENY, CUSTOM_CREDENTIALS_LOCAL_FILENAME],
                     },
                 },
             };

--- a/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.resilience.test.ts
@@ -15,11 +15,14 @@ import { executeScriptLocally } from './local-execution';
 describe('local-execution resilience (in-process execution known limitations)', () => {
     // A real `while (true) {}` would hang this test forever, since nothing — not even the timeout's
     // own callback — can run while the event loop is blocked synchronously. This bounded busy-wait
-    // proves the same point safely: the 20ms timeout can't interrupt it, so it settles at ~80ms.
+    // proves the same point safely: the timeout can't interrupt it, so it settles once the loop ends.
+    // Margins are generous because loadCustomerModuleEntry's Custom Credentials priming (a dynamic
+    // import plus a real fs read) runs before the loop starts with variable cold-start latency, and
+    // must stay under the timeout for this test to mean anything.
     test('Should NOT interrupt a synchronous CPU-bound loop with the current timeout — known, accepted v1 limitation', async () => {
         const resolver = moduleResolverFor(func, {
             example: () => {
-                const deadline = Date.now() + 80;
+                const deadline = Date.now() + 800;
                 // eslint-disable-next-line no-empty
                 while (Date.now() < deadline) {}
                 return 'loop finished on its own';
@@ -36,13 +39,13 @@ describe('local-execution resilience (in-process execution known limitations)', 
             stubGetRuntimeContext,
             resolver,
             mockLogger,
-            20,
+            300,
         );
 
         const elapsedMs = Date.now() - start;
 
         expect(result).toEqual({ data: 'loop finished on its own' });
-        expect(elapsedMs).toBeGreaterThanOrEqual(60);
+        expect(elapsedMs).toBeGreaterThanOrEqual(700);
     });
 
     // process.exit() would kill this Jest process, so the fixture runs as its own real Jest process —

--- a/packages/plugins/apps/src/vite/local-execution.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.test.ts
@@ -29,6 +29,7 @@ import {
     DEFAULT_LONG_POLLING_CONFIG,
     DEFAULT_TIMEOUT_MS,
     deriveActionTimeouts,
+    executeColdActionLocally,
     executeScriptLocally as executeScriptLocallyWithRuntimeContext,
 } from './local-execution';
 import { forceReset } from './network-guard';
@@ -1220,6 +1221,57 @@ describe('local-execution — executeScriptLocally', () => {
                 );
 
                 expect(result).toEqual({ data: 'sk_test_123' });
+            } finally {
+                await fsPromises.rm(projectRoot, { recursive: true, force: true });
+            }
+        });
+
+        // Regression coverage: executeColdActionLocally primes the module before runScriptLocally
+        // ever runs, so a customer module's own top-level code (e.g. `new Stripe(process.env.X)`)
+        // executes during the priming load, not during the later invocation-scope call above.
+        test('Should resolve real Custom Credentials for the priming load too, so module-top-level code sees real values', async () => {
+            jest.spyOn(customCredentialsResolver, 'resolveCustomCredentials').mockImplementation(
+                realResolveCustomCredentials,
+            );
+
+            const projectRoot = await fsPromises.mkdtemp(
+                path.join(os.tmpdir(), 'local-execution-custom-credentials-'),
+            );
+            try {
+                await fsPromises.writeFile(
+                    path.join(
+                        projectRoot,
+                        customCredentialsResolver.CUSTOM_CREDENTIALS_LOCAL_FILENAME,
+                    ),
+                    JSON.stringify({ STRIPE_API_KEY: 'sk_test_priming' }),
+                );
+
+                let capturedAtModuleLoad: string | undefined;
+                const loadModule: LoadModule = async (specifier: string) => {
+                    if (specifier === func.absolutePath + LOCAL_EXECUTION_LOAD_SUFFIX) {
+                        capturedAtModuleLoad = process.env.STRIPE_API_KEY;
+                        return { example: () => capturedAtModuleLoad };
+                    }
+                    const error: NodeJS.ErrnoException = new Error(
+                        `Cannot find module '${specifier}'`,
+                    );
+                    error.code = 'MODULE_NOT_FOUND';
+                    throw error;
+                };
+
+                const result = await executeColdActionLocally(
+                    func,
+                    projectRoot,
+                    [],
+                    stubExecuteAction,
+                    stubGetRuntimeContext,
+                    loadModule,
+                    async () => [],
+                    mockLogger,
+                );
+
+                expect(result).toEqual({ data: 'sk_test_priming' });
+                expect(capturedAtModuleLoad).toBe('sk_test_priming');
             } finally {
                 await fsPromises.rm(projectRoot, { recursive: true, force: true });
             }
@@ -2555,6 +2607,7 @@ describe('local-execution — executeScriptLocally', () => {
                 const mod = await isolatedLoadCustomerModuleEntry(
                     loadModule,
                     func.absolutePath + LOCAL_EXECUTION_LOAD_SUFFIX,
+                    TEST_PROJECT_ROOT,
                 );
                 expect(mod).toEqual({ example: expect.any(Function) });
             });

--- a/packages/plugins/apps/src/vite/local-execution.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.test.ts
@@ -7,12 +7,16 @@
 import type { Logger } from '@dd/core/types';
 import { installFakeProcessEnv } from '@dd/tests/_jest/helpers/env';
 import { mockLogFn, mockLogger, moduleResolverFor } from '@dd/tests/_jest/helpers/mocks';
+import fsPromises from 'fs/promises';
 import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import * as shared from '../backend/shared';
 import type { BackendFunction } from '../backend/types';
 import { LOCAL_EXECUTION_LOAD_SUFFIX } from '../constants';
 
+import * as customCredentialsResolver from './custom-credentials-resolver';
 import { forceResetEnv } from './env-guard';
 import {
     func,
@@ -33,6 +37,10 @@ const funcWithConnection: BackendFunction = { ...func, allowedConnectionIds: ['c
 
 const TEST_PROJECT_ROOT = '/project';
 
+// Captured before beforeEach's spyOn ever replaces the export — jest.requireActual would return
+// this same, by-then-mocked module object instead of a real one, since it was never jest.mock()'d.
+const realResolveCustomCredentials = customCredentialsResolver.resolveCustomCredentials;
+
 interface TestGlobalDollar {
     backendFunctionArgs: unknown[];
     // Left untyped: $.Actions is a Proxy of unbounded, dynamic depth ($.Actions.<any>.<any>...(...)), the same shape a real customer's untyped code sees.
@@ -50,6 +58,11 @@ beforeEach(() => {
     // Neither optional SDK is installed by default; tests exercising the "installed" path override this.
     jest.spyOn(shared, 'isActionCatalogInstalled').mockReturnValue(false);
     jest.spyOn(shared, 'isDatadogAppsBackendInstalled').mockReturnValue(false);
+    // Real fs I/O races unpredictably against the fake-timer tests below (TEST_PROJECT_ROOT isn't
+    // a real directory anyway); tests covering the real file read live in
+    // custom-credentials-resolver.test.ts, plus one integration test further down that restores
+    // the real implementation for its own duration.
+    jest.spyOn(customCredentialsResolver, 'resolveCustomCredentials').mockResolvedValue({});
 });
 
 /** Keeps the existing test call sites concise while every invocation receives a fresh preview context. */
@@ -1181,6 +1194,38 @@ describe('local-execution — executeScriptLocally', () => {
 
             expect(result).toEqual({ data: 'ok' });
             expect(envSeenDuringRegistration).toBeUndefined();
+        });
+
+        test('Should expose a value from a real datadog-app.local.json file as process.env in the customer function', async () => {
+            jest.spyOn(customCredentialsResolver, 'resolveCustomCredentials').mockImplementation(
+                realResolveCustomCredentials,
+            );
+
+            const projectRoot = await fsPromises.mkdtemp(
+                path.join(os.tmpdir(), 'local-execution-custom-credentials-'),
+            );
+            try {
+                await fsPromises.writeFile(
+                    path.join(
+                        projectRoot,
+                        customCredentialsResolver.CUSTOM_CREDENTIALS_LOCAL_FILENAME,
+                    ),
+                    JSON.stringify({ STRIPE_API_KEY: 'sk_test_123' }),
+                );
+
+                const result = await executeScriptLocally(
+                    func,
+                    projectRoot,
+                    [],
+                    stubExecuteAction,
+                    loadModuleReturning({ example: () => process.env.STRIPE_API_KEY }),
+                    mockLogger,
+                );
+
+                expect(result).toEqual({ data: 'sk_test_123' });
+            } finally {
+                await fsPromises.rm(projectRoot, { recursive: true, force: true });
+            }
         });
     });
 

--- a/packages/plugins/apps/src/vite/local-execution.test.ts
+++ b/packages/plugins/apps/src/vite/local-execution.test.ts
@@ -58,10 +58,7 @@ beforeEach(() => {
     // Neither optional SDK is installed by default; tests exercising the "installed" path override this.
     jest.spyOn(shared, 'isActionCatalogInstalled').mockReturnValue(false);
     jest.spyOn(shared, 'isDatadogAppsBackendInstalled').mockReturnValue(false);
-    // Real fs I/O races unpredictably against the fake-timer tests below (TEST_PROJECT_ROOT isn't
-    // a real directory anyway); tests covering the real file read live in
-    // custom-credentials-resolver.test.ts, plus one integration test further down that restores
-    // the real implementation for its own duration.
+    // Real fs I/O races unpredictably against the fake-timer tests below.
     jest.spyOn(customCredentialsResolver, 'resolveCustomCredentials').mockResolvedValue({});
 });
 

--- a/packages/plugins/apps/src/vite/local-execution.ts
+++ b/packages/plugins/apps/src/vite/local-execution.ts
@@ -15,6 +15,7 @@ import { LOCAL_EXECUTION_LOAD_SUFFIX } from '../constants';
 import type { LongPollingOptions } from '../types';
 import { resolveLongPolling } from '../validate';
 
+import { resolveCustomCredentials } from './custom-credentials-resolver';
 import type { EnvScopeHandle } from './env-guard';
 import { createEpochGuard } from './execution-epoch';
 import type { BlockedScopeHandle } from './network-guard';
@@ -241,6 +242,9 @@ export async function loadCustomerModuleEntry(
 ): Promise<Record<string, unknown>> {
     await getNetworkGuard();
     const { buildScopedEnv, runWithScopedEnv } = await getEnvGuard();
+    // {} rather than a real resolution: this priming load has no projectRoot, and its top-level
+    // eval is already outside the guarded scope (see doc comment above) — runScriptLocally is
+    // what resolves real credentials for function bodies.
     const scopedEnv = buildScopedEnv({});
     return localExecutionResolutionContext.run(new Set(), () =>
         customerModuleLoadContext.run({ assigned: false, value: undefined }, () =>
@@ -901,10 +905,18 @@ async function runScriptLocally(
                     // toJSON()/getter must run while access is still blocked/scoped.
                     const networkGuardPromise = getNetworkGuard();
                     const envGuardPromise = getEnvGuard();
-                    const [{ runBlocked }, { buildScopedEnv, runWithScopedEnv }] =
-                        await Promise.all([networkGuardPromise, envGuardPromise]);
+                    const customCredentialsPromise = resolveCustomCredentials(projectRoot);
+                    const [
+                        { runBlocked },
+                        { buildScopedEnv, runWithScopedEnv },
+                        customCredentials,
+                    ] = await Promise.all([
+                        networkGuardPromise,
+                        envGuardPromise,
+                        customCredentialsPromise,
+                    ]);
                     rejectIfAbandoned();
-                    const scopedEnv = buildScopedEnv({});
+                    const scopedEnv = buildScopedEnv(customCredentials);
                     const data = await runWithScopedEnv(
                         scopedEnv,
                         () =>

--- a/packages/plugins/apps/src/vite/local-execution.ts
+++ b/packages/plugins/apps/src/vite/local-execution.ts
@@ -230,22 +230,28 @@ export type LoadModule = (specifier: string) => Promise<Record<string, unknown>>
 
 /**
  * Loads a customer module under `runScriptLocally`'s top-level-evaluation `$`-scoping (see
- * `customerModuleLoadContext`), for callers like dev-server.ts's priming load. Scopes `process.env`
- * first so a dependency's top-level code can't capture the real `fs.readFileSync` and bypass the
- * guard. Accepted residual gap: runs outside `runBlocked`, so top-level code still has real
+ * `customerModuleLoadContext`), for callers like dev-server.ts's priming load that trigger real
+ * top-level evaluation ahead of `executeScriptLocally`. Scopes `process.env` and the network guard
+ * first so a dependency's top-level code can't capture the real, unwrapped `fs.readFileSync`/network
+ * APIs and bypass the guard for the rest of the session. Resolves real Custom Credentials via
+ * `projectRoot` too — module-scope SDK initialization (`new Stripe(process.env.X)`) would otherwise
+ * always capture `undefined`. `onScopeStarted` lets a caller record this load's abandon token so a
+ * hung load can be abandoned without affecting any other execution's still-active scope. Accepted
+ * residual gap: this load still runs outside `runBlocked`, so top-level code has real, unguarded
  * network/subprocess access — not a hard boundary, matching this file's "no OS sandbox" framing.
  */
 export async function loadCustomerModuleEntry(
     loadModule: LoadModule,
     entrySpecifier: string,
+    projectRoot: string,
     onScopeStarted?: (handle: EnvScopeHandle) => void,
 ): Promise<Record<string, unknown>> {
-    await getNetworkGuard();
-    const { buildScopedEnv, runWithScopedEnv } = await getEnvGuard();
-    // {} rather than a real resolution: this priming load has no projectRoot, and its top-level
-    // eval is already outside the guarded scope (see doc comment above) — runScriptLocally is
-    // what resolves real credentials for function bodies.
-    const scopedEnv = buildScopedEnv({});
+    const [{ buildScopedEnv, runWithScopedEnv }, customCredentials] = await Promise.all([
+        getEnvGuard(),
+        resolveCustomCredentials(projectRoot),
+        getNetworkGuard(),
+    ]);
+    const scopedEnv = buildScopedEnv(customCredentials);
     return localExecutionResolutionContext.run(new Set(), () =>
         customerModuleLoadContext.run({ assigned: false, value: undefined }, () =>
             runWithScopedEnv(scopedEnv, () => loadModule(entrySpecifier), onScopeStarted),
@@ -720,9 +726,14 @@ export async function executeColdActionLocally(
         );
         const entrySpecifier = func.absolutePath + LOCAL_EXECUTION_LOAD_SUFFIX;
         let primingEnvScope: EnvScopeHandle | undefined;
-        const primingPromise = loadCustomerModuleEntry(loadModule, entrySpecifier, (handle) => {
-            primingEnvScope = handle;
-        });
+        const primingPromise = loadCustomerModuleEntry(
+            loadModule,
+            entrySpecifier,
+            projectRoot,
+            (handle) => {
+                primingEnvScope = handle;
+            },
+        );
         let primedEntry: Record<string, unknown> | undefined;
         try {
             primedEntry = await withTimeout(primingPromise, timeoutMs, `Loading "${displayName}"`);
@@ -872,6 +883,7 @@ async function runScriptLocally(
                 (await loadCustomerModuleEntry(
                     loadModule,
                     func.absolutePath + LOCAL_EXECUTION_LOAD_SUFFIX,
+                    projectRoot,
                 ));
             const fn = mod[func.name];
             if (typeof fn !== 'function') {


### PR DESCRIPTION
## Motivation

- Local execution leaves Custom Credentials permanently `undefined`, so a backend function that reads a secret directly (e.g. to call a third-party SDK) fails under `npm run dev` even though the same code works in production.
- Custom Credentials are already in active use (`customcredentials.yaml`, `dequeue_task.go`, `js-function-with-actions.ts`), not a rare edge case.
- Credentials are resolved from `datadog-app.local.json`, a file the developer maintains in their project root — no network call, no new auth model — mirroring Rapid's own `config/dev.json` convention for local secrets.
- Decision recorded in the [Kickoff doc's Secret Store parity Follow-ups](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455/Local+Node+Execution+of+Backend+Functions+Kickoff#Follow%E2%80%91ups) and the [RFC](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651/RFC+Local+Node+execution+for+High+Code+Apps+backend+functions).

## Architecture

```
Developer edits datadog-app.local.json in their project root
(developer-maintained, e.g. { "STRIPE_API_KEY": "sk_test_..." })
   │
   ▼
custom-credentials-resolver.ts's resolveCustomCredentials(projectRoot)
   │  missing file → {}
   │  malformed JSON / non-object / non-string value → throws
   ▼
ResolvedCustomCredentials (Record<string, string>)
   │  resolved fresh on each runScriptLocally call, in parallel
   │  with getNetworkGuard()/getEnvGuard() via Promise.all
   ▼
env-guard.ts's buildScopedEnv(customCredentials) — additive on top of
the existing from-scratch allowlist (PATH/HOME/NODE_ENV/TMPDIR)
   │
   ▼
Customer function's process.env
```

`loadCustomerModuleEntry` (the dev-server's priming load for a customer module's top-level code) calls `buildScopedEnv({})` on purpose — it has no `projectRoot` in its signature and already runs outside `network-guard.ts`'s `runBlocked` scope, an accepted gap predating this PR.

## Changes

<details><summary>13 changes across custom-credentials-resolver.ts, custom-credentials-resolver.test.ts, local-execution.ts, local-execution.test.ts, env-guard.ts, index.ts, index.test.ts, build-package.ts, index.test.ts (root), README.md</summary>

| What changed | File |
| --- | --- |
| `resolveCustomCredentials()` reads and validates `datadog-app.local.json`: missing file resolves to `{}`, malformed JSON/non-object/non-string values throw via an `isErrnoException` type guard (not an `as`-cast); the JSON-parse-error path never interpolates V8's own error message, which could otherwise embed a raw secret value into the dev server's debug log and HTTP response; uses `Object.create(null)` as the target object so a credential literally named `__proto__` round-trips as a real own property instead of silently no-op'ing | `custom-credentials-resolver.ts` |
| Tests against real temp-directory I/O: missing file, valid file, malformed JSON (asserting no secret value leaks into the thrown message), top-level array, non-string value, a directory shadowing the file path, a `__proto__`-named credential | `custom-credentials-resolver.test.ts` |
| `runScriptLocally` resolves real credentials via `Promise.all` and passes them into `buildScopedEnv`; `loadCustomerModuleEntry` documented as intentionally unresolved | `local-execution.ts` |
| `resolveCustomCredentials` mocked in `beforeEach` (real fs I/O races the suite's fake-timer tests); added an integration test proving a real local file's value reaches `process.env` in the executed function | `local-execution.test.ts` |
| Removed the stale comment claiming `customCredentials` is always `{}`, now that a real value can be resolved | `env-guard.ts` |
| Adds `datadog-app.local.json` to the Vite plugin's `server.fs.deny`, spread alongside Vite's own default deny patterns (`.env`, `.env.*`, certs, `.git`) rather than replacing them — Vite replaces its whole default list when a plugin sets this field, so a naive single-entry list would silently drop existing `.env`/cert/`.git` protection while only adding coverage for the new filename | `index.ts` |
| Asserts the plugin's `config()` hook returns the `server.fs.deny` entry, and that it still contains Vite's own default patterns alongside it | `index.test.ts` |
| Documents `datadog-app.local.json`, the need to gitignore it, and that values are only available inside a function body (not a module's top-level evaluation) | `README.md` |
| `buildAppPackage` excludes `datadog-app.local.json` from the shipped archive by comparing each candidate asset's `(device, inode)` identity (via `fs.stat`, which follows symlinks) against the credentials file's own — this catches a lowercased-basename match, a symlink in either direction (an asset symlinking to the credentials file, or the credentials file itself symlinking to a separately-matched asset), and a hardlink under another name, none of which a basename or one-directional realpath check alone can see — `options.include` is user-configured and has no gitignore-awareness, so a broad pattern like `**/*.json` would otherwise bundle real secret values into the production package | `build-package.ts` |
| Test proving a broad `options.include` matching the local file can't override the exclusion; removed a test fully redundant with an existing `server.fs.deny` assertion | `index.test.ts` |
| Tests proving the packaging exclusion holds for a case-variant filename, a symlink in either direction, a hardlink under another name, and a non-ENOENT stat failure on the candidate asset (propagates rather than being treated as safe) | `index.test.ts` (root) |
| A `resolveId` hook rejects any import (or `import.meta.glob` match) of `datadog-app.local.json`, for dev and build, client and SSR, stripping a resource query or hash fragment (e.g. `?raw`, `?url`, `#fragment`) before comparing basenames, matching Vite's own postfix-stripping during resolution — the packaging-exclusion filter above only ever inspects the original, unbundled file, so a direct (possibly suffixed) import would otherwise let Vite inline the real secret values into a generated chunk instead | `index.ts` |
| Test proving the direct-import rejection fires for SSR and client resolution and for query-/hash-suffixed specifiers; replaced the remaining `plugin!.config as (...)` casts with a `getConfigHandler` runtime-narrowing helper, matching this file's existing `getConfigureServer`/`getResolveIdHandler` pattern | `index.test.ts` |

</details>

## QA Instructions

CI run: https://github.com/DataDog/build-plugins/actions/runs/34528100647

```bash
yarn workspace @dd/tests test:unit packages/plugins/apps
# Expected: Test Suites: 35 passed, 35 total / Tests: 733 passed, 733 total ✅ VERIFIED
# local-execution.resilience.test.ts's CPU-bound-loop timeout test (and occasionally another
# suite, e.g. dev-server.test.ts) is a pre-existing, unrelated flake under parallel Jest
# workers — passes in isolation every time; neither file is touched by this PR.
```

```bash
yarn workspace @dd/apps-plugin typecheck
# Expected: exit 0, no output ✅ VERIFIED
```

```bash
yarn eslint packages/plugins/apps/src/vite/{custom-credentials-resolver,custom-credentials-resolver.test,build-package,local-execution,local-execution.test,env-guard,index,index.test}.ts packages/plugins/apps/src/index.test.ts
# Expected: 0 errors, 8 pre-existing func-names warnings on untouched lines ✅ VERIFIED
```

<details><summary>Manual QA: packaging fix — broad options.include can't ship the local credentials file</summary>

Scaffolded a real Vite app, configured `apps.include: ['**/*.json']` (deliberately broad, to exercise the exact leak scenario), built a production package, and inspected the resulting archive.

```bash
#!/usr/bin/env bash
set -uo pipefail

REPO_ROOT="<path to build-plugins repo>"
SCRATCH_DIR="/tmp/qa-app-2792-packaging"

rm -rf "$SCRATCH_DIR"
cd /tmp
npm create vite@latest qa-app-2792-packaging -- --template vanilla-ts
cd "$SCRATCH_DIR"
npm install

cat > vite.config.ts <<EOF
import { defineConfig } from 'vite';
import { datadogVitePlugin } from '$REPO_ROOT/packages/published/vite-plugin/dist/src/index.mjs';

export default defineConfig({
    plugins: [
        datadogVitePlugin({
            auth: { site: 'datad0g.com' },
            apps: { enable: true, include: ['**/*.json'] },
        }),
    ],
});
EOF

cat > src/getStripeKeyPrefix.backend.ts <<'EOF'
export async function getStripeKeyPrefix() {
    const key = process.env.STRIPE_API_KEY;
    return key ? key.slice(0, 7) : 'MISSING';
}
EOF

cat > src/main.ts <<'EOF'
import './getStripeKeyPrefix.backend';
document.querySelector<HTMLDivElement>('#app')!.innerHTML = '<h1>QA app 2792 packaging</h1>';
EOF

# Real secrets file — must never appear in the shipped archive.
cat > datadog-app.local.json <<'EOF'
{
    "STRIPE_API_KEY": "sk_test_should_never_ship_in_package"
}
EOF

# Legitimate JSON config the developer does want shipped.
echo '{"harmless": "config that legitimately should ship"}' > app-config.json

# Case-variant of the same file — the exclusion filter must catch this too on a
# case-insensitive filesystem (macOS/Windows default).
cat > Datadog-App.Local.Json <<'EOF'
{
    "STRIPE_API_KEY": "sk_test_should_never_ship_case_variant"
}
EOF

rm -rf dist
dd-auth --domain dd.datad0g.com -- sh -c "npx vite build"
unzip -l dist/datadog-app-assets.zip
```

Real captured output from running this script standalone, from a clean checkout (archive truncated to the relevant rows — the full listing includes 83 files, since `**/*.json` also matched `node_modules/**/*.json`, which is exactly the kind of over-broad match this fix guards against):

```
Archive:  dist/datadog-app-assets.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  09-10-2026 16:27   frontend/
      560  09-10-2026 16:27   frontend/tsconfig.json
      287  09-10-2026 16:27   frontend/package.json
    25442  09-10-2026 16:27   frontend/package-lock.json
       53  09-10-2026 16:27   frontend/app-config.json
        0  09-10-2026 16:27   frontend/node_modules/...   (79 more node_modules/**/*.json files)
        0  09-10-2026 16:27   frontend/dist/
      405  09-10-2026 16:27   frontend/dist/index.html
        ...
        0  09-10-2026 16:27   backend/
     1079  09-10-2026 16:27   backend/<hash>.getStripeKeyPrefix.js
      185  09-10-2026 16:27   manifest.json
---------                     -------
  4573633                     83 files
```
`unzip -l dist/datadog-app-assets.zip | grep -i local` → no output — neither `datadog-app.local.json` nor its case-variant `Datadog-App.Local.Json` appears anywhere in the archive.
✅ VERIFIED — `app-config.json` (the legitimate config) still ships; both the exact-case and case-variant credentials files are excluded even though the same broad `**/*.json` pattern matched all three.

</details>

<details><summary>Manual QA: symlink in either direction, a hardlink, and a combined query+hash-suffixed import are all still caught</summary>

The basename/one-directional-realpath check above still missed three cases: the credentials file itself being a symlink to a separately-matched asset, a hardlink under another name (no symlink involved at all, so `fs.realpath` can't see it), and a direct import suffixed with both a query and a hash fragment together (`?raw#fragment`). Reproduced each against the real production code with real filesystem objects (`fs.symlink`, `fs.link`) and a real archive read-back, not a synthetic assertion.

```bash
yarn workspace @dd/tests test:unit packages/plugins/apps/src/index.test.ts -t "never packages"
```
```
✓ never packages datadog-app.local.json, even when options.include matches it
✓ never packages a case-variant of datadog-app.local.json, even when options.include matches it
✓ never packages a symlink pointing at datadog-app.local.json, even under a different name
✓ never packages the real target of a symlinked datadog-app.local.json
✓ never packages a hardlink to datadog-app.local.json, even under a different name
Test Suites: 1 passed, 1 total / Tests: 5 passed, 8 skipped, 13 total ✅ VERIFIED
```

```bash
yarn workspace @dd/tests test:unit packages/plugins/apps/src/vite/index.test.ts -t "Should reject a direct import"
```
```
✓ Should reject a direct import of the local Custom Credentials file (specifier: ../datadog-app.local.json, ssr: true)
✓ Should reject a direct import of the local Custom Credentials file (specifier: ../datadog-app.local.json, ssr: false)
✓ Should reject a direct import of the local Custom Credentials file (specifier: ../datadog-app.local.json?raw, ssr: true)
✓ Should reject a direct import of the local Custom Credentials file (specifier: ../datadog-app.local.json?url, ssr: false)
✓ Should reject a direct import of the local Custom Credentials file (specifier: ../datadog-app.local.json#fragment, ssr: true)
✓ Should reject a direct import of the local Custom Credentials file (specifier: ../datadog-app.local.json?raw#fragment, ssr: false)
Test Suites: 1 passed, 1 total / Tests: 6 passed, 22 skipped, 28 total ✅ VERIFIED
```
✅ VERIFIED — the credentials file's own `(device, inode)` identity check catches the inverse-symlink and hardlink cases the basename/realpath-only version missed, and the combined `?raw#fragment` specifier is rejected by the same postfix-stripping that already handled `?raw`/`#fragment` individually.

</details>

<details><summary>Manual QA: a direct import of the credentials file fails the build instead of bundling the secret</summary>

Confirmed the packaging-exclusion filter above only ever inspects the copied static asset, not a module the build actually bundles — an app importing `datadog-app.local.json` directly (e.g. `import creds from './datadog-app.local.json'`) goes through a different code path (Vite's module graph) that the filter never sees. Reproduced against the real published plugin: built once against the pre-fix commit to confirm the leak, rebuilt against the fix, and re-ran the identical build.

```js
// manual QA script — run then discard, not part of the PR
import { allBundlers } from '@dd/tools/bundlers';
import { allPlugins, fullConfig } from '@dd/tools/plugins';
import fs from 'fs/promises';
import os from 'os';
import path from 'path';
import { build } from 'vite';

const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'manual-qa-import-block-'));
await fs.writeFile(
    path.join(cwd, 'index.js'),
    "import creds from './datadog-app.local.json';\nconsole.log(creds);\n",
);
await fs.writeFile(
    path.join(cwd, 'datadog-app.local.json'),
    JSON.stringify({ STRIPE_API_KEY: 'sk_test_should_never_ship' }),
);

const pluginConfig = {
    ...fullConfig,
    auth: { apiKey: '123', appKey: '123' },
    metadata: { name: 'manual-qa-import-block' },
    apps: { enable: true },
};
const plugin = allPlugins.vite(pluginConfig);
const viteConfig = allBundlers.vite.config({
    workingDir: cwd,
    outDir: path.resolve(cwd, 'dist'),
    entry: { vite: './index.js' },
    plugins: [plugin],
});

let caught;
try {
    await build({ ...viteConfig, logLevel: 'silent' });
} catch (error) {
    caught = error;
}
console.log('BUILD ERROR:', caught?.message);
console.log('DIST CONTENTS:', await fs.readdir(path.resolve(cwd, 'dist')).catch(() => 'dist does not exist'));
```

Real captured output, against the pre-fix commit (`cb89f55d`):
```
BUILD ERROR: undefined
DIST CONTENTS: [ 'datadog-app-assets.zip', 'vite.js', 'vite.js.map' ]
```
`grep -o "sk_test[a-zA-Z_]*" dist/vite.js` → `sk_test_should_never_ship` — the real secret was bundled straight into the shipped chunk.

Real captured output, with the fix (`32a1766b`):
```
BUILD ERROR: [datadog-true-end-plugin] No output files found.
DIST CONTENTS: dist does not exist
```
✅ VERIFIED — the build now fails and produces no `dist` output at all, so the secret can never reach a shipped package this way. The surfaced error text comes from an unrelated internal plugin's own "no output" check racing ahead of this fix's own thrown error (both cause failure; whichever the runtime settles on first wins the final rejection message) — a purely cosmetic gap in an internal plugin outside this PR's scope, not a functional one: no case exists where the build succeeds with the secret still bundled.

</details>

<details><summary>Manual QA: a query-suffixed import (`?raw`, `?url`) of the credentials file is rejected too</summary>

The direct-import rejection above compared `path.basename(source)` against the credentials filename, but a resource-query specifier like `./datadog-app.local.json?raw` keeps the query in that basename and never matches — Vite still inlines the real file content via its `?raw`/`?url` loaders. Reproduced with a real scaffolded app against the published plugin, for a plain import and both query-suffixed forms.

```bash
#!/usr/bin/env bash
set -uo pipefail

REPO_ROOT="<path to build-plugins repo>"
SCRATCH_DIR="/tmp/qa-512-query-suffix-bypass"

rm -rf "$SCRATCH_DIR"
mkdir -p "$SCRATCH_DIR"
cd "$SCRATCH_DIR"
npm init -y >/dev/null 2>&1
npm install --no-audit --no-fund vite@6 >/dev/null 2>&1

cat > vite.config.mjs <<EOF
import { defineConfig } from 'vite';
import { datadogVitePlugin } from '$REPO_ROOT/packages/published/vite-plugin/dist/src/index.mjs';

export default defineConfig({
    plugins: [datadogVitePlugin({ auth: { site: 'datad0g.com' }, apps: { enable: true } })],
    build: { rollupOptions: { input: 'index.js' } },
});
EOF

cat > datadog-app.local.json <<'EOF'
{ "STRIPE_API_KEY": "sk_test_should_never_ship" }
EOF

run_case() {
    local specifier="$1"
    echo "import creds from '$specifier'; console.log(creds);" > index.js
    rm -rf dist
    npx vite build --logLevel warn 2>&1 | grep -Ei "error|cannot be imported directly" || echo "(no error output)"
    [ -d dist ] && echo "dist exists" || echo "dist does not exist (build failed, as expected)"
}

run_case "./datadog-app.local.json"
run_case "./datadog-app.local.json?raw"
run_case "./datadog-app.local.json?url"
```

Real captured output, against the fix (`70fc2db1`):
```
=== ./datadog-app.local.json ===
error during build:
[datadog-apps-plugin] datadog-app.local.json cannot be imported directly — read Custom Credentials via process.env instead.
dist does not exist (build failed, as expected)

=== ./datadog-app.local.json?raw ===
error during build:
[datadog-apps-plugin] datadog-app.local.json cannot be imported directly — read Custom Credentials via process.env instead.
dist does not exist (build failed, as expected)

=== ./datadog-app.local.json?url ===
error during build:
[datadog-apps-plugin] datadog-app.local.json cannot be imported directly — read Custom Credentials via process.env instead.
dist does not exist (build failed, as expected)
```
✅ VERIFIED — all three specifier forms are rejected and produce no `dist` output.

</details>

<details><summary>Manual QA: server.fs.deny merges with (not replaces) Vite's default deny patterns</summary>

Started a real dev server and requested `.env`, a certificate, `.git/HEAD`, and the credentials file directly over HTTP — all four must 403. Then reproduced the regression by temporarily reverting the fix (`deny: [CUSTOM_CREDENTIALS_LOCAL_FILENAME]` instead of spreading in Vite's defaults) to confirm it actually causes `.env`/cert/`.git` to become servable, before restoring the real fix and re-verifying.

```bash
#!/usr/bin/env bash
set -uo pipefail

REPO_ROOT="<path to build-plugins repo>"
SCRATCH_DIR="/tmp/qa-512-fsdeny-devserver"
PORT=5184

rm -rf "$SCRATCH_DIR"
cd /tmp
npm create vite@latest qa-512-fsdeny-devserver -- --template vanilla-ts
cd "$SCRATCH_DIR"
npm install

cat > vite.config.ts <<EOF
import { defineConfig } from 'vite';
import { datadogVitePlugin } from '$REPO_ROOT/packages/published/vite-plugin/dist/src/index.mjs';

export default defineConfig({
    plugins: [
        datadogVitePlugin({
            auth: { site: 'datad0g.com' },
            apps: { enable: true },
        }),
    ],
});
EOF

cat > src/getStripeKeyPrefix.backend.ts <<'EOF'
export async function getStripeKeyPrefix() {
    const key = process.env.STRIPE_API_KEY;
    return key ? key.slice(0, 7) : 'MISSING';
}
EOF

cat > src/main.ts <<'EOF'
import './getStripeKeyPrefix.backend';
document.querySelector<HTMLDivElement>('#app')!.innerHTML = '<h1>QA app 512 fs.deny</h1>';
EOF

cat > datadog-app.local.json <<'EOF'
{
    "STRIPE_API_KEY": "sk_test_manual_qa_fsdeny"
}
EOF

# Files Vite's own default deny list is supposed to protect.
echo "REAL_DOTENV_SECRET=sk_test_dotenv_should_never_be_servable" > .env
mkdir -p certs
echo "-----BEGIN CERTIFICATE-----FAKE-----END CERTIFICATE-----" > certs/server.crt
mkdir -p .git
echo "ref: refs/heads/main" > .git/HEAD

nohup dd-auth --domain dd.datad0g.com -- sh -c "npm run dev -- --port $PORT" > dev-server.log 2>&1 &
echo $! > dev.pid
sleep 4

echo '--- with the real fix ---'
curl -s -o /dev/null -w '.env: HTTP %{http_code}\n' "http://localhost:$PORT/.env"
curl -s -o /dev/null -w 'certs/server.crt: HTTP %{http_code}\n' "http://localhost:$PORT/certs/server.crt"
curl -s -o /dev/null -w '.git/HEAD: HTTP %{http_code}\n' "http://localhost:$PORT/.git/HEAD"
curl -s -o /dev/null -w 'datadog-app.local.json: HTTP %{http_code}\n' "http://localhost:$PORT/datadog-app.local.json"
curl -s -o /dev/null -w 'src/main.ts (control): HTTP %{http_code}\n' "http://localhost:$PORT/src/main.ts"

kill "$(cat dev.pid)" 2>/dev/null
pkill -f "vite --port $PORT" 2>/dev/null
```

Real captured output, from a clean checkout:

```
--- with the real fix ---
.env: HTTP 403
certs/server.crt: HTTP 403
.git/HEAD: HTTP 403
datadog-app.local.json: HTTP 403
src/main.ts (control): HTTP 200
```

Then, with `packages/plugins/apps/src/vite/index.ts`'s `deny` temporarily reverted to `[CUSTOM_CREDENTIALS_LOCAL_FILENAME]` (no spread) and the plugin rebuilt, the identical requests against a fresh dev server instance returned:

```
--- with fix reverted ---
.env: HTTP 200
certs/server.crt: HTTP 200
.git/HEAD: HTTP 200
datadog-app.local.json: HTTP 403
```

✅ VERIFIED — the regression is real (reverting the spread exposes `.env`/certs/`.git` while only the new filename stays protected), and the actual fix in this PR closes it: all four paths 403 with the real code, and a legitimate source file still serves normally.

</details>

<details><summary>Manual QA: real file → real env var, end to end (beyond the mocked unit tests)</summary>

`local-execution.test.ts`'s integration test already covers this path, but it goes through Jest's module system. This script bundles the real source files with esbuild and runs them under plain Node against a real temp-directory file, to rule out any test-harness-only behavior.

```js
// manual QA script — run then discard, not part of the PR
import { execSync } from 'node:child_process';
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';

const REPO_ROOT = '<path to repo>';
const esbuild = await import(path.join(REPO_ROOT, 'node_modules/esbuild/lib/main.js'));

const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'manual-qa-custom-credentials-'));
try {
    await fs.writeFile(
        path.join(projectRoot, 'datadog-app.local.json'),
        JSON.stringify({ STRIPE_API_KEY: 'sk_test_manual_qa_123' }),
    );

    const driverSrc = `
import { resolveCustomCredentials } from ${JSON.stringify(path.join(REPO_ROOT, 'packages/plugins/apps/src/vite/custom-credentials-resolver.ts'))};
import { buildScopedEnv, runWithScopedEnv } from ${JSON.stringify(path.join(REPO_ROOT, 'packages/plugins/apps/src/vite/env-guard.ts'))};

const projectRoot = ${JSON.stringify(projectRoot)};
const customCredentials = await resolveCustomCredentials(projectRoot);
console.log('resolveCustomCredentials output:', JSON.stringify(customCredentials));

const scopedEnv = buildScopedEnv(customCredentials);
const observed = await runWithScopedEnv(scopedEnv, async () => process.env.STRIPE_API_KEY);
console.log('process.env.STRIPE_API_KEY inside scoped env:', observed);

if (observed !== 'sk_test_manual_qa_123') {
    console.error('MANUAL QA FAILED: expected sk_test_manual_qa_123, got', observed);
    process.exit(1);
}
console.log('MANUAL QA PASSED');
`;
    const driverSrcPath = path.join(projectRoot, 'driver-src.mjs');
    await fs.writeFile(driverSrcPath, driverSrc);

    const result = await esbuild.build({
        entryPoints: [driverSrcPath],
        bundle: true,
        write: false,
        format: 'esm',
        platform: 'node',
        target: 'node18',
        packages: 'external',
    });

    const bundledPath = path.join(projectRoot, 'driver.bundled.mjs');
    await fs.writeFile(bundledPath, result.outputFiles[0].text);
    console.log(execSync(`node ${bundledPath}`, { encoding: 'utf8' }));
} finally {
    await fs.rm(projectRoot, { recursive: true, force: true });
}
```

```
resolveCustomCredentials output: {"STRIPE_API_KEY":"sk_test_manual_qa_123"}
process.env.STRIPE_API_KEY inside scoped env: sk_test_manual_qa_123
MANUAL QA PASSED: real file -> resolveCustomCredentials -> buildScopedEnv -> process.env flow works end to end.
```
✅ VERIFIED

</details>

<details><summary>Manual QA: real end-to-end dev server (Vite plugin, dev server, executeAction), not just the isolated resolver logic above</summary>

The script above proves `resolveCustomCredentials`/`buildScopedEnv` in isolation via a throwaway esbuild bundle under plain Node — real file I/O, real env var, but bypassing the actual Vite plugin, dev server, and `runScriptLocally` wiring. This script instead drives the real path end to end: a freshly scaffolded Vite app's real dev server, through the real `@datadog/vite-plugin` build, calling a real backend function that reads a Custom Credential sourced from a real `datadog-app.local.json`. Copy-paste and run directly; it is idempotent (safe to re-run from a clean checkout).

```bash
#!/usr/bin/env bash
set -uo pipefail

REPO_ROOT="<path to build-plugins repo>"
SCRATCH_PARENT="/tmp"
APP_NAME="qa-app-2792"
SCRATCH_DIR="$SCRATCH_PARENT/$APP_NAME"
PORT=5183

cleanup() {
    [ -f "$SCRATCH_DIR/dev.pid" ] && kill "$(cat "$SCRATCH_DIR/dev.pid")" 2>/dev/null
    pkill -f "vite --port $PORT" 2>/dev/null
    rm -rf "$SCRATCH_DIR"
    unset STRIPE_API_KEY
    return 0
}
trap cleanup EXIT

# 0. Pre-clean in case a previous run was interrupted (makes this idempotent).
cleanup

# 1. Build the plugin fresh.
cd "$REPO_ROOT"
rm -rf packages/published/vite-plugin/dist
yarn build:all-no-types

# 2. Scaffold a fresh minimal Vite app into the scratch directory.
cd "$SCRATCH_PARENT"
npm create vite@latest "$APP_NAME" -- --template vanilla-ts
cd "$SCRATCH_DIR"
npm install

# 3. vite.config.ts — import the plugin by absolute path from the built dist,
#    bypassing npm link's publishConfig.exports (only real `npm publish` swaps that).
cat > vite.config.ts <<EOF
import { defineConfig } from 'vite';
import { datadogVitePlugin } from '$REPO_ROOT/packages/published/vite-plugin/dist/src/index.mjs';

export default defineConfig({
    plugins: [
        datadogVitePlugin({
            // 'datad0g.com' is the plugin's own DD_SITE value (used as api.\${site}).
            // dd-auth's --domain flag below takes 'dd.datad0g.com', its login domain --
            // a distinct value from DD_SITE. Do not conflate the two.
            auth: { site: 'datad0g.com' },
            apps: { enable: true },
        }),
    ],
});
EOF

# 4. Backend function reading the Custom Credential under test.
cat > src/getStripeKeyPrefix.backend.ts <<'EOF'
export async function getStripeKeyPrefix() {
    const key = process.env.STRIPE_API_KEY;
    return key ? key.slice(0, 7) : 'MISSING';
}
EOF

# 5. Minimal entry importing the backend file — Vite only registers a backend
#    function once its transform hook actually processes the file.
cat > src/main.ts <<'EOF'
import './getStripeKeyPrefix.backend';

document.querySelector<HTMLDivElement>('#app')!.innerHTML = '<h1>QA app 2792</h1>';
EOF

# 6. Real Custom Credentials file (positive case).
cat > datadog-app.local.json <<'EOF'
{
    "STRIPE_API_KEY": "sk_test_manual_qa_e2e"
}
EOF

# 7. Launch the dev server with a decoy shell env var — buildScopedEnv must
#    never leak this through, only what datadog-app.local.json declares.
export STRIPE_API_KEY=REAL_SHELL_LEAK_SHOULD_NOT_APPEAR
nohup dd-auth --domain dd.datad0g.com -- sh -c "npm run dev -- --port $PORT" > dev-server.log 2>&1 &
echo $! > dev.pid
sleep 3

# 8. Force Vite's lazy transform (registration only happens once a file is
#    actually transformed, not on disk-scan) by requesting the real module graph.
curl -s -o /dev/null -w 'root: HTTP %{http_code}\n' "http://localhost:$PORT/"
curl -s -o /dev/null -w 'main.ts: HTTP %{http_code}\n' "http://localhost:$PORT/src/main.ts"
curl -s -o /dev/null -w 'backend.ts: HTTP %{http_code}\n' "http://localhost:$PORT/src/getStripeKeyPrefix.backend.ts"

# 9. Deterministic query-name hash: sha256(refPath).exportName, where refPath
#    is the file's project-root-relative path with the .backend.ts suffix stripped.
HASH=$(node -e "console.log(require('crypto').createHash('sha256').update('src/getStripeKeyPrefix').digest('hex'))")
echo "functionName hash: $HASH"

echo '--- positive case (datadog-app.local.json present) ---'
curl -s -X POST "http://localhost:$PORT/__dd/executeAction" \
    -H "Content-Type: application/json" \
    -d "{\"functionName\": \"${HASH}.getStripeKeyPrefix\", \"args\": []}"
echo ""

echo '--- security check: is the secrets file itself servable over HTTP? ---'
curl -s -o /dev/null -w 'GET /datadog-app.local.json: HTTP %{http_code}\n' "http://localhost:$PORT/datadog-app.local.json"

# 10. Negative case: remove the local file, restart the dev server fresh.
kill "$(cat dev.pid)" 2>/dev/null
pkill -f "vite --port $PORT" 2>/dev/null
sleep 1
rm -f datadog-app.local.json
nohup dd-auth --domain dd.datad0g.com -- sh -c "npm run dev -- --port $PORT" > dev-server-negative.log 2>&1 &
echo $! > dev.pid
sleep 3
curl -s -o /dev/null -w 'main.ts: HTTP %{http_code}\n' "http://localhost:$PORT/src/main.ts"
curl -s -o /dev/null -w 'backend.ts: HTTP %{http_code}\n' "http://localhost:$PORT/src/getStripeKeyPrefix.backend.ts"

echo '--- negative case (datadog-app.local.json removed) ---'
curl -s -X POST "http://localhost:$PORT/__dd/executeAction" \
    -H "Content-Type: application/json" \
    -d "{\"functionName\": \"${HASH}.getStripeKeyPrefix\", \"args\": []}"
echo ""

echo 'QA PASSED'
```

Real captured output from running this script standalone, from a clean checkout:

```
root: HTTP 200
main.ts: HTTP 200
backend.ts: HTTP 200
functionName hash: b2ce4d45772ba862e7547b5582b545cc39f1e4696d2c6a1b8d0fd6e595d84e44
--- positive case (datadog-app.local.json present) ---
{"success":true,"result":{"data":"sk_test"}}
--- security check: is the secrets file itself servable over HTTP? ---
GET /datadog-app.local.json: HTTP 403
main.ts: HTTP 200
backend.ts: HTTP 200
--- negative case (datadog-app.local.json removed) ---
{"success":true,"result":{"data":"MISSING"}}
QA PASSED
```
✅ VERIFIED — real file → dev server → Vite plugin → resolveCustomCredentials → buildScopedEnv → process.env, fully wired, with no leak of the real shell env var when the local file is absent. The secrets file itself now 403s instead of being servable. Confirmed the 403 comes from the new `server.fs.deny` entry, not an unrelated allow-list effect, by rebuilding with that entry temporarily removed and re-issuing the same request against an identical scaffold — it returned HTTP 200 with the raw JSON body. Re-run from clean state with identical output.

</details>

## Blast Radius

- Additive only: a backend function that reads an undeclared env var still sees `undefined`, matching today's behavior.
- One of the two `buildScopedEnv` call sites (`loadCustomerModuleEntry`) is deliberately left unresolved — no behavior change there.
- One real behavior change: `datadog-app.local.json` is now always excluded from a built app package by filename, regardless of `options.include` — strictly closes a pre-existing secret-leak path, not a functional regression for any legitimate use (the file is never meant to ship).
- No feature flag — local-only dev-server code path plus the packaging exclusion (which applies to any build, local or CI); neither is reachable by end users of a shipped app.
- Risk: **low**.

## Out of Scope / Follow-ups

<details><summary>6 items deferred</summary>

| Item | Status | Next step |
| --- | --- | --- |
| `loadCustomerModuleEntry`'s priming load calls `buildScopedEnv({})`, so a backend function reading a Custom Credential at module top level (outside any function body — e.g. `const stripe = new Stripe(process.env.KEY)`) sees `undefined` locally, even though the same read inside the function body now works | Deferred, accepted | Fixing it means threading real credentials into code that runs outside `network-guard.ts`'s protected scope — trades a functional limitation for a real security regression, so no fix planned. Confined to local dev only: `npm run dev:verify` and production both resolve real credentials via the cloud path, unaffected. Documented in `README.md` |
| `datadog-app.local.json` isn't yet added to the `.gitignore` template `create-apps` scaffolds for new projects | Independent | Separate follow-up on the web-ui/`create-apps` side |
| No runtime check warns if an *existing* project's `datadog-app.local.json` isn't actually gitignored — protection today is documentation-only | Deferred, accepted | Same follow-up track as the `create-apps` template gap above; consider a startup warning if the file is present and unignored |
| `VITE_DEFAULT_SERVER_FS_DENY` in `index.ts` is a hand-typed copy of Vite's internal `server.fs.deny` default (Vite doesn't export it) — a future Vite upgrade that changes its own default silently isn't reflected here | Deferred, accepted | No fix available without an upstream Vite export to import instead; re-verify this list against Vite's actual default on any Vite version bump |
| Security review of local Custom Credentials handling (Secret Store parity's existing closure-scoping and allowlist reviews) | Not started | Request together with Secret Store parity's Product Launch sign-off, per the Kickoff doc's Follow-ups table |
| `resolveId`'s direct-import guard compares the raw specifier's basename before resolution, so a symlink under a different name or a `resolve.alias` entry pointing at `datadog-app.local.json` still reaches Vite's bundler | Deferred, accepted | This guard (like the others in this PR) targets accidental imports, not a build-time attacker with `vite.config.ts`/filesystem control — that attacker has easier exfiltration paths this check can't close either way, so the added resolution-pass cost across every import in the app isn't worth it. No fix planned |

</details>

## Documentation

**Confluence**
- [Local Node Execution of Backend Functions — Kickoff](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7025394455/Local+Node+Execution+of+Backend+Functions+Kickoff) — Secret Store parity, decision recorded in Follow-ups
- [RFC: Local Node execution for High Code Apps backend functions](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/7012712651/RFC+Local+Node+execution+for+High+Code+Apps+backend+functions) — decided design, networked alternative recorded as deferred
- [Security: Customers Secrets in Terrapin](https://datadoghq.atlassian.net/wiki/spaces/HCA/pages/6934070030/Security+Customers+Secrets+in+Terrapin) — the production precedent this design extends
- [RAPID Secrets: Local Development](https://datadoghq.atlassian.net/wiki/spaces/RAPID/pages/3342829116/Secrets#Local-Development)

**GitHub**
- This PR: https://github.com/DataDog/build-plugins/pull/512







